### PR TITLE
Localize "Sura" prefix

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/data/QuranInfo.java
+++ b/app/src/main/java/com/quran/labs/androidquran/data/QuranInfo.java
@@ -17,11 +17,7 @@ public class QuranInfo {
 	public static String getAyahTitle(Context cx) {
 		return cx.getString(R.string.quran_ayah);
 	}
-	
-	public static String getSuraTitle(Context cx) {
-		return cx.getString(R.string.quran_sura_title);
-	}
-	
+
 	public static String getJuzTitle(Context cx){
 		return cx.getString(R.string.quran_juz2);
    }
@@ -29,12 +25,15 @@ public class QuranInfo {
    public static String getSuraName(Context context, int sura,
                                     boolean wantTitle){
       if (sura < Constants.SURA_FIRST ||
-              sura > Constants.SURA_LAST){ return ""; }
-      String title = "";
-      if (wantTitle){ title = getSuraTitle(context) + " "; }
+              sura > Constants.SURA_LAST) {
+         return "";
+      }
+      if (wantTitle) {
+         return context.getString(R.string.quran_sura_title,
+              context.getResources().getStringArray(R.array.sura_names)[sura-1]);
+      }
 
-      return title + context.getResources()
-              .getStringArray(R.array.sura_names)[sura-1];
+      return context.getResources().getStringArray(R.array.sura_names)[sura-1];
    }
 
    public static int getSuraNumberFromPage(int page){
@@ -615,9 +614,9 @@ public class QuranInfo {
 		return getSuraName(cx, sura, true) + " - "
 				+ getAyahTitle(cx) + " " + ayah;
 	}
-	
+
 	public static String getSuraNameString(Context context, int page){
-		return getSuraTitle(context) + " " + getSuraNameFromPage(context, page);
+		return context.getString(R.string.quran_sura_title, getSuraNameFromPage(context, page));
 	}
 
   public static Set<String> getAyahKeysOnPage(int page, SuraAyah lowerBound, SuraAyah upperBound) {

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -141,7 +141,7 @@
     <string name="quran_page">الصفحة</string>
     <string name="quran_sura">سورة</string>
     <string name="quran_ayah">آية</string>
-    <string name="quran_sura_title">سورة</string>
+    <string name="quran_sura_title">سورة %1$s</string>
     
         <string name="sura_ayah_notification_str">سورة %1$s, آية %2$d</string>
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -216,7 +216,7 @@
     <string name="quran_page">Seite</string>
     <string name="quran_sura">Sura</string>
     <string name="quran_ayah">Vers</string>
-    <string name="quran_sura_title">Sura</string>
+    <string name="quran_sura_title">Sura %1$s</string>
     <string name="sura_ayah_notification_str">Sura %1$s, Vers %2$d</string>
 
     <string name="bookmarks_current_page">Aktuelle Seite</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -125,7 +125,7 @@
   <string name="quran_page">Página</string>
   <string name="quran_sura">Capítulo</string>
   <string name="quran_ayah">Versículo</string>
-  <string name="quran_sura_title">Capítulo</string>
+  <string name="quran_sura_title">Capítulo %1$s</string>
   <string name="sura_ayah_notification_str">Capítulo %1$s, Versículo %2$d</string>
   <string name="bookmarks_current_page">Página corriente</string>
   <string name="index_loading">Cargando...</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -147,7 +147,7 @@
     <string name="quran_page">صفحه</string>
     <string name="quran_sura">سوره</string>
     <string name="quran_ayah">آيه</string>
-    <string name="quran_sura_title">سوره</string>
+    <string name="quran_sura_title">سوره %1$s</string>
     <string name="sura_ayah_notification_str">سوره %1$s, آيه %2$d</string>
 
     <string name="bookmarks_current_page">صفحه کنوني</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -182,7 +182,7 @@
   <string name="quran_page">Page</string>
   <string name="quran_sura">Sourate</string>
   <string name="quran_ayah">Aya</string>
-  <string name="quran_sura_title">Sourate</string>
+  <string name="quran_sura_title">Sourate %1$s</string>
   <string name="sura_ayah_notification_str">Sourate %1$s, Aya %2$d</string>
   <string name="bookmarks_current_page">Page courante</string>
   <string name="index_loading">Chargement…</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -170,7 +170,7 @@
     <string name="quran_page">Halaman</string>
     <string name="quran_sura">Surat</string>
     <string name="quran_ayah">Ayat</string>
-    <string name="quran_sura_title">Surat</string>
+    <string name="quran_sura_title">Surat %1$s</string>
     <string name="sura_ayah_notification_str">Surat %1$s, Ayat %2$d</string>
 
     <string name="bookmarks_current_page">Halaman Saat Ini</string>

--- a/app/src/main/res/values-ku/strings.xml
+++ b/app/src/main/res/values-ku/strings.xml
@@ -174,7 +174,7 @@
     <string name="quran_page">پەڕەی</string>
     <string name="quran_sura">سورەتی</string>
     <string name="quran_ayah">ئایەت</string>
-    <string name="quran_sura_title">سورەت</string>
+    <string name="quran_sura_title">سورەت %1$s</string>
     <string name="sura_ayah_notification_str">سورەتی %1$s, ئایەتی %2$d</string>
 
     <string name="bookmarks_current_page">پەڕەی ئێستا</string>

--- a/app/src/main/res/values-my/strings.xml
+++ b/app/src/main/res/values-my/strings.xml
@@ -171,7 +171,7 @@
 	<string name="quran_page">Halaman</string>
 	<string name="quran_sura">Surah</string>
 	<string name="quran_ayah">Ayat</string>
-	<string name="quran_sura_title">Surah</string>
+	<string name="quran_sura_title">Surah %1$s</string>
 	<string name="sura_ayah_notification_str">Surah %1$s, Ayat %2$d</string>
 
 	<string name="bookmarks_current_page">Halaman Ketika Ini</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -203,7 +203,7 @@
     <string name="quran_page">Страница</string>
     <string name="quran_sura">Сура</string>
     <string name="quran_ayah">Аят</string>
-    <string name="quran_sura_title">Сура</string>
+    <string name="quran_sura_title">Сура %1$s</string>
     <string name="sura_ayah_notification_str">Сура %1$s, Аят %2$d</string>
 
     <string name="bookmarks_current_page">Текущая страница</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -153,7 +153,7 @@
     <string name="search_data">Veri arama</string>
     <string name="remove_dlg_title">Meâl kaldırılsın mı?</string>
     <string name="remove_dlg_msg">\"%1$s\" meâlini kaldırmak istediğinize emin misiniz?</string>
-    <string name="quran_sura_title">Suresi</string>
+    <string name="quran_sura_title">%1$s suresi</string>
     <string name="prefs_volume_key_navigation_summary">Sayfalar arasında ses düğmelerini kullanarak dolaş</string>
     <string name="prefs_volume_key_navigation_title">Ses düğmesi ile dolaşma</string>
     <string name="process_progress"> %1$d / %2$d dosya işleniyor</string>

--- a/app/src/main/res/values-ug/strings.xml
+++ b/app/src/main/res/values-ug/strings.xml
@@ -151,7 +151,7 @@
     <string name="quran_page">بەت</string>
     <string name="quran_sura">سۈرە</string>
     <string name="quran_ayah">ئايەت</string>
-    <string name="quran_sura_title">سۈرە</string>
+    <string name="quran_sura_title">%1$s - سۈرە</string>
     <string name="sura_ayah_notification_str">%1$s -سۈرە، %2$d - ئايەت</string>
 
     <string name="bookmarks_current_page">نۆۋەتتىكى بەت</string>

--- a/app/src/main/res/values-uz/strings.xml
+++ b/app/src/main/res/values-uz/strings.xml
@@ -202,7 +202,7 @@
     <string name="quran_page">Sahifa</string>
     <string name="quran_sura">Sura</string>
     <string name="quran_ayah">Oyat</string>
-    <string name="quran_sura_title">Sura</string>
+    <string name="quran_sura_title">%1$s surasi</string>
     <string name="sura_ayah_notification_str">Sura %1$s, oyat %2$d</string>
 
     <string name="bookmarks_current_page">Joriy sahifa</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -209,7 +209,7 @@
     <string name="quran_page">Page</string>
     <string name="quran_sura">Sura</string>
     <string name="quran_ayah">Ayah</string>
-    <string name="quran_sura_title">Surat</string>
+    <string name="quran_sura_title">Surat %1$s</string>
     <string name="sura_ayah_notification_str">Sura %1$s, Ayah %2$d</string>
 
     <string name="bookmarks_current_page">Current Page</string>


### PR DESCRIPTION
Not all languages follow `"<prefix> <sura_name>"` order,
therefore maintaining such a fixed order in the code
breaks grammar rules in certain languages and causes
difficulty in translations.

This moves ordering to values resources, now the ordering
can be either `"<prefix> <sura_name>"` or `"<sura_name> <suffix>"`
depending on the particular language rules.
