### PR TITLE
709 Refactored TranslationManager/Adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,4 @@ Choose "Import Project," and choose the `build.gradle` file from the top level d
 * [moshi](https://github.com/square/moshi)
 * [dagger2](http://google.github.io/dagger/)
 * [retrolambda](https://github.com/orfjackal/retrolambda) and [retrolambda gradle plugin](https://github.com/evant/gradle-retrolambda).
+* [butterknife](http://jakewharton.github.io/butterknife/)

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -117,6 +117,8 @@ dependencies {
   compile 'com.squareup.okhttp3:okhttp:3.5.0'
   compile 'com.squareup.moshi:moshi:1.3.1'
   compile 'com.jakewharton.timber:timber:4.4.0'
+  compile 'com.jakewharton:butterknife:8.4.0'
+  annotationProcessor 'com.jakewharton:butterknife-compiler:8.4.0'
   debugCompile 'com.facebook.stetho:stetho:1.4.1'
   debugCompile 'com.facebook.stetho:stetho-okhttp3:1.4.1'
   debugCompile 'com.squareup.leakcanary:leakcanary-android:1.5'

--- a/app/src/main/java/com/quran/labs/androidquran/ui/TranslationManagerActivity.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/TranslationManagerActivity.java
@@ -56,10 +56,7 @@ public class TranslationManagerActivity extends QuranActionBarActivity
   TranslationManagerPresenter presenter;
 
   @BindView(R.id.translation_recycler)
-  RecyclerView mTranslationRecycler;
-
-  @BindView(R.id.translation_layout)
-  View mTranslationLayout;
+  RecyclerView translationRecycler;
 
   @Override
   public void onCreate(Bundle savedInstanceState) {
@@ -69,10 +66,10 @@ public class TranslationManagerActivity extends QuranActionBarActivity
     ButterKnife.bind(this);
 
     RecyclerView.LayoutManager mLayoutManager = new LinearLayoutManager(this);
-    mTranslationRecycler.setLayoutManager(mLayoutManager);
+    translationRecycler.setLayoutManager(mLayoutManager);
 
     adapter = new TranslationsAdapter(this);
-    mTranslationRecycler.setAdapter(adapter);
+    translationRecycler.setAdapter(adapter);
 
     databaseDirectory = QuranFileUtils.getQuranDatabaseDirectory(this);
 
@@ -169,7 +166,7 @@ public class TranslationManagerActivity extends QuranActionBarActivity
 
   public void onErrorDownloadTranslations() {
     Snackbar
-        .make(mTranslationLayout, R.string.error_getting_translation_list, Snackbar.LENGTH_SHORT)
+        .make(translationRecycler, R.string.error_getting_translation_list, Snackbar.LENGTH_SHORT)
         .show();
   }
 

--- a/app/src/main/java/com/quran/labs/androidquran/ui/TranslationManagerActivity.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/TranslationManagerActivity.java
@@ -11,7 +11,6 @@ import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.util.SparseIntArray;
 import android.view.MenuItem;
-import android.view.View;
 
 import com.quran.labs.androidquran.QuranApplication;
 import com.quran.labs.androidquran.R;
@@ -35,6 +34,7 @@ import javax.inject.Inject;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
+import io.reactivex.disposables.Disposable;
 import timber.log.Timber;
 
 public class TranslationManagerActivity extends QuranActionBarActivity
@@ -51,6 +51,9 @@ public class TranslationManagerActivity extends QuranActionBarActivity
   private String databaseDirectory;
   private QuranSettings quranSettings;
   private DefaultDownloadReceiver mDownloadReceiver = null;
+
+  private Disposable onClickDownloadDisposable;
+  private Disposable onClickRemoveDisposable;
 
   @Inject
   TranslationManagerPresenter presenter;
@@ -82,8 +85,8 @@ public class TranslationManagerActivity extends QuranActionBarActivity
     quranSettings = QuranSettings.getInstance(this);
     presenter.bind(this);
     presenter.getTranslationsList(false);
-    adapter.getOnClickDownloadSubject().subscribe(this::downloadItem);
-    adapter.getOnClickRemoveSubject().subscribe(this::removeItem);
+    onClickDownloadDisposable = adapter.getOnClickDownloadSubject().subscribe(this::downloadItem);
+    onClickRemoveDisposable = adapter.getOnClickRemoveSubject().subscribe(this::removeItem);
   }
 
   @Override
@@ -100,6 +103,8 @@ public class TranslationManagerActivity extends QuranActionBarActivity
   @Override
   protected void onDestroy() {
     presenter.unbind(this);
+    onClickDownloadDisposable.dispose();
+    onClickRemoveDisposable.dispose();
     super.onDestroy();
   }
 

--- a/app/src/main/java/com/quran/labs/androidquran/ui/TranslationManagerActivity.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/TranslationManagerActivity.java
@@ -23,7 +23,7 @@ import com.quran.labs.androidquran.service.QuranDownloadService;
 import com.quran.labs.androidquran.service.util.DefaultDownloadReceiver;
 import com.quran.labs.androidquran.service.util.QuranDownloadNotifier;
 import com.quran.labs.androidquran.service.util.ServiceIntentHelper;
-import com.quran.labs.androidquran.ui.adapter.TranslationAdapter;
+import com.quran.labs.androidquran.ui.adapter.TranslationsAdapter;
 import com.quran.labs.androidquran.util.QuranFileUtils;
 import com.quran.labs.androidquran.util.QuranSettings;
 
@@ -46,7 +46,7 @@ public class TranslationManagerActivity extends QuranActionBarActivity
   private List<TranslationItem> allItems;
   private SparseIntArray translationPositions;
 
-  private TranslationAdapter adapter;
+  private TranslationsAdapter adapter;
   private TranslationItem downloadingItem;
   private String databaseDirectory;
   private QuranSettings quranSettings;
@@ -71,7 +71,7 @@ public class TranslationManagerActivity extends QuranActionBarActivity
     RecyclerView.LayoutManager mLayoutManager = new LinearLayoutManager(this);
     mTranslationRecycler.setLayoutManager(mLayoutManager);
 
-    adapter = new TranslationAdapter(this);
+    adapter = new TranslationsAdapter(this);
     mTranslationRecycler.setAdapter(adapter);
 
     databaseDirectory = QuranFileUtils.getQuranDatabaseDirectory(this);

--- a/app/src/main/java/com/quran/labs/androidquran/ui/TranslationManagerActivity.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/TranslationManagerActivity.java
@@ -53,7 +53,7 @@ public class TranslationManagerActivity extends QuranActionBarActivity
   private DefaultDownloadReceiver mDownloadReceiver = null;
 
   @Inject
-  TranslationManagerPresenter mPresenter;
+  TranslationManagerPresenter presenter;
 
   @BindView(R.id.translation_recycler)
   RecyclerView mTranslationRecycler;
@@ -83,8 +83,8 @@ public class TranslationManagerActivity extends QuranActionBarActivity
     }
 
     quranSettings = QuranSettings.getInstance(this);
-    mPresenter.bind(this);
-    mPresenter.getTranslationsList(false);
+    presenter.bind(this);
+    presenter.getTranslationsList(false);
     adapter.getOnClickDownloadSubject().subscribe(this::downloadItem);
     adapter.getOnClickRemoveSubject().subscribe(this::removeItem);
   }
@@ -102,7 +102,7 @@ public class TranslationManagerActivity extends QuranActionBarActivity
 
   @Override
   protected void onDestroy() {
-    mPresenter.unbind(this);
+    presenter.unbind(this);
     super.onDestroy();
   }
 
@@ -164,7 +164,7 @@ public class TranslationManagerActivity extends QuranActionBarActivity
       allItems.remove(allItemsIndex);
       allItems.add(allItemsIndex, updated);
     }
-    mPresenter.updateItem(updated);
+    presenter.updateItem(updated);
   }
 
   public void onErrorDownloadTranslations() {
@@ -226,10 +226,6 @@ public class TranslationManagerActivity extends QuranActionBarActivity
   }
 
   private void downloadItem(TranslationRowData translationRowData) {
-    if (!(translationRowData instanceof TranslationItem)) {
-      return;
-    }
-
     TranslationItem selectedItem = (TranslationItem) translationRowData;
     if (selectedItem.exists() && !selectedItem.needsUpgrade()) {
       return;

--- a/app/src/main/java/com/quran/labs/androidquran/ui/TranslationManagerActivity.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/TranslationManagerActivity.java
@@ -1,24 +1,17 @@
 package com.quran.labs.androidquran.ui;
 
-import android.content.Context;
-import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.os.Bundle;
+import android.support.design.widget.Snackbar;
 import android.support.v4.content.LocalBroadcastManager;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AlertDialog;
-import android.text.TextUtils;
+import android.support.v7.widget.LinearLayoutManager;
+import android.support.v7.widget.RecyclerView;
 import android.util.SparseIntArray;
-import android.view.LayoutInflater;
 import android.view.MenuItem;
 import android.view.View;
-import android.view.ViewGroup;
-import android.widget.AdapterView;
-import android.widget.BaseAdapter;
-import android.widget.ImageView;
-import android.widget.ListView;
-import android.widget.TextView;
 
 import com.quran.labs.androidquran.QuranApplication;
 import com.quran.labs.androidquran.R;
@@ -30,6 +23,7 @@ import com.quran.labs.androidquran.service.QuranDownloadService;
 import com.quran.labs.androidquran.service.util.DefaultDownloadReceiver;
 import com.quran.labs.androidquran.service.util.QuranDownloadNotifier;
 import com.quran.labs.androidquran.service.util.ServiceIntentHelper;
+import com.quran.labs.androidquran.ui.adapter.TranslationAdapter;
 import com.quran.labs.androidquran.util.QuranFileUtils;
 import com.quran.labs.androidquran.util.QuranSettings;
 
@@ -39,6 +33,8 @@ import java.util.List;
 
 import javax.inject.Inject;
 
+import butterknife.BindView;
+import butterknife.ButterKnife;
 import timber.log.Timber;
 
 public class TranslationManagerActivity extends QuranActionBarActivity
@@ -47,39 +43,36 @@ public class TranslationManagerActivity extends QuranActionBarActivity
   public static final String TRANSLATION_DOWNLOAD_KEY = "TRANSLATION_DOWNLOAD_KEY";
   private static final String UPGRADING_EXTENSION = ".old";
 
-  private List<TranslationRowData> items;
   private List<TranslationItem> allItems;
   private SparseIntArray translationPositions;
 
-  private ListView listView;
-  private TextView messageArea;
-  private TranslationsAdapter adapter;
+  private TranslationAdapter adapter;
   private TranslationItem downloadingItem;
   private String databaseDirectory;
   private QuranSettings quranSettings;
-
-  @Inject TranslationManagerPresenter mPresenter;
   private DefaultDownloadReceiver mDownloadReceiver = null;
+
+  @Inject
+  TranslationManagerPresenter mPresenter;
+
+  @BindView(R.id.translation_recycler)
+  RecyclerView mTranslationRecycler;
+
+  @BindView(R.id.translation_layout)
+  View mTranslationLayout;
 
   @Override
   public void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
-    //requestWindowFeature(Window.FEATURE_INDETERMINATE_PROGRESS);
-
     ((QuranApplication) getApplication()).getApplicationComponent().inject(this);
-
     setContentView(R.layout.translation_manager);
-    listView = (ListView) findViewById(R.id.translation_list);
-    adapter = new TranslationsAdapter(this, null);
-    listView.setAdapter(adapter);
-    messageArea = (TextView) findViewById(R.id.message_area);
-    listView.setOnItemClickListener(new AdapterView.OnItemClickListener() {
-      @Override
-      public void onItemClick(AdapterView<?> adapterView,
-          View view, int pos, long id) {
-        downloadItem(pos);
-      }
-    });
+    ButterKnife.bind(this);
+
+    RecyclerView.LayoutManager mLayoutManager = new LinearLayoutManager(this);
+    mTranslationRecycler.setLayoutManager(mLayoutManager);
+
+    adapter = new TranslationAdapter(this);
+    mTranslationRecycler.setAdapter(adapter);
 
     databaseDirectory = QuranFileUtils.getQuranDatabaseDirectory(this);
 
@@ -92,6 +85,8 @@ public class TranslationManagerActivity extends QuranActionBarActivity
     quranSettings = QuranSettings.getInstance(this);
     mPresenter.bind(this);
     mPresenter.getTranslationsList(false);
+    adapter.getOnClickDownloadSubject().subscribe(this::downloadItem);
+    adapter.getOnClickRemoveSubject().subscribe(this::removeItem);
   }
 
   @Override
@@ -173,7 +168,9 @@ public class TranslationManagerActivity extends QuranActionBarActivity
   }
 
   public void onErrorDownloadTranslations() {
-    messageArea.setText(R.string.error_getting_translation_list);
+    Snackbar
+        .make(mTranslationLayout, R.string.error_getting_translation_list, Snackbar.LENGTH_SHORT)
+        .show();
   }
 
   public void onTranslationsUpdated(List<TranslationItem> items) {
@@ -185,8 +182,6 @@ public class TranslationManagerActivity extends QuranActionBarActivity
     allItems = items;
     translationPositions = itemsSparseArray;
 
-    messageArea.setVisibility(View.GONE);
-    listView.setVisibility(View.VISIBLE);
     generateListItems();
   }
 
@@ -206,14 +201,14 @@ public class TranslationManagerActivity extends QuranActionBarActivity
       }
     }
 
