### PR TITLE
Page Info Overlay

### DIFF
--- a/res/values-ar/strings.xml
+++ b/res/values-ar/strings.xml
@@ -80,6 +80,8 @@
     <string name="prefs_landscape_orientation_summary_off">سيتم استخدام الوضع الرأسي</string>
     <string name="prefs_night_mode_title">القراءة الليلية</string>
     <string name="prefs_night_mode_summary">الخلفية باللون اﻷسود والخطوط باللون اﻷبيض</string>
+    <string name="prefs_overlay_page_info_title">عرض بيانات الصفحة (تجريبية)</string>
+    <string name="prefs_overlay_page_info_summary">عرض رقم الصفحة، إسم الصورة، ورقم الجزء أثناء القراءة</string>
     <string name="prefs_display_marker_title">التنبيه</string>
     <string name="prefs_display_marker_summary">عرض تنبيه عند الوصول إلى بداية الربع أو الجزء</string>
     <string name="prefs_translation_text_title">خط التفسير والترجمة</string>
@@ -116,6 +118,7 @@
     <string name="index_loading">جاري التحميل…</string>
 
     <string name="canceling">جاري إلغاء اﻷمر&#8230;</string>
+    <string name="juz2_description">الجزء %1$d</string>
     <string name="page_description">صفحة %1$d, جزء %2$d</string>
     <string name="highlighting_database">جاري تحميل الملفات المطلوبة</string>
     <string name="timing_database">جاري تحميل الملفات المطلوبة</string>

--- a/res/values/colors.xml
+++ b/res/values/colors.xml
@@ -10,4 +10,5 @@
     <color name="transparent_actionbar_color">#AA000000</color>
     <color name="translation_hdr_color">#ff649ab8</color>
     <color name="translation_sura_header">#ff649ab8</color>
+    <color name="overlay_text_color">#ff888888</color>
 </resources>

--- a/res/values/preferences_keys.xml
+++ b/res/values/preferences_keys.xml
@@ -9,6 +9,7 @@
     <string name="prefs_use_arabic_names">useArabicNames</string>
     <string name="prefs_new_background">useNewBackground</string>
     <string name="prefs_night_mode">nightMode</string>
+    <string name="prefs_overlay_page_info">overlayPageInfo</string>
     <string name="prefs_display_marker_popup">displayMarkerPopup</string>
     <string name="prefs_lock_orientation">lockOrientation</string>
     <string name="prefs_landscape_orientation">landscapeOrientation</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -122,8 +122,10 @@
     <string name="prefs_landscape_orientation_title">Landscape orientation</string>
     <string name="prefs_landscape_orientation_summary_on">Landscape orientation will be used</string>
     <string name="prefs_landscape_orientation_summary_off">Portrait orientation will be used</string>
-    <string name="prefs_night_mode_title">Beta - Night mode</string>
+    <string name="prefs_night_mode_title">Night mode</string>
     <string name="prefs_night_mode_summary">Dark background and light fonts will be used</string>
+    <string name="prefs_overlay_page_info_title">Show page info (beta)</string>
+    <string name="prefs_overlay_page_info_summary">Overlay page number, sura name, and juz\' number while reading</string>
     <string name="prefs_display_marker_title">Display marker popups</string>
     <string name="prefs_display_marker_summary">Display popup on reaching juz\', hizb, etc.</string>
     <string name="prefs_translation_text_title">Translation text size</string>
@@ -161,6 +163,7 @@
     <string name="index_loading">Loading…</string>
 
     <string name="canceling">Canceling&#8230;</string>
+    <string name="juz2_description">Juz\' %1$d</string>
     <string name="page_description">page %1$d, Juz\' %2$d</string>
     <string name="highlighting_database">Required Files</string>
     <string name="timing_database">Required Files</string>
@@ -219,4 +222,6 @@
     <string name="ayah_copied_popup">Ayah Copied</string>
     <string name="remove_bookmark">Remove Bookmark</string>
     <string name="select_all">Select All</string>
+    <string name="edit_tag">Edit Tag</string>
+    <string name="new_tag">New Tag</string>
 </resources>

