### PR TITLE
Fix f/c in non-Madani build types

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/ui/fragment/QuranSettingsFragment.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/fragment/QuranSettingsFragment.java
@@ -7,7 +7,9 @@ import android.os.Bundle;
 import android.preference.Preference;
 import android.preference.PreferenceCategory;
 import android.preference.PreferenceFragment;
+import android.preference.PreferenceScreen;
 
+import com.quran.labs.androidquran.QuranAdvancedPreferenceActivity;
 import com.quran.labs.androidquran.QuranApplication;
 import com.quran.labs.androidquran.QuranPreferenceActivity;
 import com.quran.labs.androidquran.R;
@@ -88,5 +90,17 @@ public class QuranSettingsFragment extends PreferenceFragment implements
         ((QuranPreferenceActivity) context).restartActivity();
       }
     }
+  }
+
+  @Override
+  public boolean onPreferenceTreeClick(PreferenceScreen preferenceScreen, Preference preference) {
+    final String key = preference.getKey();
+    if ("key_prefs_advanced".equals(key)) {
+      Intent intent = new Intent(getActivity(), QuranAdvancedPreferenceActivity.class);
+      startActivity(intent);
+      return true;
+    }
+
+    return super.onPreferenceTreeClick(preferenceScreen, preference);
   }
 }

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -199,6 +199,7 @@
   <string name="prefs_tablet_mode_enabled">В альбомном режиме две страницы будут отображаться рядом друг с другом.</string>
   <string name="prefs_tablet_mode_disabled">В альбомном режиме будет отображена только одна страницы.</string>
   <string name="prefs_category_advanced">Расширенные настройки</string>
+  <string name="prefs_category_advanced_summary">Импорт/экспорт закладок, выбрать место хранения файлов и т.д.</string>
   <string name="prefs_export_title">Экспорт</string>
   <string name="prefs_export_summary">Экспорт копию закладок и тегов</string>
 

--- a/app/src/main/res/values-uz/strings.xml
+++ b/app/src/main/res/values-uz/strings.xml
@@ -175,6 +175,7 @@
   <string name="prefs_tablet_mode_enabled">Yotiq holatda ikki bet yonma-yon koʻrinadi</string>
   <string name="prefs_tablet_mode_disabled">Yotiq holatda ham faqat bitta bet koʻrinadi</string>
   <string name="prefs_category_advanced">Ilgʻor</string>
+  <string name="prefs_category_advanced_summary">Xatchoʻplarni import/eksport qilish, maʼlumotlar jildini tanlash va h.k.</string>
   <string name="prefs_export_title">Eksport</string>
   <string name="prefs_export_summary">Xatchoʻp va teglarni eksport qilish</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -201,6 +201,7 @@
   <string name="prefs_tablet_mode_enabled">In landscape, two pages will appear side by side.</string>
   <string name="prefs_tablet_mode_disabled">In landscape, only one page will appear.</string>
   <string name="prefs_category_advanced">Advanced Options</string>
+  <string name="prefs_category_advanced_summary">Import/export bookmarks, set Quran data directory, etc.</string>
   <string name="prefs_import_title">Import</string>
   <string name="prefs_import_summary">Import bookmarks and tags</string>
   <string name="prefs_export_title">Export</string>

--- a/app/src/main/res/xml/quran_preferences.xml
+++ b/app/src/main/res/xml/quran_preferences.xml
@@ -146,13 +146,10 @@
   <PreferenceCategory
       android:key="@string/prefs_path"
       android:title="@string/prefs_category_advanced">
-<Preference
-      android:key="@string/prefs_path"
-      android:title="@string/prefs_category_advanced">
-    <intent
-        android:targetPackage="com.quran.labs.androidquran"
-        android:targetClass="com.quran.labs.androidquran.QuranAdvancedPreferenceActivity" />
-  </Preference>
-</PreferenceCategory>
-</PreferenceScreen>
 
+    <com.quran.labs.androidquran.ui.preference.QuranPreference
+        android:key="key_prefs_advanced"
+        android:summary="@string/prefs_category_advanced_summary"
+        android:title="@string/prefs_category_advanced" />
+  </PreferenceCategory>
+</PreferenceScreen>


### PR DESCRIPTION
That's caused by 2987bbf0f806eca440081f63a3240055f8290945 because advanced settings intent was hard coded in xml.
This also adds a summary to advanced settings preference.