### PR TITLE
Retain scroll position

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/presenter/translation/TranslationPresenter.java
+++ b/app/src/main/java/com/quran/labs/androidquran/presenter/translation/TranslationPresenter.java
@@ -53,6 +53,7 @@ public class TranslationPresenter extends
             if (translationScreen != null && result.ayahInformation.size() > 0) {
               translationScreen.setVerses(
                   getPage(result.ayahInformation), result.translations, result.ayahInformation);
+              translationScreen.updateScrollPosition();
             }
           }
 
@@ -102,5 +103,6 @@ public class TranslationPresenter extends
 
   public interface TranslationScreen {
     void setVerses(int page, @NonNull String[] translations, @NonNull List<QuranAyahInfo> verses);
+    void updateScrollPosition();
   }
 }

--- a/app/src/main/java/com/quran/labs/androidquran/ui/fragment/TabletFragment.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/fragment/TabletFragment.java
@@ -7,6 +7,7 @@ import android.graphics.RectF;
 import android.graphics.drawable.BitmapDrawable;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.support.annotation.StringRes;
 import android.support.v4.app.Fragment;
 import android.view.LayoutInflater;
@@ -57,6 +58,11 @@ public class TabletFragment extends Fragment
     OnTranslationActionListener {
   private static final String FIRST_PAGE_EXTRA = "pageNumber";
   private static final String MODE_EXTRA = "mode";
+  private static final String SI_LEFT_TRANSLATION_SCROLL_POSITION
+      = "SI_LEFT_TRANSLATION_SCROLL_POSITION";
+  private static final String SI_RIGHT_TRANSLATION_SCROLL_POSITION
+      = "SI_RIGHT_TRANSLATION_SCROLL_POSITION";
+
 
   public static class Mode {
     public static final int ARABIC = 1;
@@ -65,7 +71,10 @@ public class TabletFragment extends Fragment
 
   private int mode;
   private int pageNumber;
+  private int leftTranslationScrollPosition;
+  private int rightTranslationScrollPositon;
   private boolean ayahCoordinatesError;
+
   private TabletView mainView;
   private TranslationView leftTranslation;
   private TranslationView rightTranslation;
@@ -87,6 +96,16 @@ public class TabletFragment extends Fragment
     args.putInt(MODE_EXTRA, mode);
     f.setArguments(args);
     return f;
+  }
+
+  @Override
+  public void onCreate(@Nullable Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    if (savedInstanceState != null) {
+      leftTranslationScrollPosition = savedInstanceState.getInt(SI_LEFT_TRANSLATION_SCROLL_POSITION);
+      rightTranslationScrollPositon = savedInstanceState.getInt(
+          SI_RIGHT_TRANSLATION_SCROLL_POSITION);
+    }
   }
 
   @Override
@@ -129,6 +148,15 @@ public class TabletFragment extends Fragment
   }
 
   @Override
+  public void onPause() {
+    if (mode == Mode.TRANSLATION) {
+      leftTranslationScrollPosition = leftTranslation.findFirstCompletelyVisibleItemPosition();
+      rightTranslationScrollPositon = rightTranslation.findFirstCompletelyVisibleItemPosition();
+    }
+    super.onPause();
+  }
+
+  @Override
   public void onStop() {
     ayahTrackerPresenter.unbind(this);
     if (mode == Mode.ARABIC) {
@@ -147,6 +175,17 @@ public class TabletFragment extends Fragment
       rightTranslation.refresh(quranSettings);
       leftTranslation.refresh(quranSettings);
     }
+  }
+
+  @Override
+  public void onSaveInstanceState(Bundle outState) {
+    if (mode == Mode.TRANSLATION) {
+      outState.putInt(SI_LEFT_TRANSLATION_SCROLL_POSITION,
+          leftTranslation.findFirstCompletelyVisibleItemPosition());
+      outState.putInt(SI_RIGHT_TRANSLATION_SCROLL_POSITION,
+          rightTranslation.findFirstCompletelyVisibleItemPosition());
+    }
+    super.onSaveInstanceState(outState);
   }
 
   @Override
@@ -250,6 +289,12 @@ public class TabletFragment extends Fragment
     } else if (page == pageNumber - 1) {
       rightTranslation.setVerses(translations, verses);
     }