--- a/res/xml/quran_preferences.xml
+++ b/res/xml/quran_preferences.xml
@@ -60,6 +60,14 @@
 
         <CheckBoxPreference
             android:defaultValue="true"
+            android:key="@string/prefs_overlay_page_info"
+            android:persistent="true"
+            android:summary="@string/prefs_overlay_page_info_summary"
+            android:title="@string/prefs_overlay_page_info_title" >
+        </CheckBoxPreference>
+        
+        <CheckBoxPreference
+            android:defaultValue="true"
             android:key="@string/prefs_display_marker_popup"
             android:persistent="true"
             android:summary="@string/prefs_display_marker_summary"

--- a/src/com/quran/labs/androidquran/data/AyahInfoDatabaseHandler.java
+++ b/src/com/quran/labs/androidquran/data/AyahInfoDatabaseHandler.java
@@ -3,6 +3,8 @@ package com.quran.labs.androidquran.data;
 import android.database.Cursor;
 import android.database.SQLException;
 import android.database.sqlite.SQLiteDatabase;
+import android.graphics.Rect;
+
 import com.quran.labs.androidquran.common.QuranAyah;
 import com.quran.labs.androidquran.util.QuranFileUtils;
 
@@ -42,6 +44,19 @@ public class AyahInfoDatabaseHandler {
 							   MIN_X, MIN_Y, MAX_X, MAX_Y },
 				COL_SURA + "=" + sura + " and " + COL_AYAH + "=" + ayah,
 				null, null, null, COL_POSITION);
+	}
+	
+	public Rect getPageBounds(int page) {
+		if (!validDatabase()) return null;
+		String[] colNames = new String[] {
+				"MIN("+MIN_X+")", "MIN("+MIN_Y+")",
+				"MAX("+MAX_X+")", "MAX("+MAX_Y+")"};
+		Cursor c = database.query(GLYPHS_TABLE, colNames, COL_PAGE + "=" + page,
+				null, null, null, null);
+		if (!c.moveToFirst()) return null;
+		Rect r = new Rect(c.getInt(0), c.getInt(1), c.getInt(2), c.getInt(3));
+		c.close();
+		return r;
 	}
 	
 	// TODO Improve efficiency -AF

