### PR TITLE
Remove unnecessary arg in AudioUtils.getQariUrl()

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/ui/AudioManagerActivity.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/AudioManagerActivity.java
@@ -145,7 +145,7 @@ public class AudioManagerActivity extends QuranActionBarActivity
 
     String sheikhName = qariItem.getName();
     Intent intent = ServiceIntentHelper.getDownloadIntent(this,
-        AudioUtils.getQariUrl(qariItem, true),
+        AudioUtils.getQariUrl(qariItem),
         baseUri, sheikhName, AUDIO_DOWNLOAD_KEY, QuranDownloadService.DOWNLOAD_TYPE_AUDIO);
     intent.putExtra(QuranDownloadService.EXTRA_START_VERSE, new QuranAyah(1, 1));
     intent.putExtra(QuranDownloadService.EXTRA_END_VERSE, new QuranAyah(114, 6));

--- a/app/src/main/java/com/quran/labs/androidquran/ui/PagerActivity.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/PagerActivity.java
@@ -1487,7 +1487,7 @@ public class PagerActivity extends QuranActionBarActivity implements
   private void playStreaming(QuranAyah ayah, QuranAyah end,
                             int page, QariItem item, int verseRepeat,
                             int rangeRepeat, boolean enforceRange) {
-    String qariUrl = AudioUtils.getQariUrl(item, true);
+    String qariUrl = AudioUtils.getQariUrl(item);
     String dbFile = AudioUtils.getQariDatabasePathIfGapless(this, item);
     if (!TextUtils.isEmpty(dbFile)) {
       // gapless audio is "download only"
@@ -1617,7 +1617,7 @@ public class PagerActivity extends QuranActionBarActivity implements
         }
 
         QuranAyah firstAyah = new QuranAyah(1, 1);
-        String qariUrl = AudioUtils.getQariUrl(request.getQariItem(), true);
+        String qariUrl = AudioUtils.getQariUrl(request.getQariItem());
         audioStatusBar.switchMode(AudioStatusBar.DOWNLOADING_MODE);
 
         if (isActionBarHidden) {
@@ -1646,7 +1646,7 @@ public class PagerActivity extends QuranActionBarActivity implements
 
       String notificationTitle = QuranInfo.getNotificationTitle(this,
           request.getMinAyah(), request.getMaxAyah(), request.isGapless());
-      String qariUrl = AudioUtils.getQariUrl(request.getQariItem(), true);
+      String qariUrl = AudioUtils.getQariUrl(request.getQariItem());
       Timber.d("need to start download: %s", qariUrl);
 
       // start service

--- a/app/src/main/java/com/quran/labs/androidquran/util/AudioUtils.java
+++ b/app/src/main/java/com/quran/labs/androidquran/util/AudioUtils.java
@@ -79,14 +79,12 @@ public class AudioUtils {
     return items;
   }
 
-  public static String getQariUrl(@NonNull QariItem item, boolean addPlaceHolders) {
+  public static String getQariUrl(@NonNull QariItem item) {
     String url = item.getUrl();
-    if (addPlaceHolders) {
-      if (item.isGapless()) {
-        url += "%03d" + AudioUtils.AUDIO_EXTENSION;
-      } else {
-        url += "%03d%03d" + AudioUtils.AUDIO_EXTENSION;
-      }
+    if (item.isGapless()) {
+      url += "%03d" + AudioUtils.AUDIO_EXTENSION;
+    } else {
+      url += "%03d%03d" + AudioUtils.AUDIO_EXTENSION;
     }
     return url;
   }


### PR DESCRIPTION
Apparently, getQariUrl() is called with `true` as the second argument everywhere.