### PR TITLE
Put free space information below the label

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/ui/preference/DataListPreference.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/preference/DataListPreference.java
@@ -1,0 +1,127 @@
+package com.quran.labs.androidquran.ui.preference;
+
+import android.annotation.TargetApi;
+import android.app.Activity;
+import android.app.AlertDialog;
+import android.content.Context;
+import android.graphics.Color;
+import android.os.Build;
+import android.preference.ListPreference;
+import android.support.annotation.NonNull;
+import android.text.TextUtils;
+import android.util.AttributeSet;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ArrayAdapter;
+import android.widget.CheckedTextView;
+import android.widget.ListAdapter;
+import android.widget.TextView;
+
+import com.quran.labs.androidquran.R;
+import com.quran.labs.androidquran.util.QuranSettings;
+import com.quran.labs.androidquran.util.StorageUtils;
+
+import java.util.List;
+
+public class DataListPreference extends ListPreference {
+  private CharSequence[] mFreeSpaceAmounts;
+
+  @TargetApi(Build.VERSION_CODES.LOLLIPOP)
+  public DataListPreference(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
+    super(context, attrs, defStyleAttr, defStyleRes);
+  }
+
+  @TargetApi(Build.VERSION_CODES.LOLLIPOP)
+  public DataListPreference(Context context, AttributeSet attrs, int defStyleAttr) {
+    super(context, attrs, defStyleAttr);
+  }
+
+  public DataListPreference(Context context, AttributeSet attrs) {
+    super(context, attrs);
+  }
+
+  public DataListPreference(Context context) {
+    super(context);
+  }
+
+  public void setLabelsAndSummaries(Context context, int appSize,
+                                    List<StorageUtils.Storage> storageList) {
+    String summary = context.getString(R.string.prefs_app_location_summary) + "\n"
+        + context.getString(R.string.prefs_app_size) + " " +
+        context.getString(R.string.prefs_megabytes, appSize);
+    setSummary(summary);
+
+    CharSequence[] values = new CharSequence[storageList.size()];
+    CharSequence[] displayNames = new CharSequence[storageList.size()];
+    mFreeSpaceAmounts = new CharSequence[storageList.size()];
+    StorageUtils.Storage storage;
+    for (int i = 0; i < storageList.size(); i++) {
+      storage = storageList.get(i);
+      values[i] = storage.getMountPoint();
+      displayNames[i] = storage.getLabel();
+      mFreeSpaceAmounts[i] = context.getString(R.string.prefs_megabytes, storage.getFreeSpace());
+    }
+    setEntries(displayNames);
+    setEntryValues(values);
+    final QuranSettings settings = QuranSettings.getInstance(context);
+    String current = settings.getAppCustomLocation();
+    if (TextUtils.isEmpty(current)) {
+      current = values[0].toString();
+    }
+    setValue(current);
+  }
+
+  @Override
+  protected void onPrepareDialogBuilder(@NonNull AlertDialog.Builder builder) {
+    int selectedIndex = findIndexOfValue(getValue());
+    ListAdapter adapter = new StorageArrayAdapter(getContext(), R.layout.data_storage_location_item,
+        getEntries(), selectedIndex, mFreeSpaceAmounts);
+    builder.setAdapter(adapter, this);
+    super.onPrepareDialogBuilder(builder);
+  }
+
+  @Override
+  protected void onBindView(@NonNull View view) {
+    super.onBindView(view);
+    if (isEnabled()) {
+      final TextView title = (TextView) view.findViewById(android.R.id.title);
+      if (title != null) {
+        title.setTextColor(Color.WHITE);
+      }
+    }
+  }
+
+  public class StorageArrayAdapter extends ArrayAdapter<CharSequence> {
+    private int mSelectedIndex = 0;
+    private CharSequence[] mFreeSpaces;
+
+    public StorageArrayAdapter(Context context, int textViewResourceId, CharSequence[] objects,
+                               int selectedIndex, CharSequence[] freeSpaces) {
+      super(context, textViewResourceId, objects);
+      mSelectedIndex = selectedIndex;
+      mFreeSpaces = freeSpaces;
+    }
+
+    @Override
+    public View getView(int position, View convertView, ViewGroup parent) {
+      if (convertView == null) {
+        LayoutInflater inflater = ((Activity) getContext()).getLayoutInflater();
+        convertView = inflater.inflate(R.layout.data_storage_location_item, parent, false);
+      }
+
+      TextView label = (TextView) convertView.findViewById(R.id.storage_label);
+      label.setText(getItem(position));
+      TextView freeSpace = (TextView) convertView.findViewById(R.id.available_free_space);
+      freeSpace.setText(mFreeSpaces[position]);
+
+      CheckedTextView checkedTextView = (CheckedTextView) convertView.findViewById(R.id.checked_text_view);
+      checkedTextView.setText(null); // we have a 'custom' label
+      if (position == mSelectedIndex) {
+        checkedTextView.setChecked(true);
+      }
+
+      return convertView;
+    }
+  }
+}

