### PR TITLE
Viewing new rub3 permenantly instead of just poping it up

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/ui/fragment/QuranPageFragment.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/fragment/QuranPageFragment.java
@@ -301,7 +301,8 @@ public class QuranPageFragment extends Fragment implements AyahTracker, PageCont
           String suraText = QuranInfo.getSuraNameFromPage(context, page, true);
           String juzText = QuranInfo.getJuzString(context, page);
           String pageText = QuranUtils.getLocalizedNumber(context, page);
-          mImageView.setOverlayText(suraText, juzText, pageText);
+          String rub3Text =HighlightingImageView.displayRub3(context,page);
+          mImageView.setOverlayText(suraText, juzText, pageText,rub3Text);
         }
       }
     }

--- a/app/src/main/java/com/quran/labs/androidquran/ui/fragment/QuranPageFragment.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/fragment/QuranPageFragment.java
@@ -303,7 +303,7 @@ public class QuranPageFragment extends Fragment implements AyahTracker, PageCont
           String juzText = QuranInfo.getJuzString(context, page);
           String pageText = QuranUtils.getLocalizedNumber(context, page);
           String rub3Text = QuranDisplayHelper.displayRub3(context,page);
-          mImageView.setOverlayText(suraText, juzText, pageText,rub3Text);
+          mImageView.setOverlayText(suraText, juzText, pageText, rub3Text);
         }
       }
     }

--- a/app/src/main/java/com/quran/labs/androidquran/ui/fragment/QuranPageFragment.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/fragment/QuranPageFragment.java
@@ -29,6 +29,7 @@ import com.quran.labs.androidquran.ui.PagerActivity;
 import com.quran.labs.androidquran.ui.helpers.AyahSelectedListener;
 import com.quran.labs.androidquran.ui.helpers.AyahTracker;
 import com.quran.labs.androidquran.ui.helpers.HighlightType;
+import com.quran.labs.androidquran.ui.helpers.QuranDisplayHelper;
 import com.quran.labs.androidquran.ui.helpers.QuranPageWorker;
 import com.quran.labs.androidquran.ui.util.ImageAyahUtils;
 import com.quran.labs.androidquran.ui.util.PageController;
@@ -301,7 +302,7 @@ public class QuranPageFragment extends Fragment implements AyahTracker, PageCont
           String suraText = QuranInfo.getSuraNameFromPage(context, page, true);
           String juzText = QuranInfo.getJuzString(context, page);
           String pageText = QuranUtils.getLocalizedNumber(context, page);
-          String rub3Text =HighlightingImageView.displayRub3(context,page);
+          String rub3Text = QuranDisplayHelper.displayRub3(context,page);
           mImageView.setOverlayText(suraText, juzText, pageText,rub3Text);
         }
       }

