### PR TITLE
Fix 'Too Long Log Tags' lint error

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/QuranPreferenceActivity.java
+++ b/app/src/main/java/com/quran/labs/androidquran/QuranPreferenceActivity.java
@@ -41,8 +41,7 @@ import java.util.List;
 
 public class QuranPreferenceActivity extends PreferenceActivity
         implements SharedPreferences.OnSharedPreferenceChangeListener {
-  private static final String TAG =
-      "com.quran.labs.androidquran.QuranPreferenceActivity";
+  private static final String TAG = QuranPreferenceActivity.class.getSimpleName();
 
   private ListPreference mListStorageOptions;
   private MoveFilesAsyncTask mMoveFilesTask;

--- a/app/src/main/java/com/quran/labs/androidquran/data/QuranDataProvider.java
+++ b/app/src/main/java/com/quran/labs/androidquran/data/QuranDataProvider.java
@@ -27,8 +27,7 @@ import android.util.Log;
 import java.util.List;
 
 public class QuranDataProvider extends ContentProvider {
-  private static final String TAG =
-      "com.quran.labs.androidquran.data.QuranDataProvider";
+  private static final String TAG = QuranDataProvider.class.getSimpleName();
 
 	public static String AUTHORITY =
 		"com.quran.labs.androidquran.data.QuranDataProvider";

--- a/app/src/main/java/com/quran/labs/androidquran/database/BookmarksDBAdapter.java
+++ b/app/src/main/java/com/quran/labs/androidquran/database/BookmarksDBAdapter.java
@@ -18,8 +18,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class BookmarksDBAdapter {
-   private static final String TAG =
-           "com.quran.labs.androidquran.database.BookmarksDBAdapter";
+   private static final String TAG = BookmarksDBAdapter.class.getSimpleName();
 
    public static final int SORT_DATE_ADDED = 0;
    public static final int SORT_LOCATION = 1;

--- a/app/src/main/java/com/quran/labs/androidquran/database/TranslationsDBAdapter.java
+++ b/app/src/main/java/com/quran/labs/androidquran/database/TranslationsDBAdapter.java
@@ -17,8 +17,7 @@ import static com.quran.labs.androidquran.database.TranslationsDBHelper.Translat
 
 public class TranslationsDBAdapter {
 
-   private static final String TAG =
-           "com.quran.labs.androidquran.database.TranslationsDBAdapter";
+   private static final String TAG = TranslationsDBAdapter.class.getSimpleName();
 
    private SQLiteDatabase mDb;
    private Context mContext;

--- a/app/src/main/java/com/quran/labs/androidquran/ui/fragment/BookmarksFragment.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/fragment/BookmarksFragment.java
@@ -20,9 +20,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class BookmarksFragment extends AbsMarkersFragment {
-   private static final String TAG =
-         "com.quran.labs.androidquran.ui.fragment.BookmarksFragment";
-   
+   private static final String TAG = BookmarksFragment.class.getSimpleName();
+
    private static final int[] VALID_SORT_OPTIONS = {R.id.sort_location, R.id.sort_date};
 
    public static BookmarksFragment newInstance(){

--- a/app/src/main/java/com/quran/labs/androidquran/ui/util/ImageAyahUtils.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/util/ImageAyahUtils.java
@@ -18,8 +18,7 @@ import java.util.Map;
 import java.util.Set;
 
 public class ImageAyahUtils {
-   private static final String TAG =
-           "com.quran.labs.androidquran.ui.util.ImageAyahUtils";
+   private static final String TAG = ImageAyahUtils.class.getSimpleName();
 
    private static QuranAyah getAyahFromKey(String key){
       String[] parts = key.split(":");

--- a/app/src/main/java/com/quran/labs/androidquran/util/StorageUtils.java
+++ b/app/src/main/java/com/quran/labs/androidquran/util/StorageUtils.java
@@ -27,7 +27,7 @@ import java.util.Set;
  */
 public class StorageUtils {
 
-  private static final String TAG = "com.quran.labs.androidquran.util.StorageUtils";
+  private static final String TAG = StorageUtils.class.getSimpleName();
 
   /**
    * @return A List of all storage locations available


### PR DESCRIPTION
Lint is complaining with

 _The logging tag can be at most 23 characters, was NN.
  Log tags are only allowed to be at most 23 tag characters long._

error message.