--- a/app/src/main/res/layout/data_storage_location_item.xml
+++ b/app/src/main/res/layout/data_storage_location_item.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+              android:layout_width="match_parent"
+              android:layout_height="wrap_content"
+              android:orientation="horizontal"
+              android:paddingLeft="16dp"
+              android:paddingRight="16dp"
+              android:minHeight="?android:attr/listPreferredItemHeight">
+
+  <LinearLayout
+      android:layout_width="0dp"
+      android:layout_height="wrap_content"
+      android:layout_weight="4.00"
+      android:orientation="vertical"
+      android:layout_gravity="center_vertical">
+
+    <TextView
+        android:id="@+id/storage_label"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:ellipsize="marquee"
+        android:textAppearance="?android:attr/textAppearanceMedium"
+        android:textColor="?android:attr/textColorAlertDialogListItem"
+        android:text="Label"/>
+
+    <TextView
+        android:id="@+id/available_free_space"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textAppearance="?android:attr/textAppearanceSmall"
+        android:textColor="?android:attr/textColorAlertDialogListItem"
+        android:text="12345 MB"/>
+
+  </LinearLayout>
+
+  <CheckedTextView
+      android:id="@+id/checked_text_view"
+      android:layout_width="0dp"
+      android:layout_height="wrap_content"
+      android:layout_weight="1.00"
+      android:checkMark="?android:attr/listChoiceIndicatorSingle"
+      android:textColor="?android:attr/textColorAlertDialogListItem"
+      android:layout_gravity="center_vertical"/>
+
+</LinearLayout>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -187,7 +187,6 @@
     <string name="prefs_copying_app_files">Programmdateien werden kopiert</string>
     <string name="prefs_err_moving_app_files">Die Programmdateien konnten nicht verschoben werden.</string>
     <string name="prefs_no_enough_space_to_move_files">Sie haben nicht genug Speicherplatz um die Dateien zu verschieben.</string>
-    <string name="prefs_megabytes">MB</string>
     <string name="prefs_tablet_mode_title">Tablet-Modus</string>
     <string name="prefs_tablet_mode_enabled">Im Querformat werden zwei Seiten nebeneinander dargestellt.</string>
     <string name="prefs_tablet_mode_disabled">Im Querformat wird nur eine Seite dargestellt.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -97,7 +97,6 @@
   <string name="prefs_copying_app_files">Copiando archivos de la aplicación</string>
   <string name="prefs_err_moving_app_files">Error al mover los archivos de la aplicación</string>
   <string name="prefs_no_enough_space_to_move_files">Espacio insuficiente para mover archivos de la aplicación</string>
-  <string name="prefs_megabytes">MB</string>
   <string name="prefs_tablet_mode_title">Modo Tableta</string>
   <string name="prefs_tablet_mode_enabled">En modo horizontal, aparecerán dos páginas una al lado de la otra.</string>
   <string name="prefs_tablet_mode_disabled">En modo horizontal, se mostrará solo una página.</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -150,7 +150,7 @@
   <string name="prefs_calculating_app_size">Calcul de la taille de l\'application</string>
   <string name="prefs_copying_app_files">Copie des fichier de l\'application</string>
   <string name="prefs_err_moving_app_files">Echec du déplacement des fichiers de l\'application</string>
