### PR TITLE
Do not show duplicate translation upgrade dialog

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/ui/QuranActivity.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/QuranActivity.java
@@ -286,6 +286,9 @@ public class QuranActivity extends QuranActionBarActivity
   }
 
   private void showTranslationsUpgradeDialog() {
+    if (upgradeDialog != null && upgradeDialog.isShowing()) {
+      return;
+    }
     showedTranslationUpgradeDialog = true;
     AlertDialog.Builder builder = new AlertDialog.Builder(this);
     builder.setMessage(R.string.translation_updates_available);


### PR DESCRIPTION
When there is an update, "Translations update available" dialog is shown two times. This checks if the dialog is already being displayed.