### PR TITLE
Add translation for "Recent pages"

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/ui/helpers/QuranRowFactory.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/helpers/QuranRowFactory.java
@@ -12,7 +12,7 @@ public class QuranRowFactory {
 
   public static QuranRow fromRecentPageHeader(Context context, int count) {
     return new QuranRow.Builder()
-        .withText(context.getResources().getQuantityString(R.plurals.recent_pages, count))
+        .withText(context.getResources().getQuantityString(R.plurals.plural_recent_pages, count))
         .withType(QuranRow.HEADER).build();
   }
 

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -281,13 +281,7 @@
     <item quantity="many">آخر المتصفحات</item>
   </plurals>
 
-  <plurals name="bookmark_tag_deleted">
-    <item quantity="zero">لم يتم حذف عناصر</item>
-    <item quantity="one">تم حذف عنصر واحد</item>
-    <item quantity="two">تم حذف عنصران</item>
-    <item quantity="few">تم حذف %d عناصر</item>
-    <item quantity="many">تم حذف %d عنصر</item>
-  </plurals>
+  <string name="recent_pages">تم حذف عنصران</string>
   <string name="undo">تراجع</string>
 
 </resources>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -273,15 +273,15 @@
   <string name="export_data_error">خطأ في استيراد البيانات.</string>
   <string name="warning">تحذير</string>
 
-  <plurals name="recent_pages">
-    <item quantity="zero">آخر المتصفحات</item>
-    <item quantity="one">الصفحة الحالية</item>
-    <item quantity="two">آخر المتصفحات</item>
-    <item quantity="few">آخر المتصفحات</item>
-    <item quantity="many">آخر المتصفحات</item>
-  </plurals>
-
   <string name="recent_pages">تم حذف عنصران</string>
+
+  <plurals name="bookmark_tag_deleted">
+    <item quantity="zero">لم يتم حذف عناصر</item>
+    <item quantity="one">تم حذف عنصر واحد</item>
+    <item quantity="two">تم حذف عنصران</item>
+    <item quantity="few">تم حذف %d عناصر</item>
+    <item quantity="many">تم حذف %d عنصر</item>
+  </plurals>
   <string name="undo">تراجع</string>
 
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -339,6 +339,8 @@
   </plurals>
   <string name="undo">@string/cancel</string>
 
+  <string name="recent_pages">Недавние страницы</string>
+
   <!-- tag dialog -->
   <string name="tag_dlg_title">Метка</string>
   <string name="tag_name">Название</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -194,4 +194,5 @@
     <item quantity="one">1 âyet</item>
     <item quantity="other">%s âyet</item>
   </plurals>
+  <string name="recent_pages">Son sayfalar</string>
 </resources>

--- a/app/src/main/res/values-uz/strings.xml
+++ b/app/src/main/res/values-uz/strings.xml
@@ -16,7 +16,7 @@
   <string name="menu_about">Ilova haqida</string>
   <string name="menu_other_apps">Boshqa ilovalar</string>
   <string name="menu_settings">Sozlamalar</string>
-  <string name="menu_jump_last_page">Oxirgi sahifa</string>
+  <string name="menu_jump_last_page">Soʻnggi oʻqilgan sahifa</string>
   <string name="menu_bookmarks">Xatchoʻplar</string>
   <string name="menu_bookmarks_page">Sahifa xatchoʻplari</string>
   <string name="menu_bookmarks_ayah">Oyat xatchoʻplari</string>
@@ -311,6 +311,8 @@
     <item quantity="other">%d ta element oʻchirildi</item>
   </plurals>
   <string name="undo">@string/cancel</string>
+
+  <string name="recent_pages">Soʻnggi oʻqilgan sahifalar</string>
 
   <!-- tag dialog -->
   <string name="tag_dlg_title">Teg</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -339,9 +339,10 @@
   </plurals>
   <string name="undo">Undo</string>
 
-  <plurals name="recent_pages">
+  <string name="recent_pages">Recent pages</string>
+  <plurals name="recent_pages" translatable="false">
     <item quantity="one">@string/menu_jump_last_page</item>
-    <item quantity="other">Recent pages</item>
+    <item quantity="other">@string/recent_pages</item>
   </plurals>
 
   <!-- tag dialog -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -340,7 +340,7 @@
   <string name="undo">Undo</string>
 
   <string name="recent_pages">Recent pages</string>
-  <plurals name="recent_pages" translatable="false">
+  <plurals name="plural_recent_pages" translatable="false">
     <item quantity="one">@string/menu_jump_last_page</item>
     <item quantity="other">@string/recent_pages</item>
   </plurals>


### PR DESCRIPTION
Normally, `plurals` require special approach for each locale. But here, we do not care about actual number of recent pages except for one case: 1 recent page (last page) or more. So, instead of translating `plurals`, it is more convenient to just use the `string`.