### PR TITLE
Fix search menu in bookmarks tab

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/ui/fragment/BookmarksFragment.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/fragment/BookmarksFragment.java
@@ -91,12 +91,13 @@ public class BookmarksFragment extends Fragment implements QuranListAdapter.Qura
       sortItem.setVisible(true);
       sortItem.setEnabled(true);
 
-      boolean isSortByDate =
-          BookmarksDBAdapter.SORT_DATE_ADDED == bookmarkPresenter.getSortOrder();
-      MenuItem sortByDate = menu.findItem(R.id.sort_date);
-      sortByDate.setVisible(!isSortByDate);
-      MenuItem sortByLocation = menu.findItem(R.id.sort_location);
-      sortByLocation.setVisible(isSortByDate);
+      if (BookmarksDBAdapter.SORT_DATE_ADDED == bookmarkPresenter.getSortOrder()) {
+        MenuItem sortByDate = menu.findItem(R.id.sort_date);
+        sortByDate.setChecked(true);
+      } else {
+        MenuItem sortByLocation = menu.findItem(R.id.sort_location);
+        sortByLocation.setChecked(true);
+      }
 
       MenuItem groupByTags = menu.findItem(R.id.group_by_tags);
       groupByTags.setChecked(bookmarkPresenter.isGroupedByTags());
@@ -109,17 +110,20 @@ public class BookmarksFragment extends Fragment implements QuranListAdapter.Qura
     switch (itemId) {
       case R.id.sort_date:
         bookmarkPresenter.setSortOrder(BookmarksDBAdapter.SORT_DATE_ADDED);
-        break;
+        item.setChecked(true);
+        return true;
       case R.id.sort_location: {
         bookmarkPresenter.setSortOrder(BookmarksDBAdapter.SORT_LOCATION);
-        break;
+        item.setChecked(true);
+        return true;
       }
       case R.id.group_by_tags: {
         bookmarkPresenter.toggleGroupByTags();
-        break;
+        item.setChecked(bookmarkPresenter.isGroupedByTags());
+        return true;
       }
     }
-    getActivity().invalidateOptionsMenu();
+
     return super.onOptionsItemSelected(item);
   }
 

--- a/app/src/main/res/menu/home_menu.xml
+++ b/app/src/main/res/menu/home_menu.xml
@@ -1,48 +1,64 @@
 <?xml version="1.0" encoding="utf-8"?>
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
-      xmlns:app="http://schemas.android.com/apk/res-auto">
-    <item android:id="@+id/sort"
-          android:icon="@drawable/ic_sort"
-          android:title="@string/menu_sort"
-          android:visible="false"
-          android:enabled="false"
-          app:showAsAction="ifRoom" >
-          <menu>
-              <item android:id="@+id/sort_date"
-                  android:title="@string/menu_sort_date"
-                  app:showAsAction="withText" />
-              <item android:id="@+id/sort_location"
-                  android:title="@string/menu_sort_location"
-                  app:showAsAction="withText" />
-              <item android:id="@+id/group_by_tags"
-                  android:checkable="true"
-                  android:title="@string/menu_sort_group_by_tags"
-                  app:showAsAction="withText" />
-          </menu>
-    </item>
-    <item android:id="@+id/last_page"
-          android:icon="@drawable/ic_goto_quran"
-          android:title="@string/menu_jump_last_page"
-          app:showAsAction="ifRoom" />
-    <item android:id="@+id/search"
-          android:icon="@drawable/ic_ab_search"
-          android:title="@string/menu_search"
-          app:actionViewClass="android.support.v7.widget.SearchView"
-          app:showAsAction="ifRoom|collapseActionView" />
-    <item android:id="@+id/jump"
-          android:title="@string/menu_jump"
-          app:showAsAction="never" />
-    <item android:id="@+id/settings"
-          android:icon="@drawable/ic_action_settings"
-          android:title="@string/menu_settings"
-          app:showAsAction="never" />
-    <item android:id="@+id/help"
-          android:title="@string/menu_help"
-          app:showAsAction="never"/>
-    <item android:id="@+id/about"
-          android:title="@string/menu_about"
-          app:showAsAction="never"/>
-    <item android:id="@+id/other_apps"
-          android:title="@string/menu_other_apps"
-          app:showAsAction="never"/>
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+  <item
+      android:id="@+id/sort"
+      android:enabled="false"
+      android:icon="@drawable/ic_sort"
+      android:title="@string/menu_sort"
+      android:visible="false"
+      tools:visible="true"
+      app:showAsAction="ifRoom">
+    <menu>
+      <group
+          android:checkableBehavior="single">
+        <item
+            android:id="@+id/sort_date"
+            android:title="@string/menu_sort_date"
+            app:showAsAction="withText" />
+        <item
+            android:id="@+id/sort_location"
+            android:title="@string/menu_sort_location"
+            app:showAsAction="withText" />
+      </group>
+      <item
+          android:id="@+id/group_by_tags"
+          android:checkable="true"
+          android:title="@string/menu_sort_group_by_tags"
+          app:showAsAction="withText" />
+    </menu>
+  </item>
+  <item
+      android:id="@+id/last_page"
+      android:icon="@drawable/ic_goto_quran"
+      android:title="@string/menu_jump_last_page"
+      app:showAsAction="ifRoom" />
+  <item
+      android:id="@+id/search"
+      android:icon="@drawable/ic_ab_search"
+      android:title="@string/menu_search"
+      app:actionViewClass="android.support.v7.widget.SearchView"
+      app:showAsAction="ifRoom|collapseActionView" />
+  <item
+      android:id="@+id/jump"
+      android:title="@string/menu_jump"
+      app:showAsAction="never" />
+  <item
+      android:id="@+id/settings"
+      android:icon="@drawable/ic_action_settings"
+      android:title="@string/menu_settings"
+      app:showAsAction="never" />
+  <item
+      android:id="@+id/help"
+      android:title="@string/menu_help"
+      app:showAsAction="never" />
+  <item
+      android:id="@+id/about"
+      android:title="@string/menu_about"
+      app:showAsAction="never" />
+  <item
+      android:id="@+id/other_apps"
+      android:title="@string/menu_other_apps"
+      app:showAsAction="never" />
 </menu>


### PR DESCRIPTION
Apparently, I had broken it at e719dc42f37c0f98e35ff0f1fc4601a76fc9b926 :( 
This is a semi-revert with indentation fix in home_menu.xml.

There is a workaround to put a divider between menu items as explained [here](http://stackoverflow.com/questions/33277124/how-to-add-dividers-between-specific-menu-items), but I am not sure if that's worth the change.