+  }
+
+  @Override
+  public void updateScrollPosition() {
+    leftTranslation.setScrollPosition(leftTranslationScrollPosition);
+    rightTranslation.setScrollPosition(rightTranslationScrollPositon);
   }
 
   public void refresh() {

--- a/app/src/main/java/com/quran/labs/androidquran/ui/fragment/TabletFragment.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/fragment/TabletFragment.java
@@ -58,8 +58,6 @@ public class TabletFragment extends Fragment
     OnTranslationActionListener {
   private static final String FIRST_PAGE_EXTRA = "pageNumber";
   private static final String MODE_EXTRA = "mode";
-  private static final String SI_LEFT_TRANSLATION_SCROLL_POSITION
-      = "SI_LEFT_TRANSLATION_SCROLL_POSITION";
   private static final String SI_RIGHT_TRANSLATION_SCROLL_POSITION
       = "SI_RIGHT_TRANSLATION_SCROLL_POSITION";
 
@@ -70,8 +68,7 @@ public class TabletFragment extends Fragment
 
   private int mode;
   private int pageNumber;
-  private int leftTranslationScrollPosition;
-  private int rightTranslationScrollPositon;
+  private int rightPageTranslationScrollPositon;
   private boolean ayahCoordinatesError;
 
   private TabletView mainView;
@@ -101,8 +98,7 @@ public class TabletFragment extends Fragment
   public void onCreate(@Nullable Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
     if (savedInstanceState != null) {
-      leftTranslationScrollPosition = savedInstanceState.getInt(SI_LEFT_TRANSLATION_SCROLL_POSITION);
-      rightTranslationScrollPositon = savedInstanceState.getInt(
+      rightPageTranslationScrollPositon = savedInstanceState.getInt(
           SI_RIGHT_TRANSLATION_SCROLL_POSITION);
     }
   }
@@ -149,8 +145,7 @@ public class TabletFragment extends Fragment
   @Override
   public void onPause() {
     if (mode == Mode.TRANSLATION) {
-      leftTranslationScrollPosition = leftTranslation.findFirstCompletelyVisibleItemPosition();
-      rightTranslationScrollPositon = rightTranslation.findFirstCompletelyVisibleItemPosition();
+      rightPageTranslationScrollPositon = rightTranslation.findFirstCompletelyVisibleItemPosition();
     }
     super.onPause();
   }
@@ -179,8 +174,6 @@ public class TabletFragment extends Fragment
   @Override
   public void onSaveInstanceState(Bundle outState) {
     if (mode == Mode.TRANSLATION) {
-      outState.putInt(SI_LEFT_TRANSLATION_SCROLL_POSITION,
-          leftTranslation.findFirstCompletelyVisibleItemPosition());
       outState.putInt(SI_RIGHT_TRANSLATION_SCROLL_POSITION,
           rightTranslation.findFirstCompletelyVisibleItemPosition());
     }
@@ -292,8 +285,7 @@ public class TabletFragment extends Fragment
 
   @Override
   public void updateScrollPosition() {
-    leftTranslation.setScrollPosition(leftTranslationScrollPosition);
-    rightTranslation.setScrollPosition(rightTranslationScrollPositon);
+    rightTranslation.setScrollPosition(rightPageTranslationScrollPositon);
   }
 
   public void refresh() {

--- a/app/src/main/java/com/quran/labs/androidquran/ui/fragment/TabletFragment.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/fragment/TabletFragment.java
@@ -63,7 +63,6 @@ public class TabletFragment extends Fragment
   private static final String SI_RIGHT_TRANSLATION_SCROLL_POSITION
       = "SI_RIGHT_TRANSLATION_SCROLL_POSITION";
 
-
   public static class Mode {
     public static final int ARABIC = 1;
     public static final int TRANSLATION = 2;

--- a/app/src/main/java/com/quran/labs/androidquran/ui/fragment/TranslationFragment.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/fragment/TranslationFragment.java
@@ -35,9 +35,12 @@ public class TranslationFragment extends Fragment implements
 
   private static final String SI_PAGE_NUMBER = "SI_PAGE_NUMBER";
   private static final String SI_HIGHLIGHTED_AYAH = "SI_HIGHLIGHTED_AYAH";
+  private static final String SI_SCROLL_POSITION = "SI_SCROLL_POSITION";
 
   private int pageNumber;
   private int highlightedAyah;
+  private int scrollPosition;
+
   private TranslationView translationView;
   private QuranTranslationPageLayout mainView;
   private AyahTrackerItem[] ayahTrackerItems;
@@ -67,6 +70,7 @@ public class TranslationFragment extends Fragment implements
           this.highlightedAyah = highlightedAyah;
         }
       }
+      scrollPosition = savedInstanceState.getInt(SI_SCROLL_POSITION);
     }
     setHasOptionsMenu(true);
   }
@@ -134,6 +138,22 @@ public class TranslationFragment extends Fragment implements
   }
 
   @Override
+  public void onResume() {
+    super.onResume();
+    ayahTrackerPresenter.bind(this);
+    presenter.bind(this);
+    updateView();
+  }
+
+  @Override
+  public void onPause() {
+    scrollPosition = translationView.findFirstCompletelyVisibleItemPosition();
+    ayahTrackerPresenter.unbind(this);
+    presenter.unbind(this);
+    super.onPause();
+  }
+
+  @Override
   public void setVerses(int page,
                         @NonNull String[] translations,
                         @NonNull List<QuranAyahInfo> verses) {
@@ -144,18 +164,8 @@ public class TranslationFragment extends Fragment implements
   }
 
   @Override
-  public void onResume() {
-    super.onResume();
-    ayahTrackerPresenter.bind(this);
-    presenter.bind(this);
-    updateView();
-  }
-
-  @Override
-  public void onPause() {
-    ayahTrackerPresenter.unbind(this);
-    presenter.unbind(this);
-    super.onPause();
+  public void updateScrollPosition() {
+    translationView.setScrollPosition(scrollPosition);
   }
 
   public void refresh() {
@@ -167,6 +177,7 @@ public class TranslationFragment extends Fragment implements
     if (highlightedAyah > 0) {
       outState.putInt(SI_HIGHLIGHTED_AYAH, highlightedAyah);
     }
+    outState.putInt(SI_SCROLL_POSITION, translationView.findFirstCompletelyVisibleItemPosition());
     super.onSaveInstanceState(outState);
   }
 }

--- a/app/src/main/java/com/quran/labs/androidquran/ui/fragment/TranslationFragment.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/fragment/TranslationFragment.java
@@ -147,7 +147,6 @@ public class TranslationFragment extends Fragment implements
 
   @Override
   public void onPause() {
-    scrollPosition = translationView.findFirstCompletelyVisibleItemPosition();
     ayahTrackerPresenter.unbind(this);
     presenter.unbind(this);
     super.onPause();
@@ -177,7 +176,8 @@ public class TranslationFragment extends Fragment implements
     if (highlightedAyah > 0) {
       outState.putInt(SI_HIGHLIGHTED_AYAH, highlightedAyah);
     }
-    outState.putInt(SI_SCROLL_POSITION, translationView.findFirstCompletelyVisibleItemPosition());
+    scrollPosition = translationView.findFirstCompletelyVisibleItemPosition();
+    outState.putInt(SI_SCROLL_POSITION, scrollPosition);
     super.onSaveInstanceState(outState);
   }
 }