-    List<TranslationRowData> res = new ArrayList<>();
+    List<TranslationRowData> result = new ArrayList<>();
     if (downloaded.size() > 0) {
       TranslationHeader hdr = new TranslationHeader(getString(R.string.downloaded_translations));
-      res.add(hdr);
+      result.add(hdr);
 
       boolean needsUpgrade = false;
       for (TranslationItem item : downloaded) {
-        res.add(item);
+        result.add(item);
         needsUpgrade = needsUpgrade || item.needsUpgrade();
       }
 
@@ -222,23 +217,20 @@ public class TranslationManagerActivity extends QuranActionBarActivity
       }
     }
 
-    res.add(new TranslationHeader(getString(R.string.available_translations)));
+    result.add(new TranslationHeader(getString(R.string.available_translations)));
 
-    for (TranslationItem item : notDownloaded) {
-      res.add(item);
-    }
+    result.addAll(notDownloaded);
 
-    items = res;
-    adapter.setData(items);
+    adapter.setTranslations(result);
     adapter.notifyDataSetChanged();
   }
 
-  private void downloadItem(int pos) {
-    if (items == null || !(adapter.getItem(pos) instanceof TranslationItem)) {
+  private void downloadItem(TranslationRowData translationRowData) {
+    if (!(translationRowData instanceof TranslationItem)) {
       return;
     }
 
-    TranslationItem selectedItem = (TranslationItem) adapter.getItem(pos);
+    TranslationItem selectedItem = (TranslationItem) translationRowData;
     if (selectedItem.exists() && !selectedItem.needsUpgrade()) {
       return;
     }
@@ -290,170 +282,32 @@ public class TranslationManagerActivity extends QuranActionBarActivity
     startService(intent);
   }
 
-  private void removeItem(final int pos) {
-    if (items == null || adapter == null) {
+  private void removeItem(final TranslationRowData translationRowData) {
+    if (adapter == null) {
       return;
     }
 
     final TranslationItem selectedItem =
-        (TranslationItem) adapter.getItem(pos);
+        (TranslationItem) translationRowData;
     String msg = String.format(getString(R.string.remove_dlg_msg), selectedItem.name());
     AlertDialog.Builder builder = new AlertDialog.Builder(this);
     builder.setTitle(R.string.remove_dlg_title)
         .setMessage(msg)
         .setPositiveButton(R.string.remove_button,
-            new DialogInterface.OnClickListener() {
-              public void onClick(DialogInterface dialog, int id) {
-                QuranFileUtils.removeTranslation(TranslationManagerActivity.this,
-                    selectedItem.translation.filename);
-                TranslationItem updatedItem = selectedItem.withTranslationRemoved();
-                updateTranslationItem(updatedItem);
-                String current = quranSettings.getActiveTranslation();
-                if (current.equals(selectedItem.translation.filename)) {
-                  quranSettings.removeActiveTranslation();
-                }
-                generateListItems();
+            (dialog, id) -> {
+              QuranFileUtils.removeTranslation(TranslationManagerActivity.this,
+                  selectedItem.translation.filename);
+              TranslationItem updatedItem = selectedItem.withTranslationRemoved();
+              updateTranslationItem(updatedItem);
+              String current = quranSettings.getActiveTranslation();
+              if (current.equals(selectedItem.translation.filename)) {
+                quranSettings.removeActiveTranslation();
               }
+              generateListItems();
             })
         .setNegativeButton(R.string.cancel,
-            new DialogInterface.OnClickListener() {
-              @Override
-              public void onClick(DialogInterface dialog, int i) {
-                dialog.dismiss();
-              }
-            });
+            (dialog, i) -> dialog.dismiss());
     builder.show();
   }
 
-  private class TranslationsAdapter extends BaseAdapter {
-
-    private LayoutInflater mInflater;
-    private List<TranslationRowData> mElements;
-    private int TYPE_ITEM = 0;
-    private int TYPE_SEPARATOR = 1;
-
-    public TranslationsAdapter(Context context,
-        List<TranslationRowData> elements) {
-      mInflater = LayoutInflater.from(context);
-      mElements = elements;
-    }
-
-    public void setData(List<TranslationRowData> items) {
-      mElements = items;
-    }
-
-    @Override
-    public int getCount() {
-      return mElements == null ? 0 : mElements.size();
-    }
-
-    @Override
-    public int getItemViewType(int position) {
-      return (mElements.get(position).isSeparator()) ?
-          TYPE_SEPARATOR : TYPE_ITEM;
-    }
-
-    @Override
-    public int getViewTypeCount() {
-      return 2;
-    }
-
-
-    @Override
-    public TranslationRowData getItem(int position) {
-      return mElements.get(position);
-    }
-
-    @Override
-    public long getItemId(int position) {
-      return position;
-    }
-
-    @Override
-    public View getView(int position, View convertView, ViewGroup parent) {
-      ViewHolder holder;
-
-      if (convertView == null) {
-        holder = new ViewHolder();
-        if (getItemViewType(position) == TYPE_ITEM) {
-          convertView = mInflater.inflate(
-              R.layout.translation_row, parent, false);
-          holder.translationTitle = (TextView) convertView
-              .findViewById(R.id.translation_title);
-          holder.translationInfo = (TextView) convertView
-              .findViewById(R.id.translation_info);
-          holder.leftImage = (ImageView) convertView
-              .findViewById(R.id.left_image);
-          holder.rightImage = (ImageView) convertView
-              .findViewById(R.id.right_image);
-        } else {
-          convertView = mInflater.inflate(R.layout.translation_sep, parent, false);
-          holder.separatorText = (TextView) convertView
-              .findViewById(R.id.separator_txt);
-        }
-        convertView.setTag(holder);
-      } else {
-        holder = (ViewHolder) convertView.getTag();
-      }
-
-      TranslationRowData rowItem = mElements.get(position);
-      if (getItemViewType(position) == TYPE_SEPARATOR) {
-        holder.separatorText.setText(rowItem.name());
-      } else {
-        TranslationItem item = (TranslationItem) rowItem;
-        holder.translationTitle.setText(item.name());
-        if (TextUtils.isEmpty(item.translation.translatorNameLocalized)) {
-          holder.translationInfo.setText(item.translation.translator);
-        } else {
-          holder.translationInfo.setText(item.translation.translatorNameLocalized);
-        }
-
-        if (item.exists()) {
-          if (item.needsUpgrade()) {
-            holder.leftImage.setImageResource(R.drawable.ic_download);
-            holder.leftImage.setVisibility(View.VISIBLE);
-
-            holder.translationInfo.setText(R.string.update_available);
-          } else {
-            holder.leftImage.setVisibility(View.GONE);
-          }
-          holder.rightImage.setImageResource(R.drawable.ic_cancel);
-          holder.rightImage.setVisibility(View.VISIBLE);
-          holder.rightImage.setContentDescription(getString(R.string.remove_button));
-
-          final int pos = position;
-          holder.rightImage.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View view) {
-              removeItem(pos);
-            }
-          });
-        } else {
-          holder.leftImage.setVisibility(View.GONE);
-          holder.rightImage.setImageResource(R.drawable.ic_download);
-          holder.rightImage.setVisibility(View.VISIBLE);
-          holder.rightImage.setOnClickListener(null);
-          holder.rightImage.setClickable(false);
-          holder.rightImage.setContentDescription(null);
-        }
-      }
-
-      return convertView;
-    }
-
-    @Override
-    public boolean isEnabled(int position) {
-      return getItemViewType(position) != TYPE_SEPARATOR;
-    }
-
-    class ViewHolder {
-
-      TextView translationTitle;
-      TextView translationInfo;
-      ImageView leftImage;
-      ImageView rightImage;
-
-      TextView separatorText;
-    }
-  }
 }

--- a/app/src/main/java/com/quran/labs/androidquran/ui/adapter/TranslationAdapter.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/adapter/TranslationAdapter.java
@@ -1,0 +1,160 @@
+package com.quran.labs.androidquran.ui.adapter;
+
+import android.content.Context;
+import android.support.annotation.Nullable;
+import android.support.v7.widget.RecyclerView;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+import com.quran.labs.androidquran.R;
+import com.quran.labs.androidquran.dao.translation.TranslationItem;
+import com.quran.labs.androidquran.dao.translation.TranslationRowData;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import butterknife.BindView;
+import butterknife.ButterKnife;
+import io.reactivex.Observable;
+import io.reactivex.subjects.PublishSubject;
+
+import static android.text.TextUtils.isEmpty;
+
+public class TranslationAdapter extends RecyclerView.Adapter<TranslationAdapter.TranslationViewHolder> {
+
+  private final PublishSubject<TranslationRowData> onClickDownloadSubject = PublishSubject.create();
+  private final PublishSubject<TranslationRowData> onClickRemoveSubject = PublishSubject.create();
+
+  private List<TranslationRowData> mTranslations = new ArrayList<>();
+  private Context context;
+
+  public TranslationAdapter(Context context) {
+    this.context = context;
+  }
+
+  @Override
+  public TranslationViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
+    View view = LayoutInflater.from(parent.getContext()).inflate(viewType, parent, false);
+    return new TranslationViewHolder(view);
+  }
+
+  @Override
+  public void onBindViewHolder(TranslationViewHolder holder, int position) {
+    TranslationRowData rowItem = mTranslations.get(position);
+    switch (holder.getItemViewType()) {
+      case R.layout.translation_row:
+        TranslationItem item = (TranslationItem) rowItem;
+        holder.getTranslationTitle().setText(item.name());
+        if (isEmpty(item.translation.translatorNameLocalized)) {
+          holder.getTranslationInfo().setText(item.translation.translator);
+        } else {
+          holder.getTranslationInfo().setText(item.translation.translatorNameLocalized);
+        }
+
+        if (item.exists()) {
+          if (item.needsUpgrade()) {
+            holder.getLeftImage().setImageResource(R.drawable.ic_download);
+            holder.getLeftImage().setVisibility(View.VISIBLE);
+            holder.getTranslationInfo().setText(R.string.update_available);
+          } else {
+            holder.getLeftImage().setVisibility(View.GONE);
+          }
+          holder.getRightImage().setImageResource(R.drawable.ic_cancel);
+          holder.getRightImage().setVisibility(View.VISIBLE);
+          holder.getRightImage().setContentDescription(context.getString(R.string.remove_button));
+
+          holder.itemView.setOnClickListener(v -> onClickRemoveSubject.onNext(item));
+        } else {
+          holder.getLeftImage().setVisibility(View.GONE);
+          holder.getRightImage().setImageResource(R.drawable.ic_download);
+          holder.getRightImage().setVisibility(View.VISIBLE);
+          holder.getRightImage().setOnClickListener(null);
+          holder.getRightImage().setClickable(false);
+          holder.getRightImage().setContentDescription(null);
+          holder.itemView.setOnClickListener(v -> onClickDownloadSubject.onNext(item));
+        }
+        break;
+      case R.layout.translation_sep:
+        holder.getSeparatorText().setText(rowItem.name());
+        break;
+    }
+  }
+
+  @Override
+  public int getItemCount() {
+    return mTranslations.size();
+  }
+
+  @Override
+  public int getItemViewType(int position) {
+    return mTranslations.get(position).isSeparator() ?
+        R.layout.translation_sep : R.layout.translation_row;
+  }
+
+  public Observable<TranslationRowData> getOnClickDownloadSubject() {
+    return onClickDownloadSubject;
+  }
+
+  public Observable<TranslationRowData> getOnClickRemoveSubject() {
+    return onClickRemoveSubject;
+  }
+
+  public void setTranslations(List<TranslationRowData> data) {
+    this.mTranslations = data;
+  }
+
+  public List<TranslationRowData> getData() {
+    return mTranslations;
+  }
+
+  public class TranslationViewHolder extends RecyclerView.ViewHolder {
+
+    @Nullable
+    @BindView(R.id.translation_title)
+    TextView translationTitle;
+
+    @Nullable
+    @BindView(R.id.translation_info)
+    TextView translationInfo;
+
+    @Nullable
+    @BindView(R.id.left_image)
+    ImageView leftImage;
+
+    @Nullable
+    @BindView(R.id.right_image)
+    ImageView rightImage;
+
+    @Nullable
+    @BindView(R.id.separator_txt)
+    TextView separatorText;
+
+    TranslationViewHolder(View itemView) {
+      super(itemView);
+      ButterKnife.bind(this, itemView);
+    }
+
+    public TextView getSeparatorText() {
+      return separatorText;
+    }
+
+    public TextView getTranslationTitle() {
+      return translationTitle;
+    }
+
+    public TextView getTranslationInfo() {
+      return translationInfo;
+    }
+
+    public ImageView getLeftImage() {
+      return leftImage;
+    }
+
+    public ImageView getRightImage() {
+      return rightImage;
+    }
+  }
+}

