### PR TITLE
Setup Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ android:
       - platform-tools
       - build-tools-25.0.0
       - android-25
-      - android-22
+      - android-22 # required for emulator below
       - extra-android-m2repository
       - sys-img-armeabi-v7a-android-22
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,17 @@ android:
       - platform-tools
       - build-tools-25.0.0
       - android-25
+      - android-22
       - extra-android-m2repository
+      - sys-img-armeabi-v7a-android-22
+
+before_script:
+  # Create and start emulator
+  - echo no | android create avd --force -n test -t android-22 --abi armeabi-v7a
+  - emulator -avd test -no-skin -no-audio -no-window &
+  - android-wait-for-emulator
+  - adb shell input keyevent 82 &
 
 script:
    - ./gradlew clean testMadaniRelease -PdisableCrashlytics
+   - ./gradlew clean connectedMadaniDebugAndroidTest -PdisableCrashlytics

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,8 @@ android:
       - tools
       - platform-tools
       - build-tools-25.0.0
-      - android-22 # latest supported emulator image
+      - android-25
+      - android-22
       - extra-android-m2repository
       - sys-img-armeabi-v7a-android-22
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,7 @@ android:
       - tools
       - platform-tools
       - build-tools-25.0.0
-      - android-25
-      - android-22
+      - android-22 # latest supported emulator image
       - extra-android-m2repository
       - sys-img-armeabi-v7a-android-22
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/quran/quran_android.svg?branch=master)](https://travis-ci.org/quran/quran_android)
+
 # Quran for Android
 
 [<img align="right" src="https://raw.githubusercontent.com/quran/quran_android/master/app/src/madani/res/drawable-xxxhdpi/icon.png" />](https://play.google.com/store/apps/details?id=com.quran.labs.androidquran)


### PR DESCRIPTION
Follow up to #750 

- Setup Travis CI to run Espresso tests (max Android version supported is 22)
- Added build status on the README.md
