### PR TITLE
Remove null notification icon check and empty titles

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/service/AudioService.java
+++ b/app/src/main/java/com/quran/labs/androidquran/service/AudioService.java
@@ -1095,8 +1095,6 @@ public class AudioService extends Service implements OnCompletionListener,
       }
     }
 
-    // if we couldn't get the notification icon, we'll use the non-MediaStyle notification.
-    boolean emptyTitles = mNotificationIcon == null;
     String audioTitle = mAudioRequest.getTitle(getApplicationContext());
     if (mNotificationBuilder == null) {
       mNotificationBuilder = new NotificationCompat.Builder(appContext);
@@ -1107,18 +1105,15 @@ public class AudioService extends Service implements OnCompletionListener,
           .setContentTitle(getString(R.string.app_name))
           .setContentIntent(pi)
           .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
-          .addAction(R.drawable.ic_previous,
-              emptyTitles ? "" : getString(R.string.previous), previousIntent)
-          .addAction(R.drawable.ic_pause, emptyTitles ? "" : getString(R.string.pause), pauseIntent)
-          .addAction(R.drawable.ic_next, emptyTitles ? "" : getString(R.string.next), nextIntent)
+          .addAction(R.drawable.ic_previous, getString(R.string.previous), previousIntent)
+          .addAction(R.drawable.ic_pause, getString(R.string.pause), pauseIntent)
+          .addAction(R.drawable.ic_next, getString(R.string.next), nextIntent)
           .setShowWhen(false)
-          .setWhen(0); // older platforms seem to ignore setShowWhen(false)
-      if (mNotificationIcon != null) {
-        mNotificationBuilder.setStyle(new NotificationCompat.MediaStyle()
-            .setShowActionsInCompactView(0, 1, 2 )
-            .setMediaSession(mMediaSession.getSessionToken()))
-            .setLargeIcon(mNotificationIcon);
-      }
+          .setWhen(0) // older platforms seem to ignore setShowWhen(false)
+          .setStyle(new NotificationCompat.MediaStyle()
+          .setShowActionsInCompactView(0, 1, 2)
+          .setMediaSession(mMediaSession.getSessionToken()))
+          .setLargeIcon(mNotificationIcon);
     }
     mNotificationBuilder.setTicker(audioTitle);
     mNotificationBuilder.setContentText(audioTitle);
@@ -1132,17 +1127,14 @@ public class AudioService extends Service implements OnCompletionListener,
           .setContentTitle(getString(R.string.app_name))
           .setContentIntent(pi)
           .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
-          .addAction(R.drawable.ic_play, emptyTitles ? "" : getString(R.string.play), resumeIntent)
-          .addAction(R.drawable.ic_stop, emptyTitles ? "" : getString(R.string.stop), stopIntent)
+          .addAction(R.drawable.ic_play, getString(R.string.play), resumeIntent)
+          .addAction(R.drawable.ic_stop, getString(R.string.stop), stopIntent)
           .setShowWhen(false)
-          .setWhen(0);
-      if (mNotificationIcon != null) {
-        mPausedNotificationBuilder
-            .setLargeIcon(mNotificationIcon)
-            .setStyle(new NotificationCompat.MediaStyle()
-            .setShowActionsInCompactView(0, 1)
-            .setMediaSession(mMediaSession.getSessionToken()));
-      }
+          .setWhen(0)
+          .setLargeIcon(mNotificationIcon)
+          .setStyle(new NotificationCompat.MediaStyle()
+          .setShowActionsInCompactView(0, 1)
+          .setMediaSession(mMediaSession.getSessionToken()));
     }
     mPausedNotificationBuilder.setContentText(audioTitle);
 


### PR DESCRIPTION
As mentioned [elsewhere](https://github.com/quran/quran_android/pull/610#issuecomment-170500613), _that is an edge case_.

Null `mNotificationIcon` in Android 4.4.4:
![null-notification-icon_android-4 4 4](https://cloud.githubusercontent.com/assets/452620/12236649/df9ff350-b89c-11e5-87f2-8e024aeb023f.png)

Null `mNotificationIcon` in Android 6.0.1:
![null-notification-icon_android-6 0 1](https://cloud.githubusercontent.com/assets/452620/12236684/10c81070-b89d-11e5-8116-25b3a81a2105.png)

Null `mNotificationIcon` in Android 6.0.1 lockscreen:
![null-notification-icon_android-6 0 1-lockscreen](https://cloud.githubusercontent.com/assets/452620/12236704/2204a6aa-b89d-11e5-94bc-333cc7c39e7e.png)
