### PR TITLE
Show translation info even if translator has no localized name

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/ui/TranslationManagerActivity.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/TranslationManagerActivity.java
@@ -403,10 +403,9 @@ public class TranslationManagerActivity extends QuranActionBarActivity
         TranslationItem item = (TranslationItem) rowItem;
         holder.translationTitle.setText(item.name());
         if (TextUtils.isEmpty(item.translation.translatorNameLocalized)) {
-          holder.translationInfo.setVisibility(View.GONE);
+          holder.translationInfo.setText(item.translation.translator);
         } else {
           holder.translationInfo.setText(item.translation.translatorNameLocalized);
-          holder.translationInfo.setVisibility(View.VISIBLE);
         }
 
         if (item.exists()) {
@@ -415,7 +414,6 @@ public class TranslationManagerActivity extends QuranActionBarActivity
             holder.leftImage.setVisibility(View.VISIBLE);
 
             holder.translationInfo.setText(R.string.update_available);
-            holder.translationInfo.setVisibility(View.VISIBLE);
           } else {
             holder.leftImage.setVisibility(View.GONE);
           }


### PR DESCRIPTION
I don't know why translation info was not shown if translator did not have a localized name :)