### PR TITLE
Sync external SD card pref title with that of in StorageUtils

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/ui/fragment/QuranSettingsFragment.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/fragment/QuranSettingsFragment.java
@@ -1,13 +1,5 @@
 package com.quran.labs.androidquran.ui.fragment;
 
-import com.quran.labs.androidquran.QuranPreferenceActivity;
-import com.quran.labs.androidquran.R;
-import com.quran.labs.androidquran.data.Constants;
-import com.quran.labs.androidquran.util.QuranFileUtils;
-import com.quran.labs.androidquran.util.QuranScreenInfo;
-import com.quran.labs.androidquran.util.QuranSettings;
-import com.quran.labs.androidquran.util.StorageUtils;
-
 import android.app.AlertDialog;
 import android.app.ProgressDialog;
 import android.content.Context;
@@ -21,12 +13,18 @@ import android.preference.ListPreference;
 import android.preference.Preference;
 import android.preference.PreferenceCategory;
 import android.preference.PreferenceFragment;
-import android.support.v4.content.ContextCompat;
 import android.text.TextUtils;
 import android.util.Log;
 import android.widget.Toast;
 
-import java.io.File;
+import com.quran.labs.androidquran.QuranPreferenceActivity;
+import com.quran.labs.androidquran.R;
+import com.quran.labs.androidquran.data.Constants;
+import com.quran.labs.androidquran.util.QuranFileUtils;
+import com.quran.labs.androidquran.util.QuranScreenInfo;
+import com.quran.labs.androidquran.util.QuranSettings;
+import com.quran.labs.androidquran.util.StorageUtils;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -67,34 +65,11 @@ public class QuranSettingsFragment extends PreferenceFragment implements
         getString(R.string.prefs_app_location));
     mListStoragePref.setEnabled(false);
 
