### PR TITLE
Implement nicer looking notifications.

### DIFF
--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -26,6 +26,8 @@
     <color name="indicator_color">@color/accent_color</color>
     <color name="panel_label">@color/accent_color</color>
     <color name="notification_color">#ff112e44</color>
+    <color name="audio_notification_color">@color/download_button_background</color>
+    <color name="audio_notification_background_color">#ffd8d8d8</color>
     <color name="ayah_bookmark_color">#ff81c784</color>
     <color name="download_button_background">#ff556f79</color>
     <color name="snackbar_background_color">@color/download_button_background</color>


### PR DESCRIPTION
This patch draws a custom "album art" image for use in the media style.
It looks best on apis 21+, where the notification background color can
be changed, but looks fine pre-21 as well. Furthermore, since there's a
possibility that generating this image throws OOM, fall back to the
previous, non-MediaStyle notification if we can't generate the image.