### PR TITLE
Fix comma problem in the Juz' list page (for Farsi, Arabic, etc.).

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/ui/fragment/JuzListFragment.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/fragment/JuzListFragment.java
@@ -123,9 +123,8 @@ public class JuzListFragment extends Fragment {
         elements[ctr++] = builder.build();
       }
 
-      final String verseString = getString(R.string.quran_ayah, pos[1]);
-      final String metadata =
-          QuranInfo.getSuraName(activity, pos[0], true) +  ", " + verseString;
+      final String metadata = getString(R.string.sura_ayah_notification_str, 
+          QuranInfo.getSuraName(activity, pos[0], false), pos[1]);
       final QuranRow.Builder builder = new QuranRow.Builder()
           .withText(quarters[i])
           .withMetadata(metadata)


### PR DESCRIPTION
Currently the English comma is used, which is  incorrect.  #860 

To fix, I switched to use 'sura_ayah_notification_str' instead of building the string ad-hoc.