### PR TITLE
Let travis-ci test release builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ android:
       - android-23
       - extra-android-m2repository
 script:
-   - ./gradlew clean testMadaniDebug
+   - ./gradlew clean testMadaniRelease -PdisableCrashlytics

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -56,6 +56,9 @@ android {
          proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard.cfg'
          signingConfig signingConfigs.release
          versionNameSuffix "-beta"
+         if (project.hasProperty('disableCrashlytics')) {
+            ext.enableCrashlytics = false
+         }
       }
 
       debug {
@@ -66,6 +69,9 @@ android {
          minifyEnabled true
          proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard.cfg'
          signingConfig signingConfigs.release
+         if (project.hasProperty('disableCrashlytics')) {
+            ext.enableCrashlytics = false
+         }
       }
     }
 


### PR DESCRIPTION
By default, travis runs ./gradlew test, which tests all combinations.
These were failing on release builds due to the crashlytics key being
missing. Ideally, however, we want to be able to test release build (so
that we can catch proguard issues early on, for example). This patch
introduces a gradle flag, disableCrashlytics, which, when building
release or beta, disables crashlytics.