### PR TITLE
Fix page jumping Issue #140

### DIFF
--- a/src/com/quran/labs/androidquran/QuranViewActivity.java
+++ b/src/com/quran/labs/androidquran/QuranViewActivity.java
@@ -164,7 +164,7 @@ public class QuranViewActivity extends PageViewQuranActivity implements
 				// Quick fix to switch actions 
 				lastAyah = QuranAudioLibrary.getPreviousAyahAudioItem(this, getLastAyah());
 				int page = QuranInfo.getPageFromSuraAyah(lastAyah.getSoura(), lastAyah.getAyah());
-				if (page != quranPageFeeder.getCurrentPagePosition()) 
+				if (page == (quranPageFeeder.getCurrentPagePosition() - 1)) 
 					quranPageFeeder.goToPreviousPage();
 				if (quranAudioPlayer != null && quranAudioPlayer.isPlaying())
 					quranAudioPlayer.play(lastAyah);
@@ -172,7 +172,7 @@ public class QuranViewActivity extends PageViewQuranActivity implements
 				lastAyah = QuranAudioLibrary.getNextAyahAudioItem(this,
 						getLastAyah());
 				int page = QuranInfo.getPageFromSuraAyah(lastAyah.getSoura(), lastAyah.getAyah());
-				if (page != quranPageFeeder.getCurrentPagePosition()) 
+				if (page == (quranPageFeeder.getCurrentPagePosition() + 1)) 
 					quranPageFeeder.goToNextpage();
 				if (quranAudioPlayer != null && quranAudioPlayer.isPlaying())
 					quranAudioPlayer.play(lastAyah);


### PR DESCRIPTION
When pressing Next/Previous, only flip page if doing so would go to Ayah being played, otherwise, let someone else handle jumping to the correct page.
