### PR TITLE
Remove "plural_recent_pages" from values-in/strings.xml

### DIFF
--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -307,10 +307,6 @@
   <string name="undo">Urungkan</string>
 
   <string name="recent_pages">Halaman terakhir</string>
-  <plurals name="plural_recent_pages">
-    <item quantity="one">@string/menu_jump_last_page</item>
-    <item quantity="other">@string/recent_pages</item>
-  </plurals>
 
   <!-- tag dialog -->
   <string name="tag_dlg_title">Label</string>


### PR DESCRIPTION
There are two reasons for removal:
 1. `"plural_recent_pages"` is set as `translatable="false"` in `values/strings.xml`.
 2. `"one"` quantity is irrelevant in Indonesian, so it needs a proper revision.