### PR TITLE
Added Playback Options (incl. Resume from Last Played Ayah)

### DIFF
--- a/res/layout/dialog_download.xml
+++ b/res/layout/dialog_download.xml
@@ -9,16 +9,23 @@
         android:layout_width="fill_parent"
         android:layout_height="wrap_content"
         android:drawSelectorOnTop="true"
-        android:entries="@array/quran_readers_name"
-    />
-    <RadioGroup android:id="@+id/radioGroupDownload"
-    android:layout_width="fill_parent" android:layout_height="wrap_content">
-    <TextView android:text="@string/radio_download_message"  
-    	android:layout_width="fill_parent"
-    	android:layout_height="wrap_content"
-    	android:gravity="center_horizontal"/>
-    <RadioButton android:id="@+id/radioDownloadPage" android:text="Current Page" android:checked="true"/>
-    <RadioButton android:id="@+id/radioDownloadSura" android:text="Current Sura"/>    
-    <RadioButton android:id="@+id/radioDownloadJuza" android:text="Current Juza"/>
-    </RadioGroup>
+        android:prompt="@string/prompt_select_reciter"
+        android:entries="@array/quran_readers_name"/>
+    <ScrollView
+        android:id="@+id/scrollViewDownload"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content">
+        <RadioGroup
+            android:id="@+id/radioGroupDownload"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content">
+            <TextView android:text="@string/download_dialog_message"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center_horizontal"/>
+            <RadioButton android:id="@+id/radioDownloadPage" android:text="Current Page" android:checked="true"/>
+            <RadioButton android:id="@+id/radioDownloadSura" android:text="Current Sura"/>
+            <RadioButton android:id="@+id/radioDownloadJuza" android:text="Current Juza"/>
+        </RadioGroup>
+    </ScrollView>
 </LinearLayout>

--- a/res/layout/dialog_play.xml
+++ b/res/layout/dialog_play.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+  xmlns:android="http://schemas.android.com/apk/res/android"
+  android:orientation="vertical"
+  android:layout_width="fill_parent"
+  android:layout_height="fill_parent">
+    <ScrollView
+        android:id="@+id/scrollViewPlay"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content">
+        <RadioGroup android:id="@+id/radioGroupPlay"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:isScrollContainer="true">
+            <TextView android:text="@string/play_dialog_message"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center_horizontal"/>
+            <RadioButton android:id="@+id/radioPlayPage" android:text="Start of Page" android:checked="true"/>
+            <RadioButton android:id="@+id/radioPlayLast" android:text="Last Played Ayah"/>
+        </RadioGroup>
+    </ScrollView>
+</LinearLayout>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -121,5 +121,10 @@
     <string name="set_active">Set Active</string>
     <string name="prompt_select_ayah">Select Ayah</string>
     <string name="prompt_select_sura">Select Sura</string>
-    <string name="radio_download_message">Choose download option</string>
+    <string name="prompt_select_reciter">Select Reciter</string>
+	<string name="play_dialog_message">Start playing from...</string>
+	<string name="play_dialog_page">Current Page (%s)</string>
+	<string name="play_dialog_resume">Resume %1$s : %2$s</string>
+	<string name="download_dialog_message">Choose download option</string>
+	<string name="download_dialog_page">Current Page (%s)</string>
 </resources>

--- a/src/com/quran/labs/androidquran/service/AudioServiceBinder.java
+++ b/src/com/quran/labs/androidquran/service/AudioServiceBinder.java
@@ -114,6 +114,7 @@ public class AudioServiceBinder extends Binder implements
 			mp.reset();
 			mp.setOnCompletionListener(this);
 			url = null;
+			// FIXME Even though soura is downloaded, Basmallah of every sura asks for download since Al-Fati7a isn't downloaded -AF
 			if(item.isAudioFoundLocally())
 				url = item.getLocalAudioUrl();
 			else if(remotePlayEnabled) {
@@ -126,7 +127,7 @@ public class AudioServiceBinder extends Binder implements
 				}
 				else
 				{
-					// show notification ayah not found, download it or play remotely	
+					// TODO show notification ayah not found, download it or play remotely	
 				}
 			}	
 			if(url != null){

--- a/src/com/quran/labs/androidquran/util/QuranUtils.java
+++ b/src/com/quran/labs/androidquran/util/QuranUtils.java
@@ -2,7 +2,6 @@ package com.quran.labs.androidquran.util;
 
 import java.io.File;
 import java.io.FileOutputStream;
-import java.io.FilenameFilter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
@@ -287,34 +286,11 @@ public class QuranUtils {
 		return getAudioDirectory() + File.separator + quranReaderId
 		+ File.separator + sura ;
 	}
-	
-	public static int isSouraAudioFound(int quranReaderId, int sura){
-		File f = new File(getSuraAudioPath(quranReaderId, sura));
-		if(f.exists() && f.isDirectory()){
-			String[] filesNames = f.list(new FilenameFilter() {
-				
-				@Override
-				public boolean accept(File dir, String filename) {
-					try{
-						if(filename.endsWith(QuranAudioLibrary.AUDIO_EXTENSION)){
-							filename = filename.substring(0, filename.indexOf(QuranAudioLibrary.AUDIO_EXTENSION));
-							Integer.parseInt(filename);
-							return true;
-						}return false;						
-					}catch (Exception e) {
-						return false;
-					}
-				}
-			});
-			if(filesNames != null)
-				return filesNames.length;
-		}		
-		return -1;
-		
-	}
+
 	public static String getSuraImagePath(int sura){
 		return getAyahImagesDirectory() + File.separator + sura;
 	}
+
 	public static String getAyahImagePath(AyahItem ayahItem) {
 		return getAyahImagePath(ayahItem.getSoura(), ayahItem
 				.getAyah());


### PR DESCRIPTION
-Issue #78: Completed last played ayah functionality
-Added playback dialog which allows user to play from: Beginning of Page, Last Played Ayah, or Beginning of any of the Suras on cur Page.
-Enclose download dialog in ScrollView to fix bug where it goes out of screen in landscape mode
-Removed unnecessary check that was checking if Sura directory is available on file system, and if so play the required ayah.
(This was causing audio to sometimes not play as it is possible that not the whole Sura was downloaded but the directory is there (e.g. downloaded page within Sura). By default, if an ayah was not found locally, it will trigger onAyahNotFound and the listener will show the download dialog. Hene, this extra check was redundant.)
