### PR TITLE
Arabic RTL: Set Parent layout gravity to right

### DIFF
--- a/app/src/main/res/layout-ar/index_sura_row.xml
+++ b/app/src/main/res/layout-ar/index_sura_row.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <com.quran.labs.androidquran.ui.helpers.CheckableRelativeLayout
     xmlns:android="http://schemas.android.com/apk/res/android" android:layout_width="match_parent"
-    android:layout_height="match_parent" android:orientation="horizontal">
+    android:layout_height="match_parent" android:layout_gravity="right" android:orientation="horizontal">
 
     <TextView android:id="@+id/suraNumber"
               android:layout_width="34dp"
@@ -44,7 +44,6 @@
         android:layout_height="wrap_content"
         android:layout_toLeftOf="@id/rowIcon"
         android:layout_toRightOf="@+id/pageNumber"
-        android:gravity="right"
         android:maxLines="1"
         android:lines="1"
         android:ellipsize="end"
@@ -62,7 +61,6 @@
         android:layout_toRightOf="@+id/pageNumber"
         android:paddingBottom="5dp"
         android:textSize="10sp"
-        android:gravity="right"
         android:ellipsize="end"
         android:textColor="@color/sura_details_color" />
 


### PR DESCRIPTION
Set Parent layout gravity to right and remove the gravity attribute from the Surat name and details.

![screenshot_2014-05-07-09-46-49](https://cloud.githubusercontent.com/assets/739291/2900243/3cedfbdc-d5c4-11e3-87f4-6ab1804569dd.png)
![screenshot_2014-05-07-09-46-57](https://cloud.githubusercontent.com/assets/739291/2900246/41a33624-d5c4-11e3-8413-82dcdf1c15ea.png)
![screenshot_2014-05-07-09-47-05](https://cloud.githubusercontent.com/assets/739291/2900248/4492c0b6-d5c4-11e3-9f6a-35574a2e3a2b.png)
