### PR TITLE
Fix no active translations case

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/ui/fragment/AyahTranslationFragment.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/fragment/AyahTranslationFragment.java
@@ -106,7 +106,7 @@ public class AyahTranslationFragment extends AyahActionFragment
     final Activity activity = getActivity();
     if (activity instanceof PagerActivity) {
       PagerActivity pagerActivity = (PagerActivity) activity;
-      if (translations == null) {
+      if (translations == null || translations.size() == 0) {
         translations = pagerActivity.getTranslations();
       }
 


### PR DESCRIPTION
This patch fixes the no active translations case by using all available
translations as active translations when there are no active
translations. Fixes #910.