### PR TITLE
Fix strange behaviour of Jump dialog on re-creation

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/ui/PagerActivity.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/PagerActivity.java
@@ -78,6 +78,7 @@ import com.quran.labs.androidquran.ui.fragment.TranslationFragment;
 import com.quran.labs.androidquran.ui.helpers.AyahSelectedListener;
 import com.quran.labs.androidquran.ui.helpers.AyahTracker;
 import com.quran.labs.androidquran.ui.helpers.HighlightType;
+import com.quran.labs.androidquran.ui.helpers.JumpDestination;
 import com.quran.labs.androidquran.ui.helpers.QuranDisplayHelper;
 import com.quran.labs.androidquran.ui.helpers.QuranPage;
 import com.quran.labs.androidquran.ui.helpers.QuranPageAdapter;
@@ -125,7 +126,8 @@ public class PagerActivity extends QuranActionBarActivity implements
     AudioStatusBar.AudioBarListener,
     DefaultDownloadReceiver.DownloadListener,
     TagBookmarkDialog.OnBookmarkTagsUpdateListener,
-    AyahSelectedListener {
+    AyahSelectedListener,
+    JumpDestination {
   private static final String AUDIO_DOWNLOAD_KEY = "AUDIO_DOWNLOAD_KEY";
   private static final String LAST_AUDIO_DL_REQUEST = "LAST_AUDIO_DL_REQUEST";
   private static final String LAST_READ_PAGE = "LAST_READ_PAGE";
@@ -799,12 +801,14 @@ public class PagerActivity extends QuranActionBarActivity implements
     }
   }
 
+  @Override
   public void jumpTo(int page) {
     Intent i = new Intent(this, PagerActivity.class);
     i.putExtra("page", page);
     onNewIntent(i);
   }
 
