### PR TITLE
Fix issue #809 Quran spinner  layout width match parent

### DIFF
--- a/app/src/main/res/layout/quran_page_activity.xml
+++ b/app/src/main/res/layout/quran_page_activity.xml
@@ -40,7 +40,7 @@
         >
       <com.quran.labs.androidquran.widgets.QuranSpinner
           android:id="@+id/spinner"
-          android:layout_width="wrap_content"
+          android:layout_width="match_parent"
           android:layout_height="wrap_content"
           android:visibility="gone"
           />


### PR DESCRIPTION
translation names cut off in spinner 
Using match parent and leaving code in Quran spinner unmodified. 