-  <string name="prefs_megabytes">Mo</string>
+  <string name="prefs_megabytes">%1$d Mo</string>
   <string name="prefs_no_enough_space_to_move_files">Espace insuffisant pour déplacer les fichiers de l\'application</string>
   <string name="prefs_sdcard_internal">Stockage interne</string>
   <string name="prefs_sdcard_external">Carte SD externe %1$d</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -141,7 +141,6 @@
     <string name="prefs_copying_app_files">Menyalin file aplikasi</string>
     <string name="prefs_err_moving_app_files">Gagal memindahkan file aplikasi</string>
     <string name="prefs_no_enough_space_to_move_files">Ruang yang tersedia tidak cukup untuk memindahkan file aplikasi</string>
-    <string name="prefs_megabytes">MB</string>
     <string name="prefs_tablet_mode_title">Mode Tablet</string>
     <string name="prefs_tablet_mode_enabled">Dalam mode landscape, dua halaman akan muncul berdampingan.</string>
     <string name="prefs_tablet_mode_disabled">Dalam mode landscape, hanya menampilkan satu halaman.</string>

--- a/app/src/main/res/values-ku/strings.xml
+++ b/app/src/main/res/values-ku/strings.xml
@@ -148,7 +148,7 @@
     <string name="prefs_copying_app_files">لەبەرگرتنەوەی فایلەکانی بەرنامە</string>
     <string name="prefs_err_moving_app_files">گواستنەوەی فایلەکانی بەرنامە سەرکەوتو نەبوو</string>
     <string name="prefs_no_enough_space_to_move_files">شوێنی بەتاڵ کەمە بۆ گواستنەوەی فایلەکانی بەرنامە</string>
-    <string name="prefs_megabytes">مێگابایت</string>
+    <string name="prefs_megabytes">مێگابایت  %1$d</string>
     <!-- Preferences End -->
 
     <!-- translation updates -->

--- a/app/src/main/res/values-my/strings.xml
+++ b/app/src/main/res/values-my/strings.xml
@@ -142,7 +142,6 @@
 	<string name="prefs_copying_app_files">Menyalin fail aplikasi</string>
 	<string name="prefs_err_moving_app_files">Gagal memindahkan fail aplikasi</string>
 	<string name="prefs_no_enough_space_to_move_files">Tidak cukup ruang untuk memindahkan fail aplikasi</string>
-	<string name="prefs_megabytes">MB</string>
 	<string name="prefs_tablet_mode_title">Mod Tablet</string>
 	<string name="prefs_tablet_mode_enabled">Dalam mod landscape, dua halaman akan muncul bersebelahan.</string>
 	<string name="prefs_tablet_mode_disabled">Dalam mod landscape, hanya paparkan satu halaman.</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -174,7 +174,7 @@
     <string name="prefs_copying_app_files">Копирование файлов приложения</string>
     <string name="prefs_err_moving_app_files">Ошибка перемещения файлов приложения</string>
     <string name="prefs_no_enough_space_to_move_files">Недостаточно свободного места для перемещения файлов приложения</string>
-    <string name="prefs_megabytes">MБ</string>
+    <string name="prefs_megabytes">%1$d MБ</string>
     <string name="prefs_tablet_mode_title">Режим планшета</string>
     <string name="prefs_tablet_mode_enabled">В альбомном режиме две страницы будут отображаться рядом друг с другом.</string>
     <string name="prefs_tablet_mode_disabled">В альбомном режиме будет отображена только одна страницы.</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -169,7 +169,6 @@
     <string name="prefs_night_mode_text_brightness_title">Metin parlaklığı</string>
     <string name="prefs_night_mode_text_brightness_summary">Gece modu açıkken metin parlaklığı</string>
     <string name="prefs_new_background_title">Yeni arkaplan</string>
