### PR TITLE
Use `external-files-path` instead of `external-path`

### DIFF
--- a/app/src/debug/res/xml/file_paths.xml
+++ b/app/src/debug/res/xml/file_paths.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<paths>
-   <external-path
-      path="Android/data/com.quran.labs.androidquran.debug/files/backups/" 
-      name="backups" />
-</paths>

--- a/app/src/madani/res/xml/file_paths.xml
+++ b/app/src/madani/res/xml/file_paths.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<paths>
-   <external-path
-      path="Android/data/com.quran.labs.androidquran/files/backups/" 
-      name="backups" />
-</paths>

--- a/app/src/main/res/xml/file_paths.xml
+++ b/app/src/main/res/xml/file_paths.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+  <external-files-path
+      name="backups"
+      path="backups/" />
+</paths>

--- a/app/src/naskh/res/xml/file_paths.xml
+++ b/app/src/naskh/res/xml/file_paths.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<paths>
-   <external-path
-      path="Android/data/com.quran.labs.androidquran.naskh/files/backups/" 
-      name="backups" />
-</paths>

--- a/app/src/qaloon/res/xml/file_paths.xml
+++ b/app/src/qaloon/res/xml/file_paths.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<paths>
-   <external-path
-      path="Android/data/com.quran.labs.androidquran.qaloon/files/backups/" 
-      name="backups" />
-</paths>

--- a/app/src/shemerly/res/xml/file_paths.xml
+++ b/app/src/shemerly/res/xml/file_paths.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<paths>
-   <external-path
-      path="Android/data/com.quran.labs.androidquran.shemerly/files/backups/"
-      name="backups" />
-</paths>


### PR DESCRIPTION
Because, we are actually using `external-files-path` albeit in hard-coded way. This should now fix exporting data in all other build variants and flavors as well.