--- a/src/com/quran/labs/androidquran/data/Constants.java
+++ b/src/com/quran/labs/androidquran/data/Constants.java
@@ -27,6 +27,7 @@ public class Constants {
    public static final String PREF_NIGHT_MODE = "nightMode";
    public static final String PREF_DEFAULT_QARI = "defaultQari";
    public static final String PREF_SHOULD_FETCH_PAGES ="shouldFetchPages";
+   public static final String PREF_OVERLAY_PAGE_INFO = "overlayPageInfo";
    public static final String PREF_DISPLAY_MARKER_POPUP = "displayMarkerPopup";
    public static final String PREF_AYAH_BEFORE_TRANSLATION = "ayahBeforeTranslation";
    public static final String PREF_PREFER_STREAMING = "preferStreaming";

--- a/src/com/quran/labs/androidquran/data/QuranInfo.java
+++ b/src/com/quran/labs/androidquran/data/QuranInfo.java
@@ -49,6 +49,11 @@ public class QuranInfo {
       return String.format(description, page, QuranInfo.getJuzFromPage(page));
    }
 
+   public static String getJuzString(Context context, int page){
+      String description = context.getString(R.string.juz2_description);
+      return String.format(description, QuranInfo.getJuzFromPage(page));
+   }
+   
    public static String getSuraAyahString(Context context, int sura, int ayah){
       String suraName = getSuraName(context, sura, false);
       String format = context.getString(R.string.sura_ayah_notification_str);

--- a/src/com/quran/labs/androidquran/ui/fragment/QuranPageFragment.java
+++ b/src/com/quran/labs/androidquran/ui/fragment/QuranPageFragment.java
@@ -125,6 +125,10 @@ public class QuranPageFragment extends SherlockFragment {
       mImageView.setOnTouchListener(gestureListener);
       mImageView.setClickable(true);
       mImageView.setLongClickable(true);
+      if (prefs.getBoolean(Constants.PREF_OVERLAY_PAGE_INFO, true)) {
+         try {mImageView.setOverlayText(mPageNumber, true);}
+         catch (Exception e) {/*do nothing*/} // Temporary to avoid any unanticipated FC's
+      }
       return view;
    }
 

--- a/src/com/quran/labs/androidquran/util/QuranSettings.java
+++ b/src/com/quran/labs/androidquran/util/QuranSettings.java
@@ -46,6 +46,11 @@ public class QuranSettings {
               Constants.PREF_NIGHT_MODE, false);
    }
 
+   public static boolean shouldOverlayPageInfo(Context context){
+      return getBooleanPreference(context,
+            Constants.PREF_OVERLAY_PAGE_INFO, true);
+   }
+
    public static boolean shouldDisplayMarkerPopup(Context context){
       return getBooleanPreference(context,
               Constants.PREF_DISPLAY_MARKER_POPUP, true);

--- a/src/com/quran/labs/androidquran/widgets/HighlightingImageView.java
+++ b/src/com/quran/labs/androidquran/widgets/HighlightingImageView.java
@@ -8,6 +8,8 @@ import android.content.SharedPreferences;
 import android.database.Cursor;
 import android.database.SQLException;
 import android.graphics.*;
+import android.graphics.Paint.Align;
+import android.graphics.Paint.FontMetrics;
 import android.graphics.drawable.Drawable;
 import android.preference.PreferenceManager;
 import android.util.AttributeSet;
@@ -18,13 +20,22 @@ import com.quran.labs.androidquran.R;
 import com.quran.labs.androidquran.common.AyahBounds;
 import com.quran.labs.androidquran.data.Constants;
 import com.quran.labs.androidquran.data.AyahInfoDatabaseHandler;
+import com.quran.labs.androidquran.data.QuranInfo;
 import com.quran.labs.androidquran.util.QuranFileUtils;
 
 public class HighlightingImageView extends ImageView {
+   // Max/Min font sizes for text overlay
+   private static final float MAX_FONT_SIZE = 28.0f;
+   private static final float MIN_FONT_SIZE = 16.0f;
+   
 	private List<AyahBounds> currentlyHighlighting = null;
 	private boolean colorFilterOn = false;
 	private String highightedAyah = null;
    private Bitmap mHighlightBitmap = null;
+   
+   // Params for drawing text
+   private OverlayParams overlayParams = null;
+   private Rect pageBounds = null;
 	
 	public HighlightingImageView(Context context){
 		super(context);
@@ -200,9 +211,118 @@ public class HighlightingImageView extends ImageView {
 		}
 	}
 	
+   private class OverlayParams {
+      boolean init = false;
+      boolean showOverlay = false;
+      Paint paint = null;
+      float offsetX;
+      float topBaseline;
+      float bottomBaseline;
+      String suraText = null;
+      String juzText = null;
+      String pageText = null;
+   }
+   
+   public void setOverlayText(int page, boolean show) {
+      // Calculate page bounding rect from ayainfo db
+      this.pageBounds = getPageBounds(page);
+      if (pageBounds == null) return;
+      
+      overlayParams = new OverlayParams();
+      overlayParams.suraText = QuranInfo.getSuraNameFromPage(getContext(), page, true);
+      overlayParams.juzText = QuranInfo.getJuzString(getContext(), page);
+      overlayParams.pageText = String.format("%1$d", page);
+      overlayParams.showOverlay = show;
+   }
+   
+   private Rect getPageBounds(int page){
+      Rect r = null;
+      try {
+         String filename = QuranFileUtils.getAyaPositionFileName();
+         if (filename == null) return null;
+         AyahInfoDatabaseHandler handler =
+               new AyahInfoDatabaseHandler(filename);
+         r = handler.getPageBounds(page);
+         handler.closeDatabase();
+      }
+      catch (SQLException se){/*do nothing*/}
+      return r;
+   }
+   
+   private boolean initOverlayParams() {
+      if (overlayParams == null || pageBounds == null) return false;
+      
+      // Overlay params previously initiated; skip
+      if (overlayParams.init) return true;
+      
+      Drawable page = this.getDrawable();
+      if (page == null) return false;
+      PageScalingData scalingData = new PageScalingData(page);
+      
+      overlayParams.paint = new Paint();
+      overlayParams.paint.setTextSize(MAX_FONT_SIZE);
+      overlayParams.paint.setColor(getResources().getColor(R.color.overlay_text_color));
+      
+      // Use font metrics to calculate the maximum possible height of the text
+      FontMetrics fm = overlayParams.paint.getFontMetrics();
+      float textHeight = fm.bottom-fm.top;
+      
+      // Text size scale based on the available 'header' and 'footer' space
+      // (i.e. gap between top/bottom of screen and actual start of the 'bitmap')
+      float scale = scalingData.offsetY/textHeight;
+      
+      // If the height of the drawn text might be greater than the available gap...
+      // scale down the text size by the calculated scale
+      if (scale < 1.0) {
+         // If after scaling the text size will be less than the minimum size...
+         // get page bounds from db and find the empty area within the image and utilize that as well.
+         if (MAX_FONT_SIZE*scale < MIN_FONT_SIZE) {
+            float emptyYTop = scalingData.offsetY + pageBounds.top*scalingData.heightFactor;
+            float emptyYBottom = scalingData.offsetY
+                  + (scalingData.scaledPageHeight - pageBounds.bottom*scalingData.heightFactor);
+            float emptyY = Math.min(emptyYTop, emptyYBottom);
+            scale = Math.min(emptyY/textHeight, 1.0f);
+         }
+         // Set the scaled text size, and update the metrics
+         overlayParams.paint.setTextSize(MAX_FONT_SIZE*scale);
+         fm = overlayParams.paint.getFontMetrics();
+         textHeight = fm.bottom-fm.top;
+      }
+      
+      // Calculate where the text's baseline should be (for top text and bottom text)
+      // (p.s. parts of the glyphs will be below the baseline such as a 'y' or 'ي')
+      overlayParams.topBaseline = -fm.top;
+      overlayParams.bottomBaseline = getHeight()-fm.bottom;
+      
+      // Calculate the horizontal margins off the edge of screen
+      overlayParams.offsetX = scalingData.offsetX
+            + (getWidth() - pageBounds.width()*scalingData.widthFactor)/2.0f;
+      
+      overlayParams.init = true;
+      return true;
+   }
+   
+   private void overlayText(Canvas canvas) {
+      if (overlayParams == null || !initOverlayParams()) return;
+      
+      overlayParams.paint.setTextAlign(Align.LEFT);
+      canvas.drawText(overlayParams.suraText,
+            overlayParams.offsetX, overlayParams.topBaseline, overlayParams.paint);
+      overlayParams.paint.setTextAlign(Align.RIGHT);
+      canvas.drawText(overlayParams.juzText,
+            getWidth()-overlayParams.offsetX, overlayParams.topBaseline, overlayParams.paint);
+      overlayParams.paint.setTextAlign(Align.CENTER);
+      canvas.drawText(overlayParams.pageText,
+            getWidth()/2.0f, overlayParams.bottomBaseline, overlayParams.paint);
+   }
+   
 	@Override
 	protected void onDraw(Canvas canvas) {
 		super.onDraw(canvas);
+		if (overlayParams != null && overlayParams.showOverlay) {
+			try {overlayText(canvas);}
+			catch (Exception e) {/*do nothing*/} // Temporary to avoid any unanticipated FC's
+		}
 		if (this.currentlyHighlighting != null){
 			Drawable page = this.getDrawable();
 			if (page != null){


### PR DESCRIPTION
Add option for overlaying page info (pg #, sura name, and juz2 #).

Beta for now. Just in case, surrounded the 2 entry points with catch-all to avoid FC's... at least until after Ramadan :)

It determines the empty gap between the top of the ImageView and the top of the actual bitmap. If the gap is large enough, it draws the text within that gap. If not, it uses the ayah-info database to get the actual location of the top of the first line, and utilizes that gap as well for drawing (i.e. between top of bitmap and top of highest glyph). A side effect is that on pages where a sura starts there is a huge gap (either because of basmallah or because of the decoration with sura name) and so it partly overlaps on that.

Should check for ayah-info files, but wasn't sure if it's a good idea because then the user would be asked every time they view a page. For now the "catch all" should take care of it..