-    <string name="prefs_megabytes">MB</string>
     <string name="prefs_download_amount_title">İndirme miktarı</string>
     <string name="prefs_download_amount_summary">Ayrık olan ses dosyaları için indrime miktarı</string>
     <string name="prefs_err_moving_app_files">Uygulama dosyalarını taşınamadı</string>

--- a/app/src/main/res/values-ug/strings.xml
+++ b/app/src/main/res/values-ug/strings.xml
@@ -122,7 +122,6 @@
     <string name="prefs_copying_app_files">ئەپ ھۆججەتلىرىنى كۆچۈرۈۋاتىدۇ</string>
     <string name="prefs_err_moving_app_files">ئەپ ھۆججەتلىرىنى يۆتكىيەلمىدى</string>
     <string name="prefs_no_enough_space_to_move_files">ئەپ ھۆججەتلىرىنى يۆتكەشكە يېتەرلىك بوشلۇق يوق</string>
-    <string name="prefs_megabytes">MB</string>
     <string name="prefs_tablet_mode_title">تاختا كومپيۇتېر ھالىتى</string>
     <string name="prefs_tablet_mode_enabled">توغرىسىغا ھالەتتە، ئىككى بەت يانمۇيان كۆرۈنىدۇ.</string>
     <string name="prefs_tablet_mode_disabled">توغرىسىغا ھالەتتە، بىرلا بەتنى كۆرسىتىدۇ.</string>

--- a/app/src/main/res/values-uz/strings.xml
+++ b/app/src/main/res/values-uz/strings.xml
@@ -167,7 +167,6 @@
     <string name="prefs_copying_app_files">Programma fayllari ko\'chirilmoqda&#8230;</string>
     <string name="prefs_err_moving_app_files">Fayllarni ko\'chirib o\'tkazishda xatolik yuz berdi</string>
     <string name="prefs_no_enough_space_to_move_files">Fayllarni ko\'chirib o\'tkazish uchun yetarli joy mavjud emas</string>
-    <string name="prefs_megabytes">MB</string>
     <string name="prefs_tablet_mode_title">Planshet rejimi</string>
     <string name="prefs_tablet_mode_enabled">Yotiq holatda ikki bet yonma-yon ko\'rinadi</string>
     <string name="prefs_tablet_mode_disabled">Yotiq holatda ham faqat bitta bet ko\'rinadi</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -181,7 +181,7 @@
     <string name="prefs_copying_app_files">Copying App files</string>
     <string name="prefs_err_moving_app_files">Failed to move app files</string>
     <string name="prefs_no_enough_space_to_move_files">Insufficient space to move app files</string>
-    <string name="prefs_megabytes">MB</string>
+    <string name="prefs_megabytes">%1$d MB</string>
     <string name="prefs_tablet_mode_title">Tablet Mode</string>
     <string name="prefs_tablet_mode_enabled">In landscape, two pages will appear side by side.</string>
     <string name="prefs_tablet_mode_disabled">In landscape, only one page will appear.</string>

--- a/app/src/main/res/xml/quran_preferences.xml
+++ b/app/src/main/res/xml/quran_preferences.xml
@@ -154,10 +154,11 @@
                     android:targetClass="com.quran.labs.androidquran.ui.AudioManagerActivity" />
         </com.quran.labs.androidquran.ui.preference.QuranPreference>
 
-        <com.quran.labs.androidquran.ui.preference.QuranListPreference
+        <com.quran.labs.androidquran.ui.preference.DataListPreference
             android:key="@string/prefs_app_location"
             android:summary="@string/prefs_app_location_summary"
             android:title="@string/prefs_app_location_title" />
     </PreferenceCategory>
 
 </PreferenceScreen>
+


### PR DESCRIPTION
This was somewhat mentioned in PR https://github.com/quran/quran_android/pull/481:
original implementation put storage label, number and free space in one line; that feels and looks confusing. This is an attempt to give the list a more decent look. 
Following is how it looks now:

![device-2015-03-19-205313](https://cloud.githubusercontent.com/assets/452620/6729868/14158ffe-ce7a-11e4-89df-622d1a5e285c.png)
