### PR TITLE
Use same text as in the menu to jump last page

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -340,7 +340,7 @@
   <string name="undo">Undo</string>
 
   <plurals name="recent_pages">
-    <item quantity="one">Current page</item>
+    <item quantity="one">@string/menu_jump_last_page</item>
     <item quantity="other">Recent pages</item>
   </plurals>
 


### PR DESCRIPTION
This is to have a consistent UI text accross the app. When there is only one recently read page, the title will be the same as the jump menu title in the action bar.

This is a conceptual change. Please feel free to argue against :)