### PR TITLE
Selectively show/hide "Sura" prefix in sura list

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/ui/fragment/SuraListFragment.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/fragment/SuraListFragment.java
@@ -102,7 +102,8 @@ public class SuraListFragment extends SherlockFragment {
 
       while ((sura <= SURAS_COUNT) &&
           (QuranInfo.SURA_PAGE_START[sura - 1] < next)) {
-        String title = QuranInfo.getSuraName(activity, sura, true);
+        String title = QuranInfo.getSuraName(activity, sura,
+            getActivity().getResources().getBoolean(R.bool.show_surat_prefix));
         elements[pos++] = new QuranRow(title,
             QuranInfo.getSuraListMetaString(activity, sura),
             sura, QuranInfo.SURA_PAGE_START[sura - 1], null);

--- a/app/src/main/res/values-es/booleans.xml
+++ b/app/src/main/res/values-es/booleans.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<resources>
+    <bool name="show_surat_prefix">false</bool>
+</resources>

--- a/app/src/main/res/values-tr/booleans.xml
+++ b/app/src/main/res/values-tr/booleans.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<resources>
+    <bool name="show_surat_prefix">false</bool>
+</resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -126,9 +126,9 @@
     <string name="quran_nos">½</string>
     <string name="quran_talt_arb3">¾</string>
     <string name="quran_hizb">Hizb</string>
-    <string name="quran_juz2">Cüz\'</string>
+    <string name="quran_juz2">Cüz</string>
     <string name="quran_page">Sayfa</string>
-    <string name="quran_sura">Sure</string>
+    <string name="quran_sura">Sureler</string>
     <string name="quran_ayah">Âyet</string>
     <string name="notification_download_canceled">İndirme iptal edildi</string>
     <string name="unbookmark_ayah">Bu âyet için sayfa işaretini kaldır</string>
@@ -171,7 +171,7 @@
     <string name="prefs_sdcard_external">Harici SD kartı</string>
     <string name="prefs_sdcard_auto">Otomatik</string>
     <string name="prefs_overlay_page_info_title">Sayfa bilgisini göster (beta)</string>
-    <string name="prefs_overlay_page_info_summary">Cüz\' numarası, sure ismi ve sayfa numarası üstünde göster</string>
+    <string name="prefs_overlay_page_info_summary">Cüz numarası, sure ismi ve sayfa numarası üstünde göster</string>
     <string name="prefs_night_mode_text_brightness_title">Metin parlaklığı</string>
     <string name="prefs_night_mode_text_brightness_summary">Gece modu açıkken metin parlaklığı</string>
     <string name="prefs_new_background_title">Yeni arkaplan</string>
@@ -190,7 +190,7 @@
     <string name="prefs_app_location_summary">Lütfen hangi SD karta kopyalanacağını seçin</string>
     <string name="prefs_advanced_settings_title">İleri ayarlar</string>
     <string name="play_from_here">Buradan çalmaya başla</string>
-    <string name="page_description">sayfa  %1$s, cüz\' %2$s</string>
+    <string name="page_description">sayfa  %1$s, cüz %2$s</string>
     <string name="download_progress">%1$s / %2$s indirildi</string>
 
     <string name="not_tagged">Etiketlenmedi</string>
@@ -207,7 +207,7 @@
     <string name="makki">Mekkî</string>
     <string name="madani">Medenî</string>
     <string name="infinity">&#8734;</string>
-    <string name="juz2_description">Cüz\' %1$s</string>
+    <string name="juz2_description">Cüz %1$s</string>
     <string name="index_loading">Yükleniyor&#8230;</string>
     <string name="highlighting_database">Gerekli dosyalar</string>
     <string name="prefs_no_enough_space_to_move_files">Uygulamayı taşımak için yeterli boş alan bulunamadı</string>

--- a/app/src/main/res/values-uz/booleans.xml
+++ b/app/src/main/res/values-uz/booleans.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<resources>
+    <bool name="show_surat_prefix">false</bool>
+</resources>

--- a/app/src/main/res/values-uz/strings.xml
+++ b/app/src/main/res/values-uz/strings.xml
@@ -200,7 +200,7 @@
     <string name="quran_hizb">Hizb</string>
     <string name="quran_juz2">Pora</string>
     <string name="quran_page">Sahifa</string>
-    <string name="quran_sura">Sura</string>
+    <string name="quran_sura">Suralar</string>
     <string name="quran_ayah">Oyat</string>
     <string name="quran_sura_title">Sura</string>
     <string name="sura_ayah_notification_str">Sura %1$s, oyat %2$d</string>

--- a/app/src/main/res/values/booleans.xml
+++ b/app/src/main/res/values/booleans.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?> 
 <resources>
-   <bool name="is_tablet">false</bool>
-   <bool name="use_arabic_reshaper">true</bool>
+    <bool name="is_tablet">false</bool>
+    <bool name="use_arabic_reshaper">true</bool>
+    <bool name="show_surat_prefix">true</bool>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -207,7 +207,7 @@
     <string name="quran_hizb">Hizb</string>
     <string name="quran_juz2">Juz\'</string>
     <string name="quran_page">Page</string>
-    <string name="quran_sura">Sura</string>
+    <string name="quran_sura">Surahs</string>
     <string name="quran_ayah">Ayah</string>
     <string name="quran_sura_title">Surat</string>
     <string name="sura_ayah_notification_str">Sura %1$s, Ayah %2$d</string>


### PR DESCRIPTION
Currently, prefix is disabled for Spanish, Turkish and Uzbek.
Prefix is shown by default.

Also, changed the first tab's title with corresponding plural
form of the word (for English, Turkish and Uzbek).

Fixes #416.
