### PR TITLE
Auto Scroll to Highlighted Ayah

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -83,6 +83,7 @@
 	<string name="prefs_use_arabic_names">useArabicNames</string>
 	<string name="prefs_keep_screen_on">keepScreenOn</string>
 	<string name="prefs_display_marker_popup">displayMarkerPopup</string>
+	<string name="prefs_auto_scroll">autoScroll</string>
 	<string name="prefs_lock_orientation">lockOrientation</string>
 	<string name="prefs_landscape_orientation">landscapeOrientation</string>
 	<string name="prefs_translation_text_size">translationTextSize</string>

--- a/res/xml/quran_preferences.xml
+++ b/res/xml/quran_preferences.xml
@@ -27,6 +27,11 @@
 			android:summaryOn="Display popup when reaching Juz', Hizb, etc." android:summaryOff="Don't display popup when reaching Juz', Hizb, etc." 
 			android:persistent="true" android:key="@string/prefs_display_marker_popup">
 		</CheckBoxPreference>
+		<CheckBoxPreference 
+			android:title="Auto Scroll" 
+			android:summaryOn="Auto scroll to highlighted ayah while playing (in landscape)" android:summaryOff="Don't auto scroll to highlighted ayah while playing (in landscape)" 
+			android:persistent="true" android:key="@string/prefs_auto_scroll">
+		</CheckBoxPreference>
 	</PreferenceCategory>
 	<PreferenceCategory android:title="@string/prefs_category_translation">
 		<com.quran.labs.androidquran.widgets.SelectTranslationPreference

--- a/src/com/quran/labs/androidquran/common/QuranPageFeeder.java
+++ b/src/com/quran/labs/androidquran/common/QuranPageFeeder.java
@@ -5,6 +5,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import android.app.Activity;
+import android.content.res.Configuration;
 import android.graphics.Bitmap;
 import android.util.Log;
 import android.view.LayoutInflater;
@@ -18,6 +19,7 @@ import com.quran.labs.androidquran.R;
 import com.quran.labs.androidquran.data.ApplicationConstants;
 import com.quran.labs.androidquran.data.QuranInfo;
 import com.quran.labs.androidquran.util.ArabicStyle;
+import com.quran.labs.androidquran.util.QuranScreenInfo;
 import com.quran.labs.androidquran.util.QuranSettings;
 import com.quran.labs.androidquran.util.QuranUtils;
 import com.quran.labs.androidquran.widgets.HighlightingImageView;
@@ -113,6 +115,12 @@ public class QuranPageFeeder implements OnPageFlipListener {
 		if (iv != null){
 			HighlightingImageView hi = (HighlightingImageView)iv;
 			hi.highlightAyah(sura, ayah);
+			if (QuranSettings.getInstance().isAutoScroll() && v.getResources()
+					.getConfiguration().orientation == Configuration.ORIENTATION_LANDSCAPE) {
+				AyahBounds yBounds = hi.getYBoundsForCurrentHighlight();
+				if (yBounds != null)
+					mQuranPage.scrollToAyah(R.id.page_scroller, yBounds);
+			}
 			mQuranPage.invalidate();
 		}
 	}

