### PR TITLE
Fix build error

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -130,6 +130,7 @@ dependencies {
   testCompile 'com.squareup.okhttp3:mockwebserver:3.5.0'
   androidTestCompile "com.android.support.test.espresso:espresso-core:${espressoVersion}"
   androidTestCompile "com.android.support.test.espresso:espresso-intents:${espressoVersion}"
+  androidTestCompile "com.android.support:support-annotations:${supportLibVersion}"
   compile('com.crashlytics.sdk.android:crashlytics:2.6.5@aar') {
     transitive = true;
   }


### PR DESCRIPTION
Error log:

> Error:Conflict with dependency 'com.android.support:support-annotations' in project ':app'. Resolved versions for app (25.1.0) and test app (23.1.1) differ. See http://g.co/androidstudio/app-test-app-conflict for details.

Tested only with Madani debug build, did not test with tests.