--- a/app/src/main/java/com/quran/labs/androidquran/ui/translation/TranslationView.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/translation/TranslationView.java
@@ -29,7 +29,7 @@ public class TranslationView extends FrameLayout implements View.OnClickListener
   private QuranAyahInfo selectedAyah;
   private OnClickListener onClickListener;
   private OnTranslationActionListener onTranslationActionListener;
-  private LinearLayoutManager mLayoutManager;
+  private LinearLayoutManager layoutManager;
 
   public TranslationView(Context context) {
     this(context, null);
@@ -42,8 +42,8 @@ public class TranslationView extends FrameLayout implements View.OnClickListener
   public TranslationView(Context context, AttributeSet attrs, int defStyleAttr) {
     super(context, attrs, defStyleAttr);
     RecyclerView translationRecycler = new RecyclerView(context);
-    mLayoutManager = new LinearLayoutManager(context);
-    translationRecycler.setLayoutManager(mLayoutManager);
+    layoutManager = new LinearLayoutManager(context);
+    translationRecycler.setLayoutManager(layoutManager);
     translationRecycler.setItemAnimator(new DefaultItemAnimator());
     translationAdapter = new TranslationAdapter(context, translationRecycler, this, this);
     translationRecycler.setAdapter(translationAdapter);
@@ -190,10 +190,10 @@ public class TranslationView extends FrameLayout implements View.OnClickListener
   }
 
   public int findFirstCompletelyVisibleItemPosition() {
-    return mLayoutManager.findFirstCompletelyVisibleItemPosition();
+    return layoutManager.findFirstCompletelyVisibleItemPosition();
   }
 
   public void setScrollPosition(int position) {
-    mLayoutManager.scrollToPosition(position);
+    layoutManager.scrollToPosition(position);
   }
 }

--- a/app/src/main/java/com/quran/labs/androidquran/ui/translation/TranslationView.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/translation/TranslationView.java
@@ -29,6 +29,7 @@ public class TranslationView extends FrameLayout implements View.OnClickListener
   private QuranAyahInfo selectedAyah;
   private OnClickListener onClickListener;
   private OnTranslationActionListener onTranslationActionListener;
+  private LinearLayoutManager mLayoutManager;
 
   public TranslationView(Context context) {
     this(context, null);
@@ -41,7 +42,8 @@ public class TranslationView extends FrameLayout implements View.OnClickListener
   public TranslationView(Context context, AttributeSet attrs, int defStyleAttr) {
     super(context, attrs, defStyleAttr);
     RecyclerView translationRecycler = new RecyclerView(context);
-    translationRecycler.setLayoutManager(new LinearLayoutManager(context));
+    mLayoutManager = new LinearLayoutManager(context);
+    translationRecycler.setLayoutManager(mLayoutManager);
     translationRecycler.setItemAnimator(new DefaultItemAnimator());
     translationAdapter = new TranslationAdapter(context, translationRecycler, this, this);
     translationRecycler.setAdapter(translationAdapter);
@@ -185,5 +187,13 @@ public class TranslationView extends FrameLayout implements View.OnClickListener
   public void onVerseSelected(QuranAyahInfo ayahInfo) {
     selectedAyah = ayahInfo;
     updateAyahToolBarPosition();
+  }
+
+  public int findFirstCompletelyVisibleItemPosition() {
+    return mLayoutManager.findFirstCompletelyVisibleItemPosition();
+  }
+
+  public void setScrollPosition(int position) {
+    mLayoutManager.scrollToPosition(position);
   }
 }


### PR DESCRIPTION
retain scroll position on TranslationFragment and TabletFragment when device orientation changed
this commit should resolve issue #667 
known issue:
when translation page change from dual pages to single page in tablet mode, scroll position will not be retained.