--- a/src/com/quran/labs/androidquran/data/ApplicationConstants.java
+++ b/src/com/quran/labs/androidquran/data/ApplicationConstants.java
@@ -42,6 +42,7 @@ public class ApplicationConstants {
 	public static final String PREF_LOCK_ORIENTATION = "lockOrientation";
 	public static final String PREF_LANDSCAPE_ORIENTATION = "landscapeOrientation";
 	public static final String PREF_DISPLAY_MARKER_POPUP = "displayMarkerPopup";
+	public static final String PREF_AUTO_SCROLL = "autoScroll";
 	public static final String PREF_TRANSLATION_TEXT_SIZE = "translationTextSize";
 	public static final String PREF_ACTIVE_TRANSLATION = "activeTranslation";
 	public static final String PREF_RESHAPE_ARABIC = "reshapeArabic";

--- a/src/com/quran/labs/androidquran/util/QuranSettings.java
+++ b/src/com/quran/labs/androidquran/util/QuranSettings.java
@@ -14,6 +14,7 @@ public class QuranSettings {
 	private boolean lockOrientation = false;
 	private boolean landscapeOrientation = false;
 	private boolean displayMarkerPopup = false;
+	private boolean autoScroll = false;
 	private int translationTextSize = ApplicationConstants.DEFAULT_TEXT_SIZE;
 	private int lastPage = 0;
 	private String activeTranslation = null;
@@ -99,6 +100,14 @@ public class QuranSettings {
 		this.displayMarkerPopup = displayMarkerPopup;
 	}
 
+	public boolean isAutoScroll() {
+		return autoScroll;
+	}
+	
+	public void setAutoScroll(boolean autoScroll) {
+		this.autoScroll = autoScroll;
+	}
+	
 	public int getTranslationTextSize() {
 		return translationTextSize;
 	}
@@ -125,6 +134,7 @@ public class QuranSettings {
 		instance.lockOrientation = preferences.getBoolean(ApplicationConstants.PREF_LOCK_ORIENTATION, false);
 		instance.landscapeOrientation = preferences.getBoolean(ApplicationConstants.PREF_LANDSCAPE_ORIENTATION, false);
 		instance.displayMarkerPopup = preferences.getBoolean(ApplicationConstants.PREF_DISPLAY_MARKER_POPUP, false);
+		instance.autoScroll = preferences.getBoolean(ApplicationConstants.PREF_AUTO_SCROLL, false);
 		instance.translationTextSize = preferences.getInt(ApplicationConstants.PREF_TRANSLATION_TEXT_SIZE, ApplicationConstants.DEFAULT_TEXT_SIZE);
 		instance.lastPage = preferences.getInt(ApplicationConstants.PREF_LAST_PAGE, ApplicationConstants.NO_PAGE_SAVED);
 		instance.activeTranslation = preferences.getString(ApplicationConstants.PREF_ACTIVE_TRANSLATION, null);
@@ -141,6 +151,7 @@ public class QuranSettings {
 		editor.putBoolean(ApplicationConstants.PREF_LOCK_ORIENTATION, instance.lockOrientation);
 		editor.putBoolean(ApplicationConstants.PREF_LANDSCAPE_ORIENTATION, instance.landscapeOrientation);
 		editor.putBoolean(ApplicationConstants.PREF_DISPLAY_MARKER_POPUP, instance.displayMarkerPopup);
+		editor.putBoolean(ApplicationConstants.PREF_AUTO_SCROLL, instance.autoScroll);
 		editor.putInt(ApplicationConstants.PREF_TRANSLATION_TEXT_SIZE, instance.translationTextSize);
 		editor.putInt(ApplicationConstants.PREF_LAST_PAGE, instance.lastPage);
 		editor.putString(ApplicationConstants.PREF_ACTIVE_TRANSLATION, instance.activeTranslation);

--- a/src/com/quran/labs/androidquran/widgets/HighlightingImageView.java
+++ b/src/com/quran/labs/androidquran/widgets/HighlightingImageView.java
@@ -111,6 +111,23 @@ public class HighlightingImageView extends ImageView {
 		this.currentlyHighlighting = rangesToDraw;
 	}
 	
+	public AyahBounds getYBoundsForCurrentHighlight() {
+		if (currentlyHighlighting == null)
+			return null;
+		Integer upperBound = null;
+		Integer lowerBound = null;
+		for (AyahBounds bounds : currentlyHighlighting) {
+			if (upperBound == null || bounds.getMinY() < upperBound)
+				upperBound = bounds.getMinY();
+			if (lowerBound == null || bounds.getMaxY() > lowerBound)
+				lowerBound = bounds.getMaxY();
+		}
+		AyahBounds yBounds = null;
+		if (upperBound != null && lowerBound != null)
+			yBounds = new AyahBounds(0, 0, 0, upperBound, 0, lowerBound);
+		return yBounds;
+	}
+	
 	@Override
 	protected void onDraw(Canvas canvas) {
 		super.onDraw(canvas);

--- a/src/com/quran/labs/androidquran/widgets/QuranPageCurlView.java
+++ b/src/com/quran/labs/androidquran/widgets/QuranPageCurlView.java
@@ -21,6 +21,8 @@ import android.view.ViewConfiguration;
 import android.widget.ScrollView;
 
 import com.quran.labs.androidquran.R;
+import com.quran.labs.androidquran.common.AyahBounds;
+import com.quran.labs.androidquran.util.QuranScreenInfo;
 
 /*
  * Adapted and modified from http://code.google.com/p/android-page-curl
@@ -529,6 +531,33 @@ public class QuranPageCurlView extends View {
 		}
 	}
 
+	public void scrollToAyah(int scrollerId, AyahBounds yBounds) {
+		ScrollView sv = (ScrollView) mCurrentPageView.findViewById(scrollerId);
+		if (sv == null || yBounds == null)
+			return;
+		
+		int screenHeight = QuranScreenInfo.getInstance().getHeight();
+		int curScrollY = sv.getScrollY();
+		int scrollToY = curScrollY;
+		
+		// If Ayah is within bounds, do nothing
+		if (yBounds.getMinY() > curScrollY && yBounds.getMaxY() < curScrollY + screenHeight)
+			return;
+		
+		int ayahHeight = yBounds.getMaxY() - yBounds.getMinY();
+		
+		// If entire ayah can fit in screen, center it vertically. Otherwise, scroll to top of Ayah.
+		if (ayahHeight < screenHeight)
+			scrollToY = yBounds.getMinY() - (screenHeight - ayahHeight)/2;
+		else
+			scrollToY = yBounds.getMinY() - (int) (screenHeight*0.05); // Leave a gap of 5% screen height
+		
+		sv.smoothScrollTo(sv.getScrollX(), scrollToY);
+		mScrollAnimationHandler.setUpdateRate(mUpdateRate);
+		mScrollAnimationHandler.setCount(20);
+		mScrollAnimationHandler.sleep();
+	}
+	
 	/**
 	 * Reset points to it's initial clip edge state
 	 */


### PR DESCRIPTION
Issue #60 - Auto scroll to currently highlighted Ayah if it goes out of view during playback (in landscape mode) + settings to enable/disable it

*Tested on my Galaxy S and on a WXGA HoneyComb Tablet emulator - worked well on both. Not sure if it'll work on all screen types though (due to the large variety out there). Either way, there's a setting to disable it (disabled by default)