--- a/app/src/main/java/com/quran/labs/androidquran/ui/fragment/TabletFragment.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/fragment/TabletFragment.java
@@ -320,8 +320,8 @@ public class TabletFragment extends Fragment
           if (mRightImageView != null && mLeftImageView != null) {
             mRightImageView.setPageBounds(rect[0]);
             mLeftImageView.setPageBounds(rect[1]);
-            if (mOverlayText) {
-              Context context = getContext();
+            Context context = getContext();
+            if (mOverlayText && isAdded()) {
               String suraText = QuranInfo.getSuraNameFromPage(context, mPageNumber - 1, true);
               String juzText = QuranInfo.getJuzString(context, mPageNumber - 1);
               String pageText = QuranUtils.getLocalizedNumber(context, mPageNumber - 1);

--- a/app/src/main/java/com/quran/labs/androidquran/ui/fragment/TabletFragment.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/fragment/TabletFragment.java
@@ -319,16 +319,18 @@ public class TabletFragment extends Fragment
           if (mRightImageView != null && mLeftImageView != null) {
             mRightImageView.setPageBounds(rect[0]);
             mLeftImageView.setPageBounds(rect[1]);
-            Context context = getContext();
-            if (mOverlayText && context != null) {
+            if (mOverlayText) {
+              Context context = getContext();
               String suraText = QuranInfo.getSuraNameFromPage(context, mPageNumber - 1, true);
               String juzText = QuranInfo.getJuzString(context, mPageNumber - 1);
               String pageText = QuranUtils.getLocalizedNumber(context, mPageNumber - 1);
-              mRightImageView.setOverlayText(suraText, juzText, pageText);
+              String rub3Text =HighlightingImageView.displayRub3(context,mPageNumber - 1);
+              mRightImageView.setOverlayText(suraText, juzText, pageText, rub3Text);
               suraText = QuranInfo.getSuraNameFromPage(context, mPageNumber, true);
               juzText = QuranInfo.getJuzString(context, mPageNumber);
               pageText = QuranUtils.getLocalizedNumber(context, mPageNumber);
-              mLeftImageView.setOverlayText(suraText, juzText, pageText);
+              rub3Text =HighlightingImageView.displayRub3(context,mPageNumber);
+              mLeftImageView.setOverlayText(suraText, juzText, pageText, rub3Text);
             }
           }
         }

--- a/app/src/main/java/com/quran/labs/androidquran/ui/fragment/TabletFragment.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/fragment/TabletFragment.java
@@ -27,6 +27,7 @@ import com.quran.labs.androidquran.ui.PagerActivity;
 import com.quran.labs.androidquran.ui.helpers.AyahSelectedListener;
 import com.quran.labs.androidquran.ui.helpers.AyahTracker;
 import com.quran.labs.androidquran.ui.helpers.HighlightType;
+import com.quran.labs.androidquran.ui.helpers.QuranDisplayHelper;
 import com.quran.labs.androidquran.ui.helpers.QuranPageWorker;
 import com.quran.labs.androidquran.ui.util.ImageAyahUtils;
 import com.quran.labs.androidquran.ui.util.PageController;
@@ -324,12 +325,12 @@ public class TabletFragment extends Fragment
               String suraText = QuranInfo.getSuraNameFromPage(context, mPageNumber - 1, true);
               String juzText = QuranInfo.getJuzString(context, mPageNumber - 1);
               String pageText = QuranUtils.getLocalizedNumber(context, mPageNumber - 1);
-              String rub3Text =HighlightingImageView.displayRub3(context,mPageNumber - 1);
+              String rub3Text =QuranDisplayHelper.displayRub3(context,mPageNumber - 1);
               mRightImageView.setOverlayText(suraText, juzText, pageText, rub3Text);
               suraText = QuranInfo.getSuraNameFromPage(context, mPageNumber, true);
               juzText = QuranInfo.getJuzString(context, mPageNumber);
               pageText = QuranUtils.getLocalizedNumber(context, mPageNumber);
-              rub3Text =HighlightingImageView.displayRub3(context,mPageNumber);
+              rub3Text = QuranDisplayHelper.displayRub3(context,mPageNumber);
               mLeftImageView.setOverlayText(suraText, juzText, pageText, rub3Text);
             }
           }

--- a/app/src/main/java/com/quran/labs/androidquran/ui/fragment/TabletFragment.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/fragment/TabletFragment.java
@@ -320,8 +320,8 @@ public class TabletFragment extends Fragment
           if (mRightImageView != null && mLeftImageView != null) {
             mRightImageView.setPageBounds(rect[0]);
             mLeftImageView.setPageBounds(rect[1]);
-            Context context = getContext();
             if (mOverlayText && isAdded()) {
+              Context context = getContext();
               String suraText = QuranInfo.getSuraNameFromPage(context, mPageNumber - 1, true);
               String juzText = QuranInfo.getJuzString(context, mPageNumber - 1);
               String pageText = QuranUtils.getLocalizedNumber(context, mPageNumber - 1);

--- a/app/src/main/java/com/quran/labs/androidquran/ui/helpers/QuranDisplayHelper.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/helpers/QuranDisplayHelper.java
@@ -39,6 +39,29 @@ public class QuranDisplayHelper {
     return response;
   }
 
+  // same logic used in displayMarkerPopup method
+  public static String displayRub3(Context context, int page)
+  {
+    int rub3 = QuranInfo.getRub3FromPage(page);
+    int hizb = (rub3 / 4) + 1;
+    StringBuilder sb = new StringBuilder();
+    if (rub3 == -1) {
+      return "";
+    }
+    int remainder = rub3 % 4;
+    if (remainder == 1) {
+      sb.append(context.getString(R.string.quran_rob3)).append(' ');
+    } else if (remainder == 2) {
+      sb.append(context.getString(R.string.quran_nos)).append(' ');
+    } else if (remainder == 3) {
+      sb.append(context.getString(R.string.quran_talt_arb3)).append(' ');
+    }
+    sb.append(context.getString(R.string.quran_hizb)).append(' ')
+            .append(QuranUtils.getLocalizedNumber(context, hizb));
+
+    return sb.toString();
+  }
+
   public static long displayMarkerPopup(Context context, int page,
       long lastPopupTime) {
     if (System.currentTimeMillis() - lastPopupTime < 3000) {

--- a/app/src/main/java/com/quran/labs/androidquran/ui/helpers/QuranDisplayHelper.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/helpers/QuranDisplayHelper.java
@@ -39,29 +39,6 @@ public class QuranDisplayHelper {
     return response;
   }
 
-  // same logic used in displayMarkerPopup method
-  public static String displayRub3(Context context, int page)
-  {
-    int rub3 = QuranInfo.getRub3FromPage(page);
-    int hizb = (rub3 / 4) + 1;
-    StringBuilder sb = new StringBuilder();
-    if (rub3 == -1) {
-      return "";
-    }
-    int remainder = rub3 % 4;
-    if (remainder == 1) {
-      sb.append(context.getString(R.string.quran_rob3)).append(' ');
-    } else if (remainder == 2) {
-      sb.append(context.getString(R.string.quran_nos)).append(' ');
-    } else if (remainder == 3) {
-      sb.append(context.getString(R.string.quran_talt_arb3)).append(' ');
-    }
-    sb.append(context.getString(R.string.quran_hizb)).append(' ')
-            .append(QuranUtils.getLocalizedNumber(context, hizb));
-
-    return sb.toString();
-  }
-
   public static long displayMarkerPopup(Context context, int page,
       long lastPopupTime) {
     if (System.currentTimeMillis() - lastPopupTime < 3000) {
@@ -94,6 +71,29 @@ public class QuranDisplayHelper {
     String result = sb.toString();
     Toast.makeText(context, result, Toast.LENGTH_SHORT).show();
     return System.currentTimeMillis();
+  }
+
+  // same logic used in displayMarkerPopup method
+  public static String displayRub3(Context context, int page){
+    int rub3 = QuranInfo.getRub3FromPage(page);
+    int hizb = (rub3 / 4) + 1;
+    StringBuilder sb = new StringBuilder();
+    sb.append(" , ");
+    if (rub3 == -1) {
+      return "";
+    }
+    int remainder = rub3 % 4;
+    if (remainder == 1) {
+      sb.append(context.getString(R.string.quran_rob3)).append(' ');
+    } else if (remainder == 2) {
+      sb.append(context.getString(R.string.quran_nos)).append(' ');
+    } else if (remainder == 3) {
+      sb.append(context.getString(R.string.quran_talt_arb3)).append(' ');
+    }
+    sb.append(context.getString(R.string.quran_hizb)).append(' ')
+            .append(QuranUtils.getLocalizedNumber(context, hizb));
+
+    return sb.toString();
   }
 
   public static PaintDrawable getPaintDrawable(int startX, int endX) {

--- a/app/src/main/java/com/quran/labs/androidquran/ui/helpers/QuranDisplayHelper.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/helpers/QuranDisplayHelper.java
@@ -76,12 +76,12 @@ public class QuranDisplayHelper {
   // same logic used in displayMarkerPopup method
   public static String displayRub3(Context context, int page){
     int rub3 = QuranInfo.getRub3FromPage(page);
-    int hizb = (rub3 / 4) + 1;
-    StringBuilder sb = new StringBuilder();
-    sb.append(" , ");
     if (rub3 == -1) {
       return "";
     }
+    int hizb = (rub3 / 4) + 1;
+    StringBuilder sb = new StringBuilder();
+    sb.append(" , ");
     int remainder = rub3 % 4;
     if (remainder == 1) {
       sb.append(context.getString(R.string.quran_rob3)).append(' ');

--- a/app/src/main/java/com/quran/labs/androidquran/widgets/HighlightingImageView.java
+++ b/app/src/main/java/com/quran/labs/androidquran/widgets/HighlightingImageView.java
@@ -247,10 +247,10 @@ public class HighlightingImageView extends RecyclingImageView {
         mOverlayParams.paint);
     // Merge the current rub3 text with the juz' text
     if (!mOverlayParams.rub3Text.equals("")) {
-       mOverlayParams.paint.setTextAlign(Align.RIGHT);
-       canvas.drawText(mOverlayParams.juzText + mOverlayParams.rub3Text,
-           getWidth() - mOverlayParams.offsetX, mOverlayParams.topBaseline,
-           mOverlayParams.paint);
+      mOverlayParams.paint.setTextAlign(Align.RIGHT);
+      canvas.drawText(mOverlayParams.juzText + mOverlayParams.rub3Text,
+          getWidth() - mOverlayParams.offsetX, mOverlayParams.topBaseline,
+          mOverlayParams.paint);
     } else {
       mOverlayParams.paint.setTextAlign(Align.RIGHT);
       canvas.drawText(mOverlayParams.juzText,

--- a/app/src/main/java/com/quran/labs/androidquran/widgets/HighlightingImageView.java
+++ b/app/src/main/java/com/quran/labs/androidquran/widgets/HighlightingImageView.java
@@ -19,7 +19,9 @@ import android.util.SparseArray;
 import com.quran.labs.androidquran.R;
 import com.quran.labs.androidquran.common.AyahBounds;
 import com.quran.labs.androidquran.data.Constants;
+import com.quran.labs.androidquran.data.QuranInfo;
 import com.quran.labs.androidquran.ui.helpers.HighlightType;
+import com.quran.labs.androidquran.util.QuranUtils;
 
 import java.util.HashSet;
 import java.util.List;
@@ -166,9 +168,33 @@ public class HighlightingImageView extends RecyclingImageView {
     String suraText = null;
     String juzText = null;
     String pageText = null;
+    String rub3Text = null;
   }
 
-  public void setOverlayText(String suraText, String juzText, String pageText) {
+    // same as displayMarker method
+    public static String displayRub3(Context context, int page)
+    {
+        int rub3 = QuranInfo.getRub3FromPage(page);
+        int hizb = (rub3 / 4) + 1;
+        StringBuilder sb = new StringBuilder();
+        if (rub3 == -1) {
+            return "";
+        }
+        int remainder = rub3 % 4;
+        if (remainder == 1) {
+            sb.append(context.getString(R.string.quran_rob3)).append(' ');
+        } else if (remainder == 2) {
+            sb.append(context.getString(R.string.quran_nos)).append(' ');
+        } else if (remainder == 3) {
+            sb.append(context.getString(R.string.quran_talt_arb3)).append(' ');
+        }
+        sb.append(context.getString(R.string.quran_hizb)).append(' ')
+                .append(QuranUtils.getLocalizedNumber(context, hizb));
+
+        return sb.toString();
+    }
+
+  public void setOverlayText(String suraText, String juzText, String pageText,String rub3Text) {
     // Calculate page bounding rect from ayahinfo db
     if (mPageBounds == null) {
       return;
@@ -178,6 +204,7 @@ public class HighlightingImageView extends RecyclingImageView {
     mOverlayParams.suraText = suraText;
     mOverlayParams.juzText = juzText;
     mOverlayParams.pageText = pageText;
+    mOverlayParams.rub3Text=rub3Text;
     mOverlayParams.paint = new Paint(Paint.ANTI_ALIAS_FLAG | Paint.DEV_KERN_TEXT_FLAG);
     mOverlayParams.paint.setTextSize(fontSize);
 
@@ -245,6 +272,13 @@ public class HighlightingImageView extends RecyclingImageView {
     canvas.drawText(mOverlayParams.pageText,
         getWidth() / 2.0f, mOverlayParams.bottomBaseline,
         mOverlayParams.paint);
+     // Write the current rub3 text at the top middle of the page
+     if (!mOverlayParams.rub3Text.equals("")) {
+          mOverlayParams.paint.setTextAlign(Align.CENTER);
+          canvas.drawText(mOverlayParams.rub3Text,
+                  getWidth() / 2.0f, mOverlayParams.topBaseline,
+                  mOverlayParams.paint);
+      }
     mDidDraw = true;
   }
 

--- a/app/src/main/java/com/quran/labs/androidquran/widgets/HighlightingImageView.java
+++ b/app/src/main/java/com/quran/labs/androidquran/widgets/HighlightingImageView.java
@@ -171,29 +171,6 @@ public class HighlightingImageView extends RecyclingImageView {
     String rub3Text = null;
   }
 
-    // same logic used in displayMarkerPopup method
-    public static String displayRub3(Context context, int page)
-    {
-        int rub3 = QuranInfo.getRub3FromPage(page);
-        int hizb = (rub3 / 4) + 1;
-        StringBuilder sb = new StringBuilder();
-        if (rub3 == -1) {
-            return "";
-        }
-        int remainder = rub3 % 4;
-        if (remainder == 1) {
-            sb.append(context.getString(R.string.quran_rob3)).append(' ');
-        } else if (remainder == 2) {
-            sb.append(context.getString(R.string.quran_nos)).append(' ');
-        } else if (remainder == 3) {
-            sb.append(context.getString(R.string.quran_talt_arb3)).append(' ');
-        }
-        sb.append(context.getString(R.string.quran_hizb)).append(' ')
-                .append(QuranUtils.getLocalizedNumber(context, hizb));
-
-        return sb.toString();
-    }
-
   public void setOverlayText(String suraText, String juzText, String pageText,String rub3Text) {
     // Calculate page bounding rect from ayahinfo db
     if (mPageBounds == null) {

--- a/app/src/main/java/com/quran/labs/androidquran/widgets/HighlightingImageView.java
+++ b/app/src/main/java/com/quran/labs/androidquran/widgets/HighlightingImageView.java
@@ -171,7 +171,7 @@ public class HighlightingImageView extends RecyclingImageView {
     String rub3Text = null;
   }
 
-    // same as displayMarker method
+    // same logic used in displayMarkerPopup method
     public static String displayRub3(Context context, int page)
     {
         int rub3 = QuranInfo.getRub3FromPage(page);

--- a/app/src/main/java/com/quran/labs/androidquran/widgets/HighlightingImageView.java
+++ b/app/src/main/java/com/quran/labs/androidquran/widgets/HighlightingImageView.java
@@ -245,14 +245,13 @@ public class HighlightingImageView extends RecyclingImageView {
     canvas.drawText(mOverlayParams.pageText,
         getWidth() / 2.0f, mOverlayParams.bottomBaseline,
         mOverlayParams.paint);
-    // Merge the current rub3 text with the juz' text
+    mOverlayParams.paint.setTextAlign(Align.RIGHT);
+    // Merge the current rub3 text with the juz' text upon reaching a rub3
     if (!mOverlayParams.rub3Text.equals("")) {
-      mOverlayParams.paint.setTextAlign(Align.RIGHT);
       canvas.drawText(mOverlayParams.juzText + mOverlayParams.rub3Text,
           getWidth() - mOverlayParams.offsetX, mOverlayParams.topBaseline,
           mOverlayParams.paint);
     } else {
-      mOverlayParams.paint.setTextAlign(Align.RIGHT);
       canvas.drawText(mOverlayParams.juzText,
           getWidth() - mOverlayParams.offsetX, mOverlayParams.topBaseline,
           mOverlayParams.paint);

--- a/app/src/main/java/com/quran/labs/androidquran/widgets/HighlightingImageView.java
+++ b/app/src/main/java/com/quran/labs/androidquran/widgets/HighlightingImageView.java
@@ -246,16 +246,11 @@ public class HighlightingImageView extends RecyclingImageView {
         getWidth() / 2.0f, mOverlayParams.bottomBaseline,
         mOverlayParams.paint);
     mOverlayParams.paint.setTextAlign(Align.RIGHT);
-    // Merge the current rub3 text with the juz' text upon reaching a rub3
-    if (!mOverlayParams.rub3Text.equals("")) {
-      canvas.drawText(mOverlayParams.juzText + mOverlayParams.rub3Text,
-          getWidth() - mOverlayParams.offsetX, mOverlayParams.topBaseline,
-          mOverlayParams.paint);
-    } else {
-      canvas.drawText(mOverlayParams.juzText,
-          getWidth() - mOverlayParams.offsetX, mOverlayParams.topBaseline,
-          mOverlayParams.paint);
-    }
+    // Merge the current rub3 text with the juz' text
+    mOverlayParams.paint.setTextAlign(Align.RIGHT);
+    canvas.drawText(mOverlayParams.juzText + mOverlayParams.rub3Text,
+        getWidth() - mOverlayParams.offsetX, mOverlayParams.topBaseline,
+        mOverlayParams.paint);
     mDidDraw = true;
   }
 

--- a/app/src/main/java/com/quran/labs/androidquran/widgets/HighlightingImageView.java
+++ b/app/src/main/java/com/quran/labs/androidquran/widgets/HighlightingImageView.java
@@ -171,7 +171,7 @@ public class HighlightingImageView extends RecyclingImageView {
     String rub3Text = null;
   }
 
-  public void setOverlayText(String suraText, String juzText, String pageText,String rub3Text) {
+  public void setOverlayText(String suraText, String juzText, String pageText, String rub3Text) {
     // Calculate page bounding rect from ayahinfo db
     if (mPageBounds == null) {
       return;
@@ -241,21 +241,22 @@ public class HighlightingImageView extends RecyclingImageView {
     canvas.drawText(mOverlayParams.suraText,
         mOverlayParams.offsetX, mOverlayParams.topBaseline,
         mOverlayParams.paint);
-    mOverlayParams.paint.setTextAlign(Align.RIGHT);
-    canvas.drawText(mOverlayParams.juzText,
-        getWidth() - mOverlayParams.offsetX, mOverlayParams.topBaseline,
-        mOverlayParams.paint);
     mOverlayParams.paint.setTextAlign(Align.CENTER);
     canvas.drawText(mOverlayParams.pageText,
         getWidth() / 2.0f, mOverlayParams.bottomBaseline,
         mOverlayParams.paint);
-     // Write the current rub3 text at the top middle of the page
-     if (!mOverlayParams.rub3Text.equals("")) {
-          mOverlayParams.paint.setTextAlign(Align.CENTER);
-          canvas.drawText(mOverlayParams.rub3Text,
-                  getWidth() / 2.0f, mOverlayParams.topBaseline,
-                  mOverlayParams.paint);
-      }
+    // Merge the current rub3 text with the juz' text
+    if (!mOverlayParams.rub3Text.equals("")) {
+       mOverlayParams.paint.setTextAlign(Align.RIGHT);
+       canvas.drawText(mOverlayParams.juzText + mOverlayParams.rub3Text,
+           getWidth() - mOverlayParams.offsetX, mOverlayParams.topBaseline,
+           mOverlayParams.paint);
+    } else {
+      mOverlayParams.paint.setTextAlign(Align.RIGHT);
+      canvas.drawText(mOverlayParams.juzText,
+          getWidth() - mOverlayParams.offsetX, mOverlayParams.topBaseline,
+          mOverlayParams.paint);
+    }
     mDidDraw = true;
   }
 

--- a/app/src/main/java/com/quran/labs/androidquran/widgets/HighlightingImageView.java
+++ b/app/src/main/java/com/quran/labs/androidquran/widgets/HighlightingImageView.java
@@ -245,7 +245,6 @@ public class HighlightingImageView extends RecyclingImageView {
     canvas.drawText(mOverlayParams.pageText,
         getWidth() / 2.0f, mOverlayParams.bottomBaseline,
         mOverlayParams.paint);
-    mOverlayParams.paint.setTextAlign(Align.RIGHT);
     // Merge the current rub3 text with the juz' text
     mOverlayParams.paint.setTextAlign(Align.RIGHT);
     canvas.drawText(mOverlayParams.juzText + mOverlayParams.rub3Text,

--- a/app/src/main/java/com/quran/labs/androidquran/widgets/HighlightingImageView.java
+++ b/app/src/main/java/com/quran/labs/androidquran/widgets/HighlightingImageView.java
@@ -181,7 +181,7 @@ public class HighlightingImageView extends RecyclingImageView {
     mOverlayParams.suraText = suraText;
     mOverlayParams.juzText = juzText;
     mOverlayParams.pageText = pageText;
-    mOverlayParams.rub3Text=rub3Text;
+    mOverlayParams.rub3Text = rub3Text;
     mOverlayParams.paint = new Paint(Paint.ANTI_ALIAS_FLAG | Paint.DEV_KERN_TEXT_FLAG);
     mOverlayParams.paint.setTextSize(fontSize);
 


### PR DESCRIPTION
Asalamu 3alaikum,

**The current situation:**
When the user reaches a new rub3, a toast will pop up showing this rub3 number. If the user took some time reading the current page and wanted to know in which rub3 he was, he has to swipe left and then swipe right to show the toast again and I think that this is not user-friendly.

**The suggested change:**
There is a space in the top middle of the page, so why we don't show the current rub3 in this space upon reaching it.

Wa jazakum allaho khairan.
