### PR TITLE
Jump to surah and ayah by allowing user to type (issue #799)

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/ui/fragment/JumpFragment.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/fragment/JumpFragment.java
@@ -210,7 +210,7 @@ public class JumpFragment extends DialogFragment {
     }
   }
 
-  private static int parseInt(String s, int defaultValue) {
+  static int parseInt(String s, int defaultValue) {
     // May be extracted to util
     try {
       return Integer.parseInt(s);

--- a/app/src/main/java/com/quran/labs/androidquran/ui/fragment/JumpFragment.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/fragment/JumpFragment.java
@@ -93,14 +93,19 @@ public class JumpFragment extends DialogFragment {
     input.setHint(QuranUtils.getLocalizedNumber(activity, 1));
     suraSpinner.setTag(1); // al-Fatiha
     suraSpinner.setText(suras[0]);
-    suraSpinner.setOnItemClickListener(true, (AdapterView<?> parent, View view, int position,
+    suraSpinner.setOnItemClickListener((AdapterView<?> parent, View view, int position,
                                         long rowId) -> {
       Context context = getActivity();
 
-      String suraName = (String) suraSpinner.getAdapter().getItem(position);
-      int sura = Arrays.asList(suras).indexOf(suraName) + 1;
-      if (sura == 0) // default to al-Fatiha
-        sura = 1;
+      int sura = 0;
+      if (position >= 0) {
+        String suraName = (String) suraSpinner.getAdapter().getItem(position);
+        sura = Arrays.asList(suras).indexOf(suraName) + 1;
+      }
+      if (sura == 0) { // sura not found or position is -1
+        sura = 1; // default to al-Fatiha
+        suraSpinner.setText(suras[0]);
+      }
       int ayahCount = QuranInfo.getNumAyahs(sura);
 
       int ayah = parseInt(ayahSpinner.getText().toString(), 1);

--- a/app/src/main/java/com/quran/labs/androidquran/ui/fragment/JumpFragment.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/fragment/JumpFragment.java
@@ -20,7 +20,6 @@ import android.view.ViewGroup;
 import android.view.WindowManager;
 import android.view.inputmethod.EditorInfo;
 import android.widget.AdapterView;
-import android.widget.AutoCompleteTextView;
 import android.widget.BaseAdapter;
 import android.widget.EditText;
 import android.widget.Filter;
@@ -94,11 +93,11 @@ public class JumpFragment extends DialogFragment {
     input.setHint(QuranUtils.getLocalizedNumber(activity, 1));
     suraSpinner.setTag(1); // al-Fatiha
     suraSpinner.setText(suras[0]);
-    suraSpinner.setOnItemClickListener((AdapterView<?> parent, View view, int position,
+    suraSpinner.setOnItemClickListener(true, (AdapterView<?> parent, View view, int position,
                                         long rowId) -> {
       Context context = getActivity();
 
-      String suraName = (String) parent.getItemAtPosition(position);
+      String suraName = (String) suraSpinner.getAdapter().getItem(position);
       int sura = Arrays.asList(suras).indexOf(suraName) + 1;
       if (sura == 0) // default to al-Fatiha
         sura = 1;
@@ -220,7 +219,7 @@ public class JumpFragment extends DialogFragment {
   }
 
   /**
-   * ListAdapter that supports filtering by using case-insensitive infix (substring)
+   * ListAdapter that supports filtering by using case-insensitive infix (substring).
    */
   private static class InfixFilterArrayAdapter extends BaseAdapter implements Filterable {
     // May be extracted to other package
@@ -232,7 +231,7 @@ public class JumpFragment extends DialogFragment {
     private Filter filter = new ItemFilter();
     private final Object lock = new Object();
 
-    public InfixFilterArrayAdapter(@NonNull Context context, @LayoutRes int itemLayoutRes,
+    InfixFilterArrayAdapter(@NonNull Context context, @LayoutRes int itemLayoutRes,
                                    @NonNull String[] items) {
       this.items = originalItems = Arrays.asList(items);
       this.inflater = LayoutInflater.from(context);
@@ -271,7 +270,7 @@ public class JumpFragment extends DialogFragment {
     }
 
     /**
-     * Filter that do filtering by matching case-insensitive infix of the input
+     * Filter that do filtering by matching case-insensitive infix of the input.
      */
     private class ItemFilter extends Filter {
 

--- a/app/src/main/java/com/quran/labs/androidquran/widgets/ForceCompleteTextView.java
+++ b/app/src/main/java/com/quran/labs/androidquran/widgets/ForceCompleteTextView.java
@@ -1,0 +1,47 @@
+package com.quran.labs.androidquran.widgets;
+
+import android.content.Context;
+import android.graphics.Rect;
+import android.support.v7.widget.AppCompatAutoCompleteTextView;
+import android.util.AttributeSet;
+import android.widget.ListAdapter;
+
+/**
+ * AutoCompleteTextView that forces show the suggestion when focused and forces choose when
+ * unfocused
+ */
+public class ForceCompleteTextView extends AppCompatAutoCompleteTextView {
+  /** Thanks to those in http://stackoverflow.com/q/15544943/1197317 for inspiration */
+
+  public ForceCompleteTextView(Context context) {
+    super(context);
+  }
+
+  public ForceCompleteTextView(Context context, AttributeSet attrs) {
+    super(context, attrs);
+  }
+
+  public ForceCompleteTextView(Context context, AttributeSet attrs, int defStyleAttr) {
+    super(context, attrs, defStyleAttr);
+  }
+
+  @Override
+  public boolean enoughToFilter() {
+    // Break the limit of minimum 1
+    return true;
+  }
+
+  @Override
+  protected void onFocusChanged(boolean focused, int direction, Rect previouslyFocusedRect) {
+    super.onFocusChanged(focused, direction, previouslyFocusedRect);
+    if (focused) {
+      performFiltering(getText(), 0);
+      showDropDown();
+    } else {
+      ListAdapter adapter = getAdapter();
+      Object value = adapter.isEmpty() ? null : adapter.getItem(0);
+      setText(value == null ? null : value.toString());
+    }
+  }
+
+}

--- a/app/src/main/java/com/quran/labs/androidquran/widgets/ForceCompleteTextView.java
+++ b/app/src/main/java/com/quran/labs/androidquran/widgets/ForceCompleteTextView.java
@@ -4,14 +4,17 @@ import android.content.Context;
 import android.graphics.Rect;
 import android.support.v7.widget.AppCompatAutoCompleteTextView;
 import android.util.AttributeSet;
+import android.widget.AdapterView;
 import android.widget.ListAdapter;
 
 /**
  * AutoCompleteTextView that forces show the suggestion when focused and forces choose when
- * unfocused
+ * unfocused.
  */
 public class ForceCompleteTextView extends AppCompatAutoCompleteTextView {
   /** Thanks to those in http://stackoverflow.com/q/15544943/1197317 for inspiration */
+
+  private boolean allowOnItemClickWithNull = false;
 
   public ForceCompleteTextView(Context context) {
     super(context);
@@ -23,6 +26,18 @@ public class ForceCompleteTextView extends AppCompatAutoCompleteTextView {
 
   public ForceCompleteTextView(Context context, AttributeSet attrs, int defStyleAttr) {
     super(context, attrs, defStyleAttr);
+  }
+
+  /**
+   * Just like {@link #setOnItemClickListener(AdapterView.OnItemClickListener)}, but accepting null
+   * also causes the listener to be called when suggestion is auto-chosen (force choose), e.g. when
+   * user leaves without choosing.
+   * @param acceptNull whether the listener accept null to be passed as first two arguments
+   * @param l the listener
+   */
+  public void setOnItemClickListener(boolean acceptNull, AdapterView.OnItemClickListener l) {
+    setOnItemClickListener(l);
+    allowOnItemClickWithNull = acceptNull;
   }
 
   @Override
@@ -41,6 +56,11 @@ public class ForceCompleteTextView extends AppCompatAutoCompleteTextView {
       ListAdapter adapter = getAdapter();
       Object value = adapter.isEmpty() ? null : adapter.getItem(0);
       setText(value == null ? null : value.toString());
+
+      AdapterView.OnItemClickListener listener = getOnItemClickListener();
+      if (allowOnItemClickWithNull && listener != null) {
+        listener.onItemClick(null, null, 0, 0);
+      }
     }
   }
 

--- a/app/src/main/java/com/quran/labs/androidquran/widgets/ForceCompleteTextView.java
+++ b/app/src/main/java/com/quran/labs/androidquran/widgets/ForceCompleteTextView.java
@@ -5,15 +5,9 @@ import android.graphics.Rect;
 import android.support.v7.widget.AppCompatAutoCompleteTextView;
 import android.util.AttributeSet;
 import android.widget.AdapterView;
-import android.widget.ListAdapter;
 
 /**
- * AutoCompleteTextView that forces show the suggestion when focused and forces choose the
- * suggestion when unfocused. Force choose is done by calling the listener set by {@link
- * #setOnItemClickListener(AdapterView.OnItemClickListener)} with null for the first two arguments,
- * if there is at least one suggestion appears then the position would be 0 and the text will be the
- * first item appears, otherwise the position would be -1 and the text will be empty, the rest is
- * left to the listener.
+ * AutoCompleteTextView that forces to use value from one of the values in adapter (choices).
  */
 public class ForceCompleteTextView extends AppCompatAutoCompleteTextView {
   /* Thanks to those in http://stackoverflow.com/q/15544943/1197317 for inspiration */
@@ -31,6 +25,16 @@ public class ForceCompleteTextView extends AppCompatAutoCompleteTextView {
   }
 
   @Override
+  protected void onAttachedToWindow() {
+    super.onAttachedToWindow();
+
+    // TODO create relevant listener name, such as onSelectChoice
+    AdapterView.OnItemClickListener listener = getOnItemClickListener();
+    if (listener != null)
+      listener.onItemClick(null, null, -1, -1);
+  }
+
+  @Override
   public boolean enoughToFilter() {
     // Break the limit of minimum 1
     return true;
@@ -42,18 +46,10 @@ public class ForceCompleteTextView extends AppCompatAutoCompleteTextView {
     if (focused) {
       performFiltering(getText(), 0);
     } else {
-      ListAdapter adapter = getAdapter();
+      // TODO create relevant listener name, such as onSelectChoice
       AdapterView.OnItemClickListener listener = getOnItemClickListener();
-      if (adapter.isEmpty()) {
-        setText(null);
-        if (listener != null)
-          listener.onItemClick(null, null, -1, -1);
-      } else {
-        Object value = adapter.getItem(0);
-        setText(value == null ? null : value.toString());
-        if (listener != null)
-          listener.onItemClick(null, null, 0, 0);
-      }
+      if (listener != null)
+        listener.onItemClick(null, null, -1, -1);
     }
   }
 

--- a/app/src/main/res/layout/jump_dialog.xml
+++ b/app/src/main/res/layout/jump_dialog.xml
@@ -32,7 +32,7 @@
       android:layout_height="wrap_content"
       android:orientation="horizontal">
 
-    <com.quran.labs.androidquran.widgets.QuranSpinner
+    <AutoCompleteTextView
         android:id="@+id/sura_spinner"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
@@ -40,7 +40,7 @@
 
     <!-- 'minWidth' is in 'sp' because we actually need that width only
      to accommodate ayah numbers and avoid horizontal jiggering -->
-    <com.quran.labs.androidquran.widgets.QuranSpinner
+    <EditText
         android:id="@+id/ayah_spinner"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/app/src/main/res/layout/jump_dialog.xml
+++ b/app/src/main/res/layout/jump_dialog.xml
@@ -32,11 +32,13 @@
       android:layout_height="wrap_content"
       android:orientation="horizontal">
 
-    <AutoCompleteTextView
+    <com.quran.labs.androidquran.widgets.ForceCompleteTextView
         android:id="@+id/sura_spinner"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_weight="1"/>
+        android:layout_weight="1"
+        android:inputType="text|textAutoComplete"
+        android:selectAllOnFocus="true"/>
 
     <!-- 'minWidth' is in 'sp' because we actually need that width only
      to accommodate ayah numbers and avoid horizontal jiggering -->
@@ -45,6 +47,8 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:gravity="center"
-        android:minWidth="64sp"/>
+        android:minWidth="64sp"
+        android:inputType="number"
+        android:selectAllOnFocus="true"/>
   </LinearLayout>
 </LinearLayout>


### PR DESCRIPTION
This is the proposal that we've discussed in issue #799.

I want to note that:

1. I assume that all Android devices' numeric soft keyboard use Western Arabic digits (123...) instead of Eastern Arabic digits (١٢٣...), so that ayah number uses Western Arabic digits.
2. When testing by using Arabic, typing "ا-ل-أ-ع" does not make "الأعراف" to show up. It turns out that the sura names in string resource are not normalized, so I've a suggestion to normalize them, probably by using [NFKC](http://unicode.org/reports/tr15/#Norm_Forms). Other issue is that some sura such as الإنفطار is written as `الانفطار`, even comparing by using collator with `PRIMARY` strength will not treat them as equal string.
3. There is a method and a class which can be extracted out of `JumpFragment`, but I am not really sure.
4. I've not renamed the variables and layout IDs yet, to make minimum changes for this prototype.