+  @Override
   public void jumpToAndHighlight(int page, int sura, int ayah) {
     Intent i = new Intent(this, PagerActivity.class);
     i.putExtra("page", page);

--- a/app/src/main/java/com/quran/labs/androidquran/ui/QuranActivity.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/QuranActivity.java
@@ -41,6 +41,7 @@ import com.quran.labs.androidquran.ui.fragment.JumpFragment;
 import com.quran.labs.androidquran.ui.fragment.JuzListFragment;
 import com.quran.labs.androidquran.ui.fragment.SuraListFragment;
 import com.quran.labs.androidquran.ui.fragment.TagBookmarkDialog;
+import com.quran.labs.androidquran.ui.helpers.JumpDestination;
 import com.quran.labs.androidquran.util.AudioUtils;
 import com.quran.labs.androidquran.util.QuranSettings;
 import com.quran.labs.androidquran.util.QuranUtils;
@@ -54,7 +55,7 @@ import io.reactivex.disposables.CompositeDisposable;
 import timber.log.Timber;
 
 public class QuranActivity extends QuranActionBarActivity
-    implements TagBookmarkDialog.OnBookmarkTagsUpdateListener {
+    implements TagBookmarkDialog.OnBookmarkTagsUpdateListener, JumpDestination {
 
   private static int[] TITLES = new int[]{
       R.string.quran_sura,
@@ -314,6 +315,7 @@ public class QuranActivity extends QuranActionBarActivity
     startActivity(i);
   }
 
+  @Override
   public void jumpTo(int page) {
     Intent i = new Intent(this, PagerActivity.class);
     i.putExtra("page", page);
@@ -321,6 +323,7 @@ public class QuranActivity extends QuranActionBarActivity
     startActivity(i);
   }
 
+  @Override
   public void jumpToAndHighlight(int page, int sura, int ayah) {
     Intent i = new Intent(this, PagerActivity.class);
     i.putExtra("page", page);

--- a/app/src/main/java/com/quran/labs/androidquran/ui/fragment/JumpFragment.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/fragment/JumpFragment.java
@@ -84,7 +84,7 @@ public class JumpFragment extends DialogFragment {
       return handled;
     });
 
-    suraInput.setOnItemClickListener((parent, view, position, rowId) -> {
+    suraInput.setOnForceCompleteListener((v, position, rowId) -> {
       List<String> suraList = Arrays.asList(suras);
       String enteredText = suraInput.getText().toString();
 

--- a/app/src/main/java/com/quran/labs/androidquran/ui/fragment/JumpFragment.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/fragment/JumpFragment.java
@@ -26,8 +26,7 @@ import android.widget.TextView;
 import com.quran.labs.androidquran.R;
 import com.quran.labs.androidquran.data.Constants;
 import com.quran.labs.androidquran.data.QuranInfo;
-import com.quran.labs.androidquran.ui.PagerActivity;
-import com.quran.labs.androidquran.ui.QuranActivity;
+import com.quran.labs.androidquran.ui.helpers.JumpDestination;
 import com.quran.labs.androidquran.util.QuranUtils;
 import com.quran.labs.androidquran.widgets.ForceCompleteTextView;
 
@@ -156,10 +155,8 @@ public class JumpFragment extends DialogFragment {
           int selectedSura = (int) suraInput.getTag();
           int selectedAyah = (int) ayahInput.getTag();
 
-          if (activity instanceof QuranActivity) {
-            ((QuranActivity) activity).jumpToAndHighlight(page, selectedSura, selectedAyah);
-          } else if (activity instanceof PagerActivity) {
-            ((PagerActivity) activity).jumpToAndHighlight(page, selectedSura, selectedAyah);
+          if (activity instanceof JumpDestination) {
+            ((JumpDestination) activity).jumpToAndHighlight(page, selectedSura, selectedAyah);
           }
         } else {
           goToPage(pageStr);
@@ -197,10 +194,8 @@ public class JumpFragment extends DialogFragment {
     }
 
     Activity activity = getActivity();
-    if (activity instanceof QuranActivity) {
-      ((QuranActivity) activity).jumpTo(page);
-    } else if (activity instanceof PagerActivity) {
-      ((PagerActivity) activity).jumpTo(page);
+    if (activity instanceof JumpDestination) {
+      ((JumpDestination) activity).jumpTo(page);
     }
   }
 

--- a/app/src/main/java/com/quran/labs/androidquran/ui/helpers/JumpDestination.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/helpers/JumpDestination.java
@@ -1,0 +1,10 @@
+package com.quran.labs.androidquran.ui.helpers;
+
+/**
+ * Activity or fragment implements this is meant to be a jump destination/target.
+ */
+public interface JumpDestination {
+  void jumpTo(int page);
+
+  void jumpToAndHighlight(int page, int sura, int ayah);
+}

--- a/app/src/main/java/com/quran/labs/androidquran/widgets/ForceCompleteTextView.java
+++ b/app/src/main/java/com/quran/labs/androidquran/widgets/ForceCompleteTextView.java
@@ -69,6 +69,12 @@ public class ForceCompleteTextView extends AppCompatAutoCompleteTextView {
     });
   }
 
+  /**
+   * Do not call this method, use {@link #setOnForceCompleteListener(OnForceCompleteListener)}
+   * instead.
+   *
+   * @throws UnsupportedOperationException if called
+   */
   @Override
   public void setOnItemClickListener(AdapterView.OnItemClickListener l) {
     throw new UnsupportedOperationException("Call setOnForceCompleteListener instead");

--- a/app/src/main/java/com/quran/labs/androidquran/widgets/ForceCompleteTextView.java
+++ b/app/src/main/java/com/quran/labs/androidquran/widgets/ForceCompleteTextView.java
@@ -2,6 +2,7 @@ package com.quran.labs.androidquran.widgets;
 
 import android.content.Context;
 import android.graphics.Rect;
+import android.support.annotation.Nullable;
 import android.support.v7.widget.AppCompatAutoCompleteTextView;
 import android.util.AttributeSet;
 import android.widget.AdapterView;
@@ -12,26 +13,31 @@ import android.widget.AdapterView;
 public class ForceCompleteTextView extends AppCompatAutoCompleteTextView {
   /* Thanks to those in http://stackoverflow.com/q/15544943/1197317 for inspiration */
 
+  private @Nullable OnForceCompleteListener onForceCompleteListener;
+
   public ForceCompleteTextView(Context context) {
     super(context);
+    init();
   }
 
   public ForceCompleteTextView(Context context, AttributeSet attrs) {
     super(context, attrs);
+    init();
   }
 
   public ForceCompleteTextView(Context context, AttributeSet attrs, int defStyleAttr) {
     super(context, attrs, defStyleAttr);
+    init();
   }
 
-  @Override
-  protected void onAttachedToWindow() {
-    super.onAttachedToWindow();
+  private void init() {
+    super.setOnItemClickListener((parent, view, position, id) -> onForceComplete(position, id));
+  }
 
-    // TODO create relevant listener name, such as onSelectChoice
-    AdapterView.OnItemClickListener listener = getOnItemClickListener();
-    if (listener != null)
-      listener.onItemClick(null, null, -1, -1);
+  protected void onForceComplete(int position, long rowId) {
+    if (onForceCompleteListener != null) {
+      onForceCompleteListener.onForceComplete(this, position, rowId);
+    }
   }
 
   @Override
@@ -46,23 +52,33 @@ public class ForceCompleteTextView extends AppCompatAutoCompleteTextView {
     if (focused) {
       performFiltering(getText(), 0);
     } else {
-      // TODO create relevant listener name, such as onSelectChoice
-      AdapterView.OnItemClickListener listener = getOnItemClickListener();
-      if (listener != null)
-        listener.onItemClick(null, null, -1, -1);
+      onForceComplete(-1, AdapterView.INVALID_ROW_ID);
     }
   }
 
   /**
-   * Sets the listener that will be notified when the user clicks an item in the drop down list,
-   * user leaves without clicking, or when this view is attached to window. The two latter cases you
-   * use to force the completion, the listener will be called with position argument set to -1 and
-   * view argument set to null.
-   *
-   * @param l the item click listener
+   * Sets the listener that will be called to do force completion ({@link #onForceComplete(int,
+   * long)}).
    */
+  public void setOnForceCompleteListener(@Nullable OnForceCompleteListener l) {
+    this.onForceCompleteListener = l;
+    post(() -> {
+      if (!isFocused()) {
+        onForceComplete(-2, AdapterView.INVALID_ROW_ID);
+      }
+    });
+  }
+
   @Override
   public void setOnItemClickListener(AdapterView.OnItemClickListener l) {
-    super.setOnItemClickListener(l);
+    throw new UnsupportedOperationException("Call setOnForceCompleteListener instead");
+  }
+
+  public interface OnForceCompleteListener {
+    /**
+     * @param position position the user selects or a negative value if nothing is selected
+     * @param rowId    corresponding item's ID of the position
+     */
+    void onForceComplete(ForceCompleteTextView view, int position, long rowId);
   }
 }

--- a/app/src/main/java/com/quran/labs/androidquran/widgets/ForceCompleteTextView.java
+++ b/app/src/main/java/com/quran/labs/androidquran/widgets/ForceCompleteTextView.java
@@ -52,7 +52,7 @@ public class ForceCompleteTextView extends AppCompatAutoCompleteTextView {
     if (focused) {
       performFiltering(getText(), 0);
     } else {
-      onForceComplete(-1, AdapterView.INVALID_ROW_ID);
+      onForceComplete(AdapterView.INVALID_POSITION, AdapterView.INVALID_ROW_ID);
     }
   }
 
@@ -64,7 +64,7 @@ public class ForceCompleteTextView extends AppCompatAutoCompleteTextView {
     this.onForceCompleteListener = l;
     post(() -> {
       if (!isFocused()) {
-        onForceComplete(-2, AdapterView.INVALID_ROW_ID);
+        onForceComplete(AdapterView.INVALID_POSITION, AdapterView.INVALID_ROW_ID);
       }
     });
   }


### PR DESCRIPTION
Issue:

- When user types sura name in Jump dialog (and completion/suggestion drop down displays) and then rotates the screen, it forces complete instead of displaying the drop down just like before.

Changes:

- Use a new approach instead of `onAttachedToWindow`.
- Create a specific event name instead of "borrowing" `onItemClick`.