### PR TITLE
Update bookmarks & tags contextual action bar

### DIFF
--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -306,6 +306,12 @@
   </plurals>
   <string name="undo">Urungkan</string>
 
+  <string name="recent_pages">Halaman terakhir</string>
+  <plurals name="plural_recent_pages">
+    <item quantity="one">@string/menu_jump_last_page</item>
+    <item quantity="other">@string/recent_pages</item>
+  </plurals>
+
   <!-- tag dialog -->
   <string name="tag_dlg_title">Label</string>
   <string name="tag_name">Nama</string>


### PR DESCRIPTION
I just add several translation lines for the bookmarks & tags bar which have not been added to the indonesian strings.

This might resolve the "weird translation" that pop up in the Bookmark bar for the recent pages.