### PR TITLE
Do not allow canceling storage permission rationale dialog

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/QuranDataActivity.java
+++ b/app/src/main/java/com/quran/labs/androidquran/QuranDataActivity.java
@@ -119,6 +119,7 @@ public class QuranDataActivity extends Activity implements
         //show permission rationale dialog
         permissionsDialog = new AlertDialog.Builder(this)
             .setMessage(R.string.storage_permission_rationale)
+            .setCancelable(false)
             .setPositiveButton(android.R.string.ok, (dialog, which) -> {
               dialog.dismiss();
               permissionsDialog = null;


### PR DESCRIPTION
Canceling or dismissing (e.g., by touching outside the dialog) this dialog leaves the UI in unusable (blank) state.