-    final File[] mountPoints = ContextCompat.getExternalFilesDirs(context, null);
-    if (mountPoints.length > 1) {
+    try {
+      mStorageList = StorageUtils.getAllStorageLocations(context.getApplicationContext());
+    } catch (Exception e) {
+      Log.d(TAG, "Exception while trying to get storage locations", e);
       mStorageList = new ArrayList<>();
-      for (int i = 0; i < mountPoints.length; i++) {
-        final StorageUtils.Storage s;
-        if (i == 0) {
-          s = new StorageUtils.Storage(
-              getString(R.string.prefs_sdcard_internal),
-              mInternalSdcardLocation);
-        } else if (mountPoints[i] != null) {
-          s = new StorageUtils.Storage(
-              getString(R.string.prefs_sdcard_external),
-              mountPoints[i].getAbsolutePath());
-        } else {
-          s = null;
-        }
-
-        if (s != null) {
-          mStorageList.add(s);
-        }
-      }
-    } else if (Build.VERSION.SDK_INT < Build.VERSION_CODES.KITKAT) {
-      try {
-        mStorageList = StorageUtils
-            .getAllStorageLocations(context.getApplicationContext());
-      } catch (Exception e) {
-        mStorageList = new ArrayList<>();
-      }
     }
 
     // Hide app location pref if there is no storage option

--- a/app/src/main/java/com/quran/labs/androidquran/util/StorageUtils.java
+++ b/app/src/main/java/com/quran/labs/androidquran/util/StorageUtils.java
@@ -37,8 +37,8 @@ public class StorageUtils {
 
     final File[] mountPoints = ContextCompat.getExternalFilesDirs(context, null);
     if (mountPoints != null && mountPoints.length > 1) {
-      for (int i = 0; i < mountPoints.length; i++) {
-        mounts.add(mountPoints[i].getAbsolutePath());
+      for (File mountPoint : mountPoints) {
+        mounts.add(mountPoint.getAbsolutePath());
       }
     } else if (Build.VERSION.SDK_INT < Build.VERSION_CODES.KITKAT) {
       mounts = readMountsFile();
@@ -48,9 +48,8 @@ public class StorageUtils {
       if (Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN_MR2) {
         Collection<String> vold = readVoldsFile();
 
-        List<String> toRemove = new ArrayList<String>();
-        for (Iterator<String> iter = mounts.iterator(); iter.hasNext(); ) {
-          String mount = iter.next();
+        List<String> toRemove = new ArrayList<>();
+        for (String mount : mounts) {
           if (!vold.contains(mount)) {
             toRemove.add(mount);
           }
@@ -71,7 +70,7 @@ public class StorageUtils {
 
   private static List<Storage> buildMountsList(Context context,
                                                Collection<String> mounts) {
-    List<Storage> list = new ArrayList<Storage>(mounts.size());
+    List<Storage> list = new ArrayList<>(mounts.size());
 
     int externalSdcardsCount = 0;
     if (mounts.size() > 0) {
@@ -108,7 +107,7 @@ public class StorageUtils {
   private static Collection<String> readMountsFile() {
     String sdcardPath = Environment
         .getExternalStorageDirectory().getAbsolutePath();
-    List<String> mounts = new ArrayList<String>();
+    List<String> mounts = new ArrayList<>();
     mounts.add(sdcardPath);
 
     Log.d(TAG, "reading mounts file begin");
@@ -146,7 +145,7 @@ public class StorageUtils {
    * reads volume manager daemon file for auto-mounted storage
    * read more about it here: http://vold.sourceforge.net/
    *
-   * @return
+   * @return Mount points from `vold.fstab` configuration file
    */
   private static Set<String> readVoldsFile() {
     Set<String> volds = new HashSet<>();
@@ -192,7 +191,6 @@ public class StorageUtils {
     private String label;
     private String mountPoint;
     private int freeSpace;
-//    private int totalSpace;
 
     public Storage(String label, String mountPoint) {
       this.label = label;
@@ -202,19 +200,14 @@ public class StorageUtils {
 
     private void computeSpace() {
       StatFs stat = new StatFs(mountPoint);
-//      long totalBytes;
       long bytesAvailable;
       if (Build.VERSION.SDK_INT > Build.VERSION_CODES.JELLY_BEAN_MR1) {
-//        totalBytes = stat.getBlockCountLong() * stat.getBlockSizeLong();
         bytesAvailable = stat.getAvailableBlocksLong() * stat.getBlockSizeLong();
       } else {
-        //noinspection deprecation
-//        totalBytes = (long) stat.getBlockCount() * (long) stat.getBlockSize();
         //noinspection deprecation
         bytesAvailable = (long) stat.getAvailableBlocks() * (long) stat.getBlockSize();
       }
       // Convert total bytes to megabytes
-//      totalSpace = Math.round(totalBytes / (1024 * 1024));
       freeSpace = Math.round(bytesAvailable / (1024 * 1024));
     }
 
@@ -232,12 +225,5 @@ public class StorageUtils {
     public int getFreeSpace() {
       return freeSpace;
     }
-
-//    /**
-//     * @return total size in Megabytes
-//     */
-//    public int getTotalSpace() {
-//      return totalSpace;
-//    }
   }
 }

--- a/app/src/main/java/com/quran/labs/androidquran/util/StorageUtils.java
+++ b/app/src/main/java/com/quran/labs/androidquran/util/StorageUtils.java
@@ -1,13 +1,13 @@
 package com.quran.labs.androidquran.util;
 
-import com.quran.labs.androidquran.R;
-
-import android.annotation.TargetApi;
 import android.content.Context;
 import android.os.Build;
 import android.os.Environment;
 import android.os.StatFs;
+import android.support.v4.content.ContextCompat;
 import android.util.Log;
+
+import com.quran.labs.androidquran.R;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -33,34 +33,44 @@ public class StorageUtils {
    * @return A List of all storage locations available
    */
   public static List<Storage> getAllStorageLocations(Context context) {
-    Collection<String> mounts = readMountsFile();
+    Collection<String> mounts = new ArrayList<>();
 
-    // As per http://source.android.com/devices/tech/storage/config.html
-    // device-specific vold.fstab file is removed after Android 4.2.2
-    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN_MR2) {
+    final File[] mountPoints = ContextCompat.getExternalFilesDirs(context, null);
+    if (mountPoints != null && mountPoints.length > 1) {
+      for (int i = 0; i < mountPoints.length; i++) {
+        mounts.add(mountPoints[i].getAbsolutePath());
+      }
+    } else if (Build.VERSION.SDK_INT < Build.VERSION_CODES.KITKAT) {
+      mounts = readMountsFile();
+
+      // As per http://source.android.com/devices/tech/storage/config.html
+      // device-specific vold.fstab file is removed after Android 4.2.2
+      if (Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN_MR2) {
         Collection<String> vold = readVoldsFile();
 
         List<String> toRemove = new ArrayList<String>();
-        for (Iterator<String> iter = mounts.iterator(); iter.hasNext(); ){
-            String mount = iter.next();
-            if (!vold.contains(mount)){
-                toRemove.add(mount);
-            }
+        for (Iterator<String> iter = mounts.iterator(); iter.hasNext(); ) {
+          String mount = iter.next();
+          if (!vold.contains(mount)) {
+            toRemove.add(mount);
+          }
         }
 
-        for (String s : toRemove){
-            mounts.remove(s);
+        for (String s : toRemove) {
+          mounts.remove(s);
         }
-    } else {
-        Log.d(TAG, "Android version: " + Build.VERSION.CODENAME + " skip reading vold.fstab file");
+      } else {
+        Log.d(TAG, "Android version: " + Build.VERSION.SDK_INT + ", skip reading vold.fstab file");
+      }
     }
+
 
     Log.d(TAG, "mounts list is: " + mounts);
     return buildMountsList(context, mounts);
   }
 
   private static List<Storage> buildMountsList(Context context,
-                                               Collection<String> mounts){
+                                               Collection<String> mounts) {
     List<Storage> list = new ArrayList<Storage>(mounts.size());
 
     int externalSdcardsCount = 0;
@@ -68,35 +78,11 @@ public class StorageUtils {
       String firstItem = mounts.iterator().next();
 
       // Follow Android SDCards naming conventions
-      if (Build.VERSION.SDK_INT < Build.VERSION_CODES.GINGERBREAD) {
-        list.add(new Storage(
-            context.getString(R.string.prefs_sdcard_auto),
-            firstItem));
-      }
-      else if (Build.VERSION.SDK_INT < Build.VERSION_CODES.HONEYCOMB) {
-        if (isExternalStorageRemovableGingerbread()) {
-          list.add(new Storage(context.getString(
-              R.string.prefs_sdcard_external) +
-              " 1", firstItem));
-          externalSdcardsCount = 1;
-        }
-        else {
-          list.add(new Storage(context.getString(
-              R.string.prefs_sdcard_internal), firstItem));
-        }
-      }
-      else {
-        if (!isExternalStorageRemovableGingerbread() ||
-            isExternalStorageEmulatedHoneycomb()) {
-          list.add(new Storage(context.getString(
-              R.string.prefs_sdcard_internal), firstItem));
-        }
-        else {
-          list.add(new Storage(context.getString(
-              R.string.prefs_sdcard_external) +
-              " 1", firstItem));
-          externalSdcardsCount = 1;
-        }
+      if (!Environment.isExternalStorageRemovable() || Environment.isExternalStorageEmulated()) {
+        list.add(new Storage(context.getString(R.string.prefs_sdcard_internal), firstItem));
+      } else {
+        externalSdcardsCount = 1;
+        list.add(new Storage(context.getString(R.string.prefs_sdcard_external, externalSdcardsCount), firstItem));
       }
 
       // All other mounts rather than the first mount point
@@ -104,32 +90,19 @@ public class StorageUtils {
       if (mounts.size() > 1) {
         Iterator<String> iter = mounts.iterator();
 
-        // skip the first one
+        // skip the first one and incremented the counter accordingly
         iter.next();
+        externalSdcardsCount++;
 
-        int i = 1;
-        while (iter.hasNext()){
+        while (iter.hasNext()) {
           String mount = iter.next();
-          list.add(new Storage(context.getString(
-              R.string.prefs_sdcard_external)
-              + " " + (i++ + externalSdcardsCount),
-              mount));
+          list.add(new Storage(context.getString(R.string.prefs_sdcard_external, externalSdcardsCount++), mount));
         }
       }
     }
 
     Log.d(TAG, "final storage list is: " + list);
     return list;
-  }
-
-  @TargetApi(Build.VERSION_CODES.GINGERBREAD)
-  private static boolean isExternalStorageRemovableGingerbread() {
-    return Environment.isExternalStorageRemovable();
-  }
-
-  @TargetApi(Build.VERSION_CODES.HONEYCOMB)
-  private static boolean isExternalStorageEmulatedHoneycomb() {
-    return Environment.isExternalStorageEmulated();
   }
 
   private static Collection<String> readMountsFile() {
@@ -151,7 +124,7 @@ public class StorageUtils {
             String[] lineElements = line.split(" ");
             String element = lineElements[1];
             Log.d(TAG, "mount element is: " + element);
-            if (!sdcardPath.equals(element)){
+            if (!sdcardPath.equals(element)) {
               mounts.add(element);
             }
           } else {
@@ -176,7 +149,7 @@ public class StorageUtils {
    * @return
    */
   private static Set<String> readVoldsFile() {
-    Set<String> volds = new HashSet<String>();
+    Set<String> volds = new HashSet<>();
     volds.add(Environment.getExternalStorageDirectory().getAbsolutePath());
 
     Log.d(TAG, "reading volds file");
@@ -194,8 +167,7 @@ public class StorageUtils {
             Log.d(TAG, "volds element is: " + element);
 
             if (element.contains(":")) {
-              element = element.substring(
-                  0, element.indexOf(":"));
+              element = element.substring(0, element.indexOf(":"));
               Log.d(TAG, "volds element is: " + element);
             }
 
@@ -205,14 +177,12 @@ public class StorageUtils {
             Log.d(TAG, "skipping volds line: " + line);
           }
         }
-      }
-      else {
+      } else {
         Log.d(TAG, "volds file doesn't exit");
       }
       Log.d(TAG, "reading volds file end.. list is: " + volds);
-    }
-    catch (Exception e) {
-      Log.e(TAG, "Error reading vold file", e);
+    } catch (Exception e) {
+      Log.e(TAG, "Error reading volds file", e);
     }
 
     return volds;
@@ -222,7 +192,7 @@ public class StorageUtils {
     private String label;
     private String mountPoint;
     private int freeSpace;
-    private int totalSpace;
+//    private int totalSpace;
 
     public Storage(String label, String mountPoint) {
       this.label = label;
@@ -232,12 +202,19 @@ public class StorageUtils {
 
     private void computeSpace() {
       StatFs stat = new StatFs(mountPoint);
-      long totalBytes = (long) stat.getBlockCount() *
-          (long) stat.getBlockSize();
-      long bytesAvailable = (long) stat.getAvailableBlocks() *
-          (long) stat.getBlockSize();
+//      long totalBytes;
+      long bytesAvailable;
+      if (Build.VERSION.SDK_INT > Build.VERSION_CODES.JELLY_BEAN_MR1) {
+//        totalBytes = stat.getBlockCountLong() * stat.getBlockSizeLong();
+        bytesAvailable = stat.getAvailableBlocksLong() * stat.getBlockSizeLong();
+      } else {
+        //noinspection deprecation
+//        totalBytes = (long) stat.getBlockCount() * (long) stat.getBlockSize();
+        //noinspection deprecation
+        bytesAvailable = (long) stat.getAvailableBlocks() * (long) stat.getBlockSize();
+      }
       // Convert total bytes to megabytes
-      totalSpace = Math.round(totalBytes / (1024 * 1024));
+//      totalSpace = Math.round(totalBytes / (1024 * 1024));
       freeSpace = Math.round(bytesAvailable / (1024 * 1024));
     }
 
@@ -256,11 +233,11 @@ public class StorageUtils {
       return freeSpace;
     }
 
-    /**
-     * @return total size in Megabytes
-     */
-    public int getTotalSpace() {
-      return totalSpace;
-    }
+//    /**
+//     * @return total size in Megabytes
+//     */
+//    public int getTotalSpace() {
+//      return totalSpace;
+//    }
   }
 }

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -109,8 +109,7 @@
     <string name="prefs_app_location_title">مكان التطبيق</string>
     <string name="prefs_app_location_summary">اختر الذاكرة التي سيتم تخزين الملفات عليها</string>
     <string name="prefs_sdcard_internal">الذاكرة الداخلية</string>
-    <string name="prefs_sdcard_external">الذاكرة الخارجية</string>
-    <string name="prefs_sdcard_auto">تلقائي</string>
+    <string name="prefs_sdcard_external">الذاكرة الخارجية %1$d</string>
     <string name="prefs_app_size">مساحة التطبيق</string>
     <string name="prefs_calculating_app_size">جاري حساب مساحة التطبيق</string>
     <string name="prefs_copying_app_files">جاري نسخ ملفات التطبيق</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -181,8 +181,7 @@
     <string name="prefs_app_location_title">Speicherort</string>
     <string name="prefs_app_location_summary">Wählen Sie den Speicherort der Dateien aus.</string>
     <string name="prefs_sdcard_internal">Interner Speicher</string>
-    <string name="prefs_sdcard_external">Externe SD-Karte</string>
-    <string name="prefs_sdcard_auto">Automatisch</string>
+    <string name="prefs_sdcard_external">Externe SD-Karte %1$d</string>
     <string name="prefs_app_size">Der vom Programm verwendete Speicherplatz ist</string>
     <string name="prefs_calculating_app_size">Die Größe des Programms wird berechnet</string>
     <string name="prefs_copying_app_files">Programmdateien werden kopiert</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -91,8 +91,7 @@
   <string name="prefs_app_location_title">Directorio de Datos del Corán</string>
   <string name="prefs_app_location_summary">Elegir ubicación para almacenar los archivos del Corán.</string>
   <string name="prefs_sdcard_internal">Almacenamiento interno</string>
-  <string name="prefs_sdcard_external">Tarjeta SD Externa</string>
-  <string name="prefs_sdcard_auto">Automático</string>
+  <string name="prefs_sdcard_external">Tarjeta SD Externa %1$d</string>
   <string name="prefs_app_size">El tamaño actual de los datos es</string>
   <string name="prefs_calculating_app_size">Calculando tamaño de la aplicación</string>
   <string name="prefs_copying_app_files">Copiando archivos de la aplicación</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -152,8 +152,7 @@
   <string name="prefs_megabytes">Mo</string>
   <string name="prefs_no_enough_space_to_move_files">Espace insuffisant pour déplacer les fichiers de l\'application</string>
   <string name="prefs_sdcard_internal">Stockage interne</string>
-  <string name="prefs_sdcard_external">Carte SD externe</string>
-  <string name="prefs_sdcard_auto">Auto</string>
+  <string name="prefs_sdcard_external">Carte SD externe %1$d</string>
   <string name="prefs_tablet_mode_title">Mode tablette</string>
   <string name="prefs_tablet_mode_enabled">En orientation paysage, deux pages s\'afficheront côte à côte.</string>
   <string name="prefs_tablet_mode_disabled">En orientation paysage, seulement une page s\'affichera.</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -135,8 +135,7 @@
     <string name="prefs_app_location_title">Lokasi aplikasi</string>
     <string name="prefs_app_location_summary">Pilih penyimpanan file</string>
     <string name="prefs_sdcard_internal">Penyimpanan Internal</string>
-    <string name="prefs_sdcard_external">SD Card Eksternal</string>
-    <string name="prefs_sdcard_auto">Auto</string>
+    <string name="prefs_sdcard_external">SD Card Eksternal %1$d</string>
     <string name="prefs_app_size">Ukuran aplikasi</string>
     <string name="prefs_calculating_app_size">Menghitung ukuran aplikasi</string>
     <string name="prefs_copying_app_files">Menyalin file aplikasi</string>

--- a/app/src/main/res/values-ku/strings.xml
+++ b/app/src/main/res/values-ku/strings.xml
@@ -144,7 +144,6 @@
     <string name="prefs_app_location_summary">شوێنێک دیاریبکە بۆ پاراستنی فایلەکانی بەرنامە</string>
     <string name="prefs_sdcard_internal">یادگەی ناوەکی</string>
     <string name="prefs_sdcard_external">یادگەی دەرەکی SD</string>
-    <string name="prefs_sdcard_auto">خۆکار</string>
     <string name="prefs_app_size">قەبارەی بەرنامە</string>
     <string name="prefs_copying_app_files">لەبەرگرتنەوەی فایلەکانی بەرنامە</string>
     <string name="prefs_err_moving_app_files">گواستنەوەی فایلەکانی بەرنامە سەرکەوتو نەبوو</string>

--- a/app/src/main/res/values-my/strings.xml
+++ b/app/src/main/res/values-my/strings.xml
@@ -136,8 +136,7 @@
 	<string name="prefs_app_location_title">Lokasi aplikasi</string>
 	<string name="prefs_app_location_summary">Pilih lokasi untuk menyimpan fail</string>
 	<string name="prefs_sdcard_internal">Simpanan Dalaman</string>
-	<string name="prefs_sdcard_external">SD Card Luar</string>
-	<string name="prefs_sdcard_auto">Auto</string>
+	<string name="prefs_sdcard_external">SD Card Luar %1$d</string>
 	<string name="prefs_app_size">Saiz aplikasi</string>
 	<string name="prefs_calculating_app_size">Mengira saiz aplikasi</string>
 	<string name="prefs_copying_app_files">Menyalin fail aplikasi</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -169,8 +169,7 @@
     <string name="prefs_app_location_title">Расположение приложения</string>
     <string name="prefs_app_location_summary">Выберите место хранения файлов</string>
     <string name="prefs_sdcard_internal">Внутренняя память</string>
-    <string name="prefs_sdcard_external">Внешняя SD карта</string>
-    <string name="prefs_sdcard_auto">Автоматически</string>
+    <string name="prefs_sdcard_external">Внешняя SD карта %1$d</string>
     <string name="prefs_app_size">Размер приложения</string>
     <string name="prefs_calculating_app_size">Расчет размера приложения</string>
     <string name="prefs_copying_app_files">Копирование файлов приложения</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -163,8 +163,7 @@
     <string name="prefs_streaming_title">Akıcı</string>
     <string name="prefs_streaming_summary">Online olarak ses akışı sağla (ayrık olmayan ses dosyaları için)</string>
     <string name="prefs_sdcard_internal">Dahili hafıza</string>
-    <string name="prefs_sdcard_external">Harici SD kartı</string>
-    <string name="prefs_sdcard_auto">Otomatik</string>
+    <string name="prefs_sdcard_external">Harici SD kartı %1$d</string>
     <string name="prefs_overlay_page_info_title">Sayfa bilgisini göster (beta)</string>
     <string name="prefs_overlay_page_info_summary">Cüz numarası, sure ismi ve sayfa numarası üstünde göster</string>
     <string name="prefs_night_mode_text_brightness_title">Metin parlaklığı</string>

--- a/app/src/main/res/values-ug/strings.xml
+++ b/app/src/main/res/values-ug/strings.xml
@@ -116,8 +116,7 @@
     <string name="prefs_app_location_title">ئەپ ئورنى</string>
     <string name="prefs_app_location_summary">ھۆججەتلەرنى قايسى sd كارتىغا ساقلايدىغانلىقىڭىزنى تاللاڭ</string>
     <string name="prefs_sdcard_internal">ئىچىدىكى ساقلىغۇچ</string>
-    <string name="prefs_sdcard_external">سىرتقى SD كارتا</string>
-    <string name="prefs_sdcard_auto">ئاپتوماتىك</string>
+    <string name="prefs_sdcard_external">سىرتقى SD كارتا %1$d</string>
     <string name="prefs_app_size">ئەپ چوڭلۇقى</string>
     <string name="prefs_calculating_app_size">ئەپ چوڭلۇقىنى ھېسابلاۋاتىدۇ</string>
     <string name="prefs_copying_app_files">ئەپ ھۆججەتلىرىنى كۆچۈرۈۋاتىدۇ</string>

--- a/app/src/main/res/values-uz/strings.xml
+++ b/app/src/main/res/values-uz/strings.xml
@@ -161,8 +161,7 @@
     <string name="prefs_app_location_title">Ma\'lumotlar jildi</string>
     <string name="prefs_app_location_summary">Qur\'on fayllari saqlanadigan joy</string>
     <string name="prefs_sdcard_internal">Ichki xotira</string>
-    <string name="prefs_sdcard_external">Tashqi xotira (SD karta)</string>
-    <string name="prefs_sdcard_auto">Avto</string>
+    <string name="prefs_sdcard_external">Tashqi xotira (SD karta %1$d)</string>
     <string name="prefs_app_size">Mavjud fayllar hajmi:</string>
     <string name="prefs_calculating_app_size">Programma hajmi hisoblanmoqda&#8230;</string>
     <string name="prefs_copying_app_files">Programma fayllari ko\'chirilmoqda&#8230;</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -124,7 +124,7 @@
     <string name="translation_settings">Translation Settings</string>
     <string name="no_arabic_search_available">You have not downloaded the Arabic search pack.  Please download it and try your search again.</string>
     <string name="get_arabic_search_db">Get Arabic Search Database</string>
-        
+
     <!-- Quran Preference Activity -->
     <string name="prefs_category_navigation">Navigation</string>
     <string name="prefs_volume_key_navigation_title">Volume key navigation</string>
@@ -168,7 +168,7 @@
     <string name="prefs_app_location_title">Quran Data Directory</string>
     <string name="prefs_app_location_summary">Choose where to store Quran files.</string>
     <string name="prefs_sdcard_internal">Internal Storage</string>
-    <string name="prefs_sdcard_external">External SD Card</string>
+    <string name="prefs_sdcard_external">External SD Card %1$d</string>
     <string name="prefs_sdcard_auto">Auto</string>
     <string name="prefs_app_size">Current data size is</string>
     <string name="prefs_calculating_app_size">Calculating App Size</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -169,7 +169,6 @@
     <string name="prefs_app_location_summary">Choose where to store Quran files.</string>
     <string name="prefs_sdcard_internal">Internal Storage</string>
     <string name="prefs_sdcard_external">External SD Card %1$d</string>
-    <string name="prefs_sdcard_auto">Auto</string>
     <string name="prefs_app_size">Current data size is</string>
     <string name="prefs_calculating_app_size">Calculating App Size</string>
     <string name="prefs_copying_app_files">Copying App files</string>


### PR DESCRIPTION
This is how it looks now:

![screenshot_2015-03-01-21-47-14](https://cloud.githubusercontent.com/assets/452620/6430791/85e1df10-c05c-11e4-91e9-78f754aa3b17.png)

It feels a little confusing with external storage number (1) and the free space amount (59933) being shown side-by-side. Probably, free space amount needs to be shown inside parenthesis or otherwise made it visually distinguishable.
