### PR TITLE
Use recent pages size to correctly get quantity string

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/presenter/bookmark/BookmarkPresenter.java
+++ b/app/src/main/java/com/quran/labs/androidquran/presenter/bookmark/BookmarkPresenter.java
@@ -310,11 +310,11 @@ public class BookmarkPresenter implements Presenter<BookmarksFragment> {
     }
 
     List<RecentPage> recentPages = data.getRecentPages();
-    boolean showLastPage = recentPages.size() > 0;
+    int size = recentPages.size();
 
-    if (showLastPage) {
-      rows.add(0, QuranRowFactory.fromRecentPageHeader(appContext, rows.size()));
-      for (int i = 0, length = recentPages.size(); i < length; i++) {
+    if (size > 0) {
+      rows.add(0, QuranRowFactory.fromRecentPageHeader(appContext, size));
+      for (int i = 0; i < size; i++) {
         rows.add(i + 1, QuranRowFactory.fromCurrentPage(appContext, recentPages.get(i).page));
       }
     }


### PR DESCRIPTION
This also removes two unnecessary local variables, `boolean showLastPage` and `int length`.