--- a/app/src/main/java/com/quran/labs/androidquran/ui/adapter/TranslationAdapter.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/adapter/TranslationAdapter.java
@@ -106,7 +106,7 @@ public class TranslationAdapter extends RecyclerView.Adapter<TranslationAdapter.
     this.mTranslations = data;
   }
 
-  public List<TranslationRowData> getData() {
+  public List<TranslationRowData> getTranslations() {
     return mTranslations;
   }
 

--- a/app/src/main/java/com/quran/labs/androidquran/ui/adapter/TranslationsAdapter.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/adapter/TranslationsAdapter.java
@@ -3,6 +3,7 @@ package com.quran.labs.androidquran.ui.adapter;
 import android.content.Context;
 import android.support.annotation.Nullable;
 import android.support.v7.widget.RecyclerView;
+import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -19,14 +20,12 @@ import java.util.List;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import io.reactivex.Observable;
-import io.reactivex.subjects.PublishSubject;
-
-import static android.text.TextUtils.isEmpty;
+import io.reactivex.subjects.UnicastSubject;
 
 public class TranslationsAdapter extends RecyclerView.Adapter<TranslationsAdapter.TranslationViewHolder> {
 
-  private final PublishSubject<TranslationRowData> onClickDownloadSubject = PublishSubject.create();
-  private final PublishSubject<TranslationRowData> onClickRemoveSubject = PublishSubject.create();
+  private final UnicastSubject<TranslationRowData> onClickDownloadSubject = UnicastSubject.create();
+  private final UnicastSubject<TranslationRowData> onClickRemoveSubject = UnicastSubject.create();
 
   private List<TranslationRowData> mTranslations = new ArrayList<>();
   private Context context;
@@ -48,32 +47,35 @@ public class TranslationsAdapter extends RecyclerView.Adapter<TranslationsAdapte
       case R.layout.translation_row:
         TranslationItem item = (TranslationItem) rowItem;
         holder.getTranslationTitle().setText(item.name());
-        if (isEmpty(item.translation.translatorNameLocalized)) {
+        if (TextUtils.isEmpty(item.translation.translatorNameLocalized)) {
           holder.getTranslationInfo().setText(item.translation.translator);
         } else {
           holder.getTranslationInfo().setText(item.translation.translatorNameLocalized);
         }
 
+        ImageView leftImage = holder.getLeftImage();
+        ImageView rightImage = holder.getRightImage();
+
         if (item.exists()) {
           if (item.needsUpgrade()) {
-            holder.getLeftImage().setImageResource(R.drawable.ic_download);
-            holder.getLeftImage().setVisibility(View.VISIBLE);
+            leftImage.setImageResource(R.drawable.ic_download);
+            leftImage.setVisibility(View.VISIBLE);
             holder.getTranslationInfo().setText(R.string.update_available);
           } else {
-            holder.getLeftImage().setVisibility(View.GONE);
+            leftImage.setVisibility(View.GONE);
           }
-          holder.getRightImage().setImageResource(R.drawable.ic_cancel);
-          holder.getRightImage().setVisibility(View.VISIBLE);
-          holder.getRightImage().setContentDescription(context.getString(R.string.remove_button));
+          rightImage.setImageResource(R.drawable.ic_cancel);
+          rightImage.setVisibility(View.VISIBLE);
+          rightImage.setContentDescription(context.getString(R.string.remove_button));
 
           holder.itemView.setOnClickListener(v -> onClickRemoveSubject.onNext(item));
         } else {
-          holder.getLeftImage().setVisibility(View.GONE);
-          holder.getRightImage().setImageResource(R.drawable.ic_download);
-          holder.getRightImage().setVisibility(View.VISIBLE);
-          holder.getRightImage().setOnClickListener(null);
-          holder.getRightImage().setClickable(false);
-          holder.getRightImage().setContentDescription(null);
+          leftImage.setVisibility(View.GONE);
+          rightImage.setImageResource(R.drawable.ic_download);
+          rightImage.setVisibility(View.VISIBLE);
+          rightImage.setOnClickListener(null);
+          rightImage.setClickable(false);
+          rightImage.setContentDescription(null);
           holder.itemView.setOnClickListener(v -> onClickDownloadSubject.onNext(item));
         }
         break;
@@ -95,11 +97,11 @@ public class TranslationsAdapter extends RecyclerView.Adapter<TranslationsAdapte
   }
 
   public Observable<TranslationRowData> getOnClickDownloadSubject() {
-    return onClickDownloadSubject;
+    return onClickDownloadSubject.hide();
   }
 
   public Observable<TranslationRowData> getOnClickRemoveSubject() {
-    return onClickRemoveSubject;
+    return onClickRemoveSubject.hide();
   }
 
   public void setTranslations(List<TranslationRowData> data) {
@@ -110,7 +112,7 @@ public class TranslationsAdapter extends RecyclerView.Adapter<TranslationsAdapte
     return mTranslations;
   }
 
-  public class TranslationViewHolder extends RecyclerView.ViewHolder {
+  static class TranslationViewHolder extends RecyclerView.ViewHolder {
 
     @Nullable
     @BindView(R.id.translation_title)
@@ -137,23 +139,23 @@ public class TranslationsAdapter extends RecyclerView.Adapter<TranslationsAdapte
       ButterKnife.bind(this, itemView);
     }
 
-    public TextView getSeparatorText() {
+    TextView getSeparatorText() {
       return separatorText;
     }
 
-    public TextView getTranslationTitle() {
+    TextView getTranslationTitle() {
       return translationTitle;
     }
 
-    public TextView getTranslationInfo() {
+    TextView getTranslationInfo() {
       return translationInfo;
     }
 
-    public ImageView getLeftImage() {
+    ImageView getLeftImage() {
       return leftImage;
     }
 
-    public ImageView getRightImage() {
+    ImageView getRightImage() {
       return rightImage;
     }
   }

--- a/app/src/main/java/com/quran/labs/androidquran/ui/adapter/TranslationsAdapter.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/adapter/TranslationsAdapter.java
@@ -23,7 +23,7 @@ import io.reactivex.subjects.PublishSubject;
 
 import static android.text.TextUtils.isEmpty;
 
-public class TranslationAdapter extends RecyclerView.Adapter<TranslationAdapter.TranslationViewHolder> {
+public class TranslationsAdapter extends RecyclerView.Adapter<TranslationsAdapter.TranslationViewHolder> {
 
   private final PublishSubject<TranslationRowData> onClickDownloadSubject = PublishSubject.create();
   private final PublishSubject<TranslationRowData> onClickRemoveSubject = PublishSubject.create();
@@ -31,7 +31,7 @@ public class TranslationAdapter extends RecyclerView.Adapter<TranslationAdapter.
   private List<TranslationRowData> mTranslations = new ArrayList<>();
   private Context context;
 
-  public TranslationAdapter(Context context) {
+  public TranslationsAdapter(Context context) {
     this.context = context;
   }
 

--- a/app/src/main/java/com/quran/labs/androidquran/ui/adapter/TranslationsAdapter.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/adapter/TranslationsAdapter.java
@@ -27,7 +27,7 @@ public class TranslationsAdapter extends RecyclerView.Adapter<TranslationsAdapte
   private final UnicastSubject<TranslationRowData> onClickDownloadSubject = UnicastSubject.create();
   private final UnicastSubject<TranslationRowData> onClickRemoveSubject = UnicastSubject.create();
 
-  private List<TranslationRowData> mTranslations = new ArrayList<>();
+  private List<TranslationRowData> translations = new ArrayList<>();
   private Context context;
 
   public TranslationsAdapter(Context context) {
@@ -42,7 +42,7 @@ public class TranslationsAdapter extends RecyclerView.Adapter<TranslationsAdapte
 
   @Override
   public void onBindViewHolder(TranslationViewHolder holder, int position) {
-    TranslationRowData rowItem = mTranslations.get(position);
+    TranslationRowData rowItem = translations.get(position);
     switch (holder.getItemViewType()) {
       case R.layout.translation_row:
         TranslationItem item = (TranslationItem) rowItem;
@@ -67,8 +67,6 @@ public class TranslationsAdapter extends RecyclerView.Adapter<TranslationsAdapte
           rightImage.setImageResource(R.drawable.ic_cancel);
           rightImage.setVisibility(View.VISIBLE);
           rightImage.setContentDescription(context.getString(R.string.remove_button));
-
-          holder.itemView.setOnClickListener(v -> onClickRemoveSubject.onNext(item));
         } else {
           leftImage.setVisibility(View.GONE);
           rightImage.setImageResource(R.drawable.ic_download);
@@ -76,7 +74,6 @@ public class TranslationsAdapter extends RecyclerView.Adapter<TranslationsAdapte
           rightImage.setOnClickListener(null);
           rightImage.setClickable(false);
           rightImage.setContentDescription(null);
-          holder.itemView.setOnClickListener(v -> onClickDownloadSubject.onNext(item));
         }
         break;
       case R.layout.translation_sep:
@@ -87,12 +84,12 @@ public class TranslationsAdapter extends RecyclerView.Adapter<TranslationsAdapte
 
   @Override
   public int getItemCount() {
-    return mTranslations.size();
+    return translations.size();
   }
 
   @Override
   public int getItemViewType(int position) {
-    return mTranslations.get(position).isSeparator() ?
+    return translations.get(position).isSeparator() ?
         R.layout.translation_sep : R.layout.translation_row;
   }
 
@@ -105,14 +102,14 @@ public class TranslationsAdapter extends RecyclerView.Adapter<TranslationsAdapte
   }
 
   public void setTranslations(List<TranslationRowData> data) {
-    this.mTranslations = data;
+    this.translations = data;
   }
 
   public List<TranslationRowData> getTranslations() {
-    return mTranslations;
+    return translations;
   }
 
-  static class TranslationViewHolder extends RecyclerView.ViewHolder {
+  class TranslationViewHolder extends RecyclerView.ViewHolder implements View.OnClickListener {
 
     @Nullable
     @BindView(R.id.translation_title)
@@ -137,6 +134,7 @@ public class TranslationsAdapter extends RecyclerView.Adapter<TranslationsAdapte
     TranslationViewHolder(View itemView) {
       super(itemView);
       ButterKnife.bind(this, itemView);
+      itemView.setOnClickListener(this);
     }
 
     TextView getSeparatorText() {
@@ -157,6 +155,16 @@ public class TranslationsAdapter extends RecyclerView.Adapter<TranslationsAdapte
 
     ImageView getRightImage() {
       return rightImage;
+    }
+
+    @Override
+    public void onClick(View v) {
+      TranslationItem item = (TranslationItem) translations.get(getAdapterPosition());
+      if(item.exists()) {
+        onClickRemoveSubject.onNext(item);
+      } else {
+        onClickDownloadSubject.onNext(item);
+      }
     }
   }
 }

--- a/app/src/main/res/layout/translation_manager.xml
+++ b/app/src/main/res/layout/translation_manager.xml
@@ -1,22 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              android:id="@+id/translation_layout"
-              android:orientation="vertical"
-              android:layout_width="match_parent"
-              android:layout_height="match_parent"
-    >
-  <ListView
-      android:id="@+id/translation_list"
+    android:id="@+id/translation_layout"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+  <android.support.v7.widget.RecyclerView
+      android:id="@+id/translation_recycler"
       android:layout_width="match_parent"
       android:layout_height="match_parent"
-      android:visibility="gone"
-      android:divider="@null"
-      />
-  <TextView
-      android:id="@+id/message_area"
-      android:layout_width="match_parent"
-      android:layout_height="match_parent"
-      android:padding="10dp"
-      android:text="@string/index_loading"
-      />
+      android:scrollbars="vertical" />
 </LinearLayout>

--- a/app/src/main/res/layout/translation_manager.xml
+++ b/app/src/main/res/layout/translation_manager.xml
@@ -1,13 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/translation_layout"
+<android.support.v7.widget.RecyclerView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/translation_recycler"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical">
-
-  <android.support.v7.widget.RecyclerView
-      android:id="@+id/translation_recycler"
-      android:layout_width="match_parent"
-      android:layout_height="match_parent"
-      android:scrollbars="vertical" />
-</LinearLayout>
+    android:scrollbars="vertical"
+    />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -75,6 +75,9 @@
   <string name="about_retrolambda" translatable="false">Retrolambda</string>
   <string name="about_retrolambda_desc" translatable="false">orfjackal/retrolambda and evant/gradle-retrolambda</string>
   <string name="about_retrolambda_url" translatable="false">https://github.com/orfjackal/retrolambda</string>
+  <string name="about_butterknife" translatable="false">ButterKnife</string>
+  <string name="about_butterknife_desc" translatable="false">https://github.com/JakeWharton/butterknife</string>
+  <string name="about_butterknife_url" translatable="false">https://github.com/JakeWharton/butterknife</string>
   <string name="about_others">Others</string>
   <string name="about_contributors">Contributors</string>
   <string name="about_contributors_summary">A list of people who contributed to the development of Quran for Android</string>

--- a/app/src/main/res/xml/about.xml
+++ b/app/src/main/res/xml/about.xml
@@ -122,6 +122,14 @@
           android:action="android.intent.action.VIEW"
           android:data="@string/about_retrolambda_url"/>
     </com.quran.labs.androidquran.ui.preference.QuranPreference>
+
+    <com.quran.labs.androidquran.ui.preference.QuranPreference
+        android:title="@string/about_butterknife"
+        android:summary="@string/about_butterknife_desc">
+      <intent
+          android:action="android.intent.action.VIEW"
+          android:data="@string/about_butterknife_url"/>
+    </com.quran.labs.androidquran.ui.preference.QuranPreference>
   </PreferenceCategory>
 
   <PreferenceCategory


### PR DESCRIPTION

- Unsubscribe from UnicastSubjects in TranslationManager (was causing crash the 2nd time you visit the translations view)
- Moved translation adapter listeners to ViewHolder's constructor for performance 