### PR TITLE
Fix issue #809 Quran spinner  layout width

### DIFF
--- a/app/src/main/res/layout/quran_page_activity.xml
+++ b/app/src/main/res/layout/quran_page_activity.xml
@@ -40,7 +40,7 @@
         >
       <com.quran.labs.androidquran.widgets.QuranSpinner
           android:id="@+id/spinner"
-          android:layout_width="wrap_content"
+          android:layout_width="fill_parent"
           android:layout_height="wrap_content"
           android:visibility="gone"
           />

--- a/app/src/main/res/layout/quran_page_activity.xml
+++ b/app/src/main/res/layout/quran_page_activity.xml
@@ -40,7 +40,7 @@
         >
       <com.quran.labs.androidquran.widgets.QuranSpinner
           android:id="@+id/spinner"
-          android:layout_width="fill_parent"
+          android:layout_width="match_parent"
           android:layout_height="wrap_content"
           android:visibility="gone"
           />


### PR DESCRIPTION
translation names cut off in spinner
This seems to provide the maximum width available in the title area. 
I disabled the code to calculate width.
I think it is only measuring the linear layout and not the views inside the layout. 
