### PR TITLE
Fix crash when a translation is added/removed

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/presenter/translation/TranslationManagerPresenter.java
+++ b/app/src/main/java/com/quran/labs/androidquran/presenter/translation/TranslationManagerPresenter.java
@@ -114,10 +114,9 @@ public class TranslationManagerPresenter implements Presenter<TranslationManager
   }
 
   public void updateItem(final TranslationItem item) {
-    Observable.fromCallable(() -> {
-      translationsDBAdapter.writeTranslationUpdates(Collections.singletonList(item));
-      return null;
-    }).subscribeOn(Schedulers.io())
+    Observable.fromCallable(() ->
+        translationsDBAdapter.writeTranslationUpdates(Collections.singletonList(item))
+    ).subscribeOn(Schedulers.io())
         .subscribe();
   }
 


### PR DESCRIPTION
Stack trace:

    com.quran.labs.androidquran E/AndroidRuntime: FATAL EXCEPTION: RxCachedThreadScheduler-2
    Process: com.quran.labs.androidquran, PID: 13793
    java.lang.NullPointerException: Callable returned null
        at io.reactivex.internal.functions.ObjectHelper.requireNonNull(ObjectHelper.java:39)
        at io.reactivex.internal.operators.observable.ObservableFromCallable.subscribeActual(ObservableFromCallable.java:42)
        at io.reactivex.Observable.subscribe(Observable.java:10514)
        at io.reactivex.internal.operators.observable.ObservableSubscribeOn$1.run(ObservableSubscribeOn.java:39)
        at io.reactivex.Scheduler$1.run(Scheduler.java:134)
        at io.reactivex.internal.schedulers.ScheduledRunnable.run(ScheduledRunnable.java:59)
        at io.reactivex.internal.schedulers.ScheduledRunnable.call(ScheduledRunnable.java:51)
        at java.util.concurrent.FutureTask.run(FutureTask.java:237)
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:272)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1133)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:607)
        at java.lang.Thread.run(Thread.java:761)