### PR TITLE
Update toolbar in translation view

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/ui/PagerActivity.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/PagerActivity.java
@@ -1322,6 +1322,11 @@ public class PagerActivity extends QuranActionBarActivity implements
               }
               translationItems = titles;
               translations = translationList;
+
+              if (showingTranslation) {
+                // Since translation items have changed, need to
+                updateActionBarSpinner();
+              }
             }
 
             @Override


### PR DESCRIPTION
Apparently, `translationItems` will not have enough time to get populated in `onCreate()` when we try to update the toolbar with translation items. So, let's call `updateActionBarSpinner()` once we get `translationItems` updated.

Fixes #757.