### PR TITLE
Make QuranInfo usage non-static

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,14 @@ android:
    components:
       - tools
       - platform-tools
-      - build-tools-26.0.2
+      - build-tools-27.0.1
       - android-27
       - android-22 # required for emulator below
       - extra-android-m2repository
       - sys-img-armeabi-v7a-android-22
+
+before_install:
+  - yes | sdkmanager "platforms;android-27"
 
 before_script:
   # Create and start emulator

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,7 +6,7 @@ apply plugin: 'kotlin-kapt'
 
 android {
   compileSdkVersion 27
-  buildToolsVersion '26.0.2'
+  buildToolsVersion '27.0.1'
 
   lintOptions {
     checkReleaseBuilds true
@@ -114,7 +114,7 @@ android {
 
 ext {
   supportLibVersion = '27.0.2'
-  espressoVersion = '2.2.2'
+  espressoVersion = '3.0.1'
   okhttpVersion = '3.9.0'
   daggerVersion = '2.13'
 }
@@ -141,7 +141,6 @@ dependencies {
   testImplementation "com.squareup.okhttp3:mockwebserver:${okhttpVersion}"
   androidTestImplementation "com.android.support.test.espresso:espresso-core:${espressoVersion}"
   androidTestImplementation "com.android.support.test.espresso:espresso-intents:${espressoVersion}"
-  androidTestImplementation "com.android.support:support-annotations:${supportLibVersion}"
   implementation('com.crashlytics.sdk.android:crashlytics:2.7.1@aar') {
     transitive = true
   }

--- a/app/src/main/java/com/quran/labs/androidquran/QuranApplication.java
+++ b/app/src/main/java/com/quran/labs/androidquran/QuranApplication.java
@@ -9,6 +9,7 @@ import android.support.annotation.NonNull;
 
 import com.crashlytics.android.Crashlytics;
 import com.crashlytics.android.core.CrashlyticsCore;
+import com.quran.labs.androidquran.component.activity.PagerActivityComponent;
 import com.quran.labs.androidquran.component.application.DaggerApplicationComponent;
 import com.quran.labs.androidquran.component.application.ApplicationComponent;
 import com.quran.labs.androidquran.module.application.ApplicationModule;
@@ -22,6 +23,7 @@ import timber.log.Timber;
 
 public class QuranApplication extends Application {
   private ApplicationComponent applicationComponent;
+  private PagerActivityComponent pagerActivityComponent;
 
   @Override
   public void onCreate() {
@@ -74,5 +76,9 @@ public class QuranApplication extends Application {
       config.setLayoutDirection(config.locale);
     }
     resources.updateConfiguration(config, resources.getDisplayMetrics());
+  }
+
+  public PagerActivityComponent getPagerActivityComponent() {
+    return pagerActivityComponent;
   }
 }

--- a/app/src/main/java/com/quran/labs/androidquran/QuranForwarderActivity.java
+++ b/app/src/main/java/com/quran/labs/androidquran/QuranForwarderActivity.java
@@ -7,11 +7,15 @@ import android.os.Bundle;
 import com.quran.labs.androidquran.data.QuranInfo;
 import com.quran.labs.androidquran.ui.PagerActivity;
 
+import javax.inject.Inject;
+
 public class QuranForwarderActivity extends Activity {
+  @Inject QuranInfo quranInfo;
 
    @Override
    protected void onCreate(Bundle savedInstanceState) {
       super.onCreate(savedInstanceState);
+      ((QuranApplication) getApplication()).getApplicationComponent().inject(this);
 
       // handle urls of type quran://sura/ayah
       Intent intent = getIntent();
@@ -33,7 +37,7 @@ public class QuranForwarderActivity extends Activity {
             }
 
             if (sura != null){
-               int page = QuranInfo.getPageFromSuraAyah(sura, ayah);
+               int page = quranInfo.getPageFromSuraAyah(sura, ayah);
                Intent showSuraIntent = new Intent(this, PagerActivity.class);
                showSuraIntent.putExtra("page", page);
                showSuraIntent.putExtra(PagerActivity.EXTRA_HIGHLIGHT_SURA, sura);

--- a/app/src/main/java/com/quran/labs/androidquran/common/QuranAyahInfo.java
+++ b/app/src/main/java/com/quran/labs/androidquran/common/QuranAyahInfo.java
@@ -3,8 +3,6 @@ package com.quran.labs.androidquran.common;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
-import com.quran.labs.androidquran.data.QuranInfo;
-
 import java.util.Collections;
 import java.util.List;
 
@@ -23,11 +21,12 @@ public class QuranAyahInfo {
   public QuranAyahInfo(int sura,
                        int ayah,
                        @Nullable String arabicText,
-                       @NonNull List<String> texts) {
+                       @NonNull List<String> texts,
+                       int ayahId) {
     this.sura = sura;
     this.ayah = ayah;
     this.arabicText = arabicText;
     this.texts = Collections.unmodifiableList(texts);
-    this.ayahId = QuranInfo.getAyahId(sura, ayah);
+    this.ayahId = ayahId;
   }
 }

--- a/app/src/main/java/com/quran/labs/androidquran/component/application/ApplicationComponent.java
+++ b/app/src/main/java/com/quran/labs/androidquran/component/application/ApplicationComponent.java
@@ -6,7 +6,9 @@ import com.quran.labs.androidquran.data.QuranDataProvider;
 import com.quran.labs.androidquran.module.application.ApplicationModule;
 import com.quran.labs.androidquran.module.application.DatabaseModule;
 import com.quran.labs.androidquran.module.application.NetworkModule;
+import com.quran.labs.androidquran.service.AudioService;
 import com.quran.labs.androidquran.service.QuranDownloadService;
+import com.quran.labs.androidquran.ui.AudioManagerActivity;
 import com.quran.labs.androidquran.ui.QuranActivity;
 import com.quran.labs.androidquran.ui.TranslationManagerActivity;
 import com.quran.labs.androidquran.ui.fragment.AddTagDialog;
@@ -29,11 +31,13 @@ public interface ApplicationComponent {
   void inject(QuranDataProvider quranDataProvider);
 
   // services
+  void inject(AudioService audioService);
   void inject(QuranDownloadService quranDownloadService);
 
   // activities
   void inject(QuranActivity quranActivity);
   void inject(QuranImportActivity quranImportActivity);
+  void inject(AudioManagerActivity audioManagerActivity);
 
   // fragments
   void inject(BookmarksFragment bookmarksFragment);

--- a/app/src/main/java/com/quran/labs/androidquran/component/application/ApplicationComponent.java
+++ b/app/src/main/java/com/quran/labs/androidquran/component/application/ApplicationComponent.java
@@ -1,6 +1,8 @@
 package com.quran.labs.androidquran.component.application;
 
+import com.quran.labs.androidquran.QuranForwarderActivity;
 import com.quran.labs.androidquran.QuranImportActivity;
+import com.quran.labs.androidquran.SearchActivity;
 import com.quran.labs.androidquran.component.activity.PagerActivityComponent;
 import com.quran.labs.androidquran.data.QuranDataProvider;
 import com.quran.labs.androidquran.module.application.ApplicationModule;
@@ -12,9 +14,13 @@ import com.quran.labs.androidquran.ui.AudioManagerActivity;
 import com.quran.labs.androidquran.ui.QuranActivity;
 import com.quran.labs.androidquran.ui.TranslationManagerActivity;
 import com.quran.labs.androidquran.ui.fragment.AddTagDialog;
+import com.quran.labs.androidquran.ui.fragment.AyahPlaybackFragment;
 import com.quran.labs.androidquran.ui.fragment.BookmarksFragment;
+import com.quran.labs.androidquran.ui.fragment.JumpFragment;
+import com.quran.labs.androidquran.ui.fragment.JuzListFragment;
 import com.quran.labs.androidquran.ui.fragment.QuranAdvancedSettingsFragment;
 import com.quran.labs.androidquran.ui.fragment.QuranSettingsFragment;
+import com.quran.labs.androidquran.ui.fragment.SuraListFragment;
 import com.quran.labs.androidquran.ui.fragment.TagBookmarkDialog;
 
 import javax.inject.Singleton;
@@ -38,12 +44,18 @@ public interface ApplicationComponent {
   void inject(QuranActivity quranActivity);
   void inject(QuranImportActivity quranImportActivity);
   void inject(AudioManagerActivity audioManagerActivity);
+  void inject(QuranForwarderActivity quranForwarderActivity);
+  void inject(SearchActivity searchActivity);
 
   // fragments
   void inject(BookmarksFragment bookmarksFragment);
   void inject(QuranSettingsFragment fragment);
   void inject(TranslationManagerActivity translationManagerActivity);
   void inject(QuranAdvancedSettingsFragment quranAdvancedSettingsFragment);
+  void inject(SuraListFragment suraListFragment);
+  void inject(JuzListFragment juzListFragment);
+  void inject(AyahPlaybackFragment ayahPlaybackFragment);
+  void inject(JumpFragment jumpFragment);
 
   // dialogs
   void inject(TagBookmarkDialog tagBookmarkDialog);

--- a/app/src/main/java/com/quran/labs/androidquran/data/QuranDataProvider.java
+++ b/app/src/main/java/com/quran/labs/androidquran/data/QuranDataProvider.java
@@ -44,6 +44,7 @@ public class QuranDataProvider extends ContentProvider {
   private static final UriMatcher uriMatcher = buildUriMatcher();
 
   private boolean didInject;
+  @Inject QuranInfo quranInfo;
   @Inject TranslationsDBAdapter translationsDBAdapter;
 
   private static UriMatcher buildUriMatcher() {
@@ -163,7 +164,7 @@ public class QuranDataProvider extends ContentProvider {
             int ayah = suggestions.getInt(2);
             String text = suggestions.getString(3);
             String foundText = context.getString(
-                R.string.found_in_sura, QuranInfo.getSuraName(context, sura, false), ayah);
+                R.string.found_in_sura, quranInfo.getSuraName(context, sura, false), ayah);
 
             gotResults = true;
             MatrixCursor.RowBuilder row = mc.newRow();

--- a/app/src/main/java/com/quran/labs/androidquran/data/QuranInfo.java
+++ b/app/src/main/java/com/quran/labs/androidquran/data/QuranInfo.java
@@ -16,14 +16,14 @@ import static com.quran.labs.androidquran.data.Constants.PAGES_LAST;
 import static com.quran.labs.androidquran.data.Constants.PAGES_LAST_DUAL;
 
 public class QuranInfo {
-  private static int[] SURA_PAGE_START = QuranData.SURA_PAGE_START;
-  private static int[] PAGE_SURA_START = QuranData.PAGE_SURA_START;
-  private static int[] PAGE_AYAH_START = QuranData.PAGE_AYAH_START;
-  private static int[] JUZ_PAGE_START = QuranData.JUZ_PAGE_START;
-  private static int[] PAGE_RUB3_START = QuranData.PAGE_RUB3_START;
-  private static int[] SURA_NUM_AYAHS = QuranData.SURA_NUM_AYAHS;
-  private static boolean[] SURA_IS_MAKKI = QuranData.SURA_IS_MAKKI;
-  private static int[][] QUARTERS = QuranData.QUARTERS;
+  private static int[] suraPageStart = QuranData.SURA_PAGE_START;
+  private static int[] pageSuraStart = QuranData.PAGE_SURA_START;
+  private static int[] pageAyahStart = QuranData.PAGE_AYAH_START;
+  private static int[] juzPageStart = QuranData.JUZ_PAGE_START;
+  private static int[] pageRub3Start = QuranData.PAGE_RUB3_START;
+  private static int[] suraNumAyahs = QuranData.SURA_NUM_AYAHS;
+  private static boolean[] suraIsMakki = QuranData.SURA_IS_MAKKI;
+  private static int[][] quarters = QuranData.QUARTERS;
 
   /**
    * Get localized sura name from resources
@@ -74,20 +74,20 @@ public class QuranInfo {
   }
 
   public static int getStartingPageForJuz(int juz) {
-    return JUZ_PAGE_START[juz - 1];
+    return juzPageStart[juz - 1];
   }
 
   public static int getPageNumberForSura(int sura) {
-    return SURA_PAGE_START[sura - 1];
+    return suraPageStart[sura - 1];
   }
 
   public static int getSuraNumberFromPage(int page) {
     int sura = -1;
     for (int i = 0; i < Constants.SURAS_COUNT; i++) {
-      if (SURA_PAGE_START[i] == page) {
+      if (suraPageStart[i] == page) {
         sura = i + 1;
         break;
-      } else if (SURA_PAGE_START[i] > page) {
+      } else if (suraPageStart[i] > page) {
         sura = i;
         break;
       }
@@ -164,10 +164,10 @@ public class QuranInfo {
   }
 
   public static String getSuraListMetaString(Context context, int sura) {
-    String info = context.getString(QuranInfo.SURA_IS_MAKKI[sura - 1]
+    String info = context.getString(QuranInfo.suraIsMakki[sura - 1]
         ? R.string.makki : R.string.madani) + " - ";
 
-    int ayahs = QuranInfo.SURA_NUM_AYAHS[sura - 1];
+    int ayahs = QuranInfo.suraNumAyahs[sura - 1];
     info += context.getResources().getQuantityString(R.plurals.verses, ayahs,
         QuranUtils.getLocalizedNumber(context, ayahs));
     return info;
@@ -179,7 +179,7 @@ public class QuranInfo {
   }
 
   public static int getFirstAyahOnPage(int page) {
-    return QuranInfo.PAGE_AYAH_START[page - 1];
+    return QuranInfo.pageAyahStart[page - 1];
   }
 
   @NonNull
@@ -189,14 +189,14 @@ public class QuranInfo {
     if (page < 1) page = 1;
 
     int[] bounds = new int[4];
-    bounds[0] = PAGE_SURA_START[page - 1];
-    bounds[1] = PAGE_AYAH_START[page - 1];
+    bounds[0] = pageSuraStart[page - 1];
+    bounds[1] = pageAyahStart[page - 1];
     if (page == PAGES_LAST) {
       bounds[2] = Constants.SURA_LAST;
       bounds[3] = 6;
     } else {
-      int nextPageSura = PAGE_SURA_START[page];
-      int nextPageAyah = PAGE_AYAH_START[page];
+      int nextPageSura = pageSuraStart[page];
+      int nextPageAyah = pageAyahStart[page];
 
       if (nextPageSura == bounds[0]) {
         bounds[2] = bounds[0];
@@ -207,7 +207,7 @@ public class QuranInfo {
           bounds[3] = nextPageAyah - 1;
         } else {
           bounds[2] = nextPageSura - 1;
-          bounds[3] = SURA_NUM_AYAHS[bounds[2] - 1];
+          bounds[3] = suraNumAyahs[bounds[2] - 1];
         }
       }
     }
@@ -219,14 +219,14 @@ public class QuranInfo {
       Crashlytics.logException(new IllegalArgumentException("got page: " + page));
       page = 1;
     }
-    return PAGE_SURA_START[page - 1];
+    return pageSuraStart[page - 1];
   }
 
   public static String getSuraNameFromPage(Context context, int page) {
     for (int i = 0; i < Constants.SURAS_COUNT; i++) {
-      if (SURA_PAGE_START[i] == page) {
+      if (suraPageStart[i] == page) {
         return getSuraName(context, i + 1, false, false);
-      } else if (SURA_PAGE_START[i] > page) {
+      } else if (suraPageStart[i] > page) {
         return getSuraName(context, i, false, false);
       }
     }
@@ -234,8 +234,8 @@ public class QuranInfo {
   }
 
   public static int getJuzFromPage(int page) {
-    for (int i = 0; i < JUZ_PAGE_START.length; i++) {
-      if (JUZ_PAGE_START[i] >= page) {
+    for (int i = 0; i < juzPageStart.length; i++) {
+      if (juzPageStart[i] >= page) {
         return i + 1;
       }
     }
@@ -244,7 +244,7 @@ public class QuranInfo {
 
   public static int getRub3FromPage(int page) {
     if ((page > PAGES_LAST) || (page < 1)) return -1;
-    return PAGE_RUB3_START[page - 1];
+    return pageRub3Start[page - 1];
   }
 
   public static int getPageFromSuraAyah(int sura, int ayah) {
@@ -256,15 +256,15 @@ public class QuranInfo {
       return -1;
 
     // what page does the sura start on?
-    int index = QuranInfo.SURA_PAGE_START[sura - 1] - 1;
+    int index = QuranInfo.suraPageStart[sura - 1] - 1;
     while (index < PAGES_LAST) {
       // what's the first sura in that page?
-      int ss = QuranInfo.PAGE_SURA_START[index];
+      int ss = QuranInfo.pageSuraStart[index];
 
       // if we've passed the sura, return the previous page
       // or, if we're at the same sura and passed the ayah
       if (ss > sura || ((ss == sura) &&
-          (QuranInfo.PAGE_AYAH_START[index] > ayah))) {
+          (QuranInfo.pageAyahStart[index] > ayah))) {
         break;
       }
 
@@ -278,7 +278,7 @@ public class QuranInfo {
   public static int getAyahId(int sura, int ayah) {
     int ayahId = 0;
     for (int i = 0; i < sura - 1; i++) {
-      ayahId += SURA_NUM_AYAHS[i];
+      ayahId += suraNumAyahs[i];
     }
     ayahId += ayah;
     return ayahId;
@@ -286,7 +286,7 @@ public class QuranInfo {
 
   public static int getNumAyahs(int sura) {
     if ((sura < 1) || (sura > Constants.SURAS_COUNT)) return -1;
-    return SURA_NUM_AYAHS[sura - 1];
+    return suraNumAyahs[sura - 1];
   }
 
   public static int getPageFromPos(int position, boolean dual) {
@@ -324,7 +324,7 @@ public class QuranInfo {
 
   // not ideal, should change this later
   public static int[] getQuarterByIndex(int quarter) {
-    return QUARTERS[quarter];
+    return quarters[quarter];
   }
 
   public static Set<String> getAyahKeysOnPage(int page, SuraAyah lowerBound, SuraAyah upperBound) {

--- a/app/src/main/java/com/quran/labs/androidquran/data/QuranInfo.java
+++ b/app/src/main/java/com/quran/labs/androidquran/data/QuranInfo.java
@@ -11,19 +11,28 @@ import com.quran.labs.androidquran.util.QuranUtils;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
+import javax.inject.Inject;
+
+import dagger.Reusable;
+
 import static com.quran.labs.androidquran.data.Constants.PAGES_FIRST;
 import static com.quran.labs.androidquran.data.Constants.PAGES_LAST;
 import static com.quran.labs.androidquran.data.Constants.PAGES_LAST_DUAL;
 
+@Reusable
 public class QuranInfo {
-  private static int[] suraPageStart = QuranData.SURA_PAGE_START;
-  private static int[] pageSuraStart = QuranData.PAGE_SURA_START;
-  private static int[] pageAyahStart = QuranData.PAGE_AYAH_START;
-  private static int[] juzPageStart = QuranData.JUZ_PAGE_START;
-  private static int[] pageRub3Start = QuranData.PAGE_RUB3_START;
-  private static int[] suraNumAyahs = QuranData.SURA_NUM_AYAHS;
-  private static boolean[] suraIsMakki = QuranData.SURA_IS_MAKKI;
-  private static int[][] quarters = QuranData.QUARTERS;
+  private final int[] suraPageStart = QuranData.SURA_PAGE_START;
+  private final int[] pageSuraStart = QuranData.PAGE_SURA_START;
+  private final int[] pageAyahStart = QuranData.PAGE_AYAH_START;
+  private final int[] juzPageStart = QuranData.JUZ_PAGE_START;
+  private final int[] pageRub3Start = QuranData.PAGE_RUB3_START;
+  private final int[] suraNumAyahs = QuranData.SURA_NUM_AYAHS;
+  private final boolean[] suraIsMakki = QuranData.SURA_IS_MAKKI;
+  private final int[][] quarters = QuranData.QUARTERS;
+
+  @Inject
+  public QuranInfo() {
+  }
 
   /**
    * Get localized sura name from resources
@@ -33,7 +42,7 @@ public class QuranInfo {
    * @param wantPrefix Whether or not to show prefix "Sura"
    * @return Compiled sura name without translations
    */
-  public static String getSuraName(Context context, int sura, boolean wantPrefix) {
+  public String getSuraName(Context context, int sura, boolean wantPrefix) {
     return getSuraName(context, sura, wantPrefix, false);
   }
 
@@ -46,8 +55,7 @@ public class QuranInfo {
    * @param wantTranslation Whether or not to show sura name translations
    * @return Compiled sura name based on provided arguments
    */
-  public static String getSuraName(Context context, int sura,
-                                   boolean wantPrefix, boolean wantTranslation) {
+  public String getSuraName(Context context, int sura, boolean wantPrefix, boolean wantTranslation) {
     if (sura < Constants.SURA_FIRST ||
         sura > Constants.SURA_LAST) {
       return "";
@@ -73,15 +81,15 @@ public class QuranInfo {
     return builder.toString();
   }
 
-  public static int getStartingPageForJuz(int juz) {
+  public int getStartingPageForJuz(int juz) {
     return juzPageStart[juz - 1];
   }
 
-  public static int getPageNumberForSura(int sura) {
+  public int getPageNumberForSura(int sura) {
     return suraPageStart[sura - 1];
   }
 
-  public static int getSuraNumberFromPage(int page) {
+  public int getSuraNumberFromPage(int page) {
     int sura = -1;
     for (int i = 0; i < Constants.SURAS_COUNT; i++) {
       if (suraPageStart[i] == page) {
@@ -96,32 +104,30 @@ public class QuranInfo {
     return sura;
   }
 
-  public static String getSuraNameFromPage(Context context, int page,
+  public String getSuraNameFromPage(Context context, int page,
                                            boolean wantTitle) {
     int sura = getSuraNumberFromPage(page);
     return (sura > 0) ? getSuraName(context, sura, wantTitle, false) : "";
   }
 
-  public static String getPageSubtitle(Context context, int page) {
+  public String getPageSubtitle(Context context, int page) {
     String description = context.getString(R.string.page_description);
     return String.format(description,
         QuranUtils.getLocalizedNumber(context, page),
-        QuranUtils.getLocalizedNumber(context,
-            QuranInfo.getJuzFromPage(page)));
+        QuranUtils.getLocalizedNumber(context, getJuzFromPage(page)));
   }
 
-  public static String getJuzString(Context context, int page) {
+  public String getJuzString(Context context, int page) {
     String description = context.getString(R.string.juz2_description);
-    return String.format(description, QuranUtils.getLocalizedNumber(
-        context, QuranInfo.getJuzFromPage(page)));
+    return String.format(description, QuranUtils.getLocalizedNumber(context, getJuzFromPage(page)));
   }
 
-  public static String getSuraAyahString(Context context, int sura, int ayah) {
+  public String getSuraAyahString(Context context, int sura, int ayah) {
     String suraName = getSuraName(context, sura, false, false);
     return context.getString(R.string.sura_ayah_notification_str, suraName, ayah);
   }
 
-  public static String getNotificationTitle(Context context,
+  public String getNotificationTitle(Context context,
                                             SuraAyah minVerse,
                                             SuraAyah maxVerse,
                                             boolean isGapless) {
@@ -129,7 +135,7 @@ public class QuranInfo {
     int maxSura = maxVerse.sura;
 
     String notificationTitle =
-        QuranInfo.getSuraName(context, minSura, true, false);
+        getSuraName(context, minSura, true, false);
     if (isGapless) {
       // for gapless, don't show the ayah numbers since we're
       // downloading the entire sura(s).
@@ -137,14 +143,14 @@ public class QuranInfo {
         return notificationTitle;
       } else {
         return notificationTitle + " - " +
-            QuranInfo.getSuraName(context, maxSura, true, false);
+            getSuraName(context, maxSura, true, false);
       }
     }
 
     int maxAyah = maxVerse.ayah;
     if (maxAyah == 0) {
       maxSura--;
-      maxAyah = QuranInfo.getNumAyahs(maxSura);
+      maxAyah = getNumAyahs(maxSura);
     }
 
     if (minSura == maxSura) {
@@ -156,36 +162,36 @@ public class QuranInfo {
       }
     } else {
       notificationTitle += " (" + minVerse.ayah +
-          ") - " + QuranInfo.getSuraName(context, maxSura, true, false) +
+          ") - " + getSuraName(context, maxSura, true, false) +
           " (" + maxAyah + ")";
     }
 
     return notificationTitle;
   }
 
-  public static String getSuraListMetaString(Context context, int sura) {
-    String info = context.getString(QuranInfo.suraIsMakki[sura - 1]
+  public String getSuraListMetaString(Context context, int sura) {
+    String info = context.getString(suraIsMakki[sura - 1]
         ? R.string.makki : R.string.madani) + " - ";
 
-    int ayahs = QuranInfo.suraNumAyahs[sura - 1];
+    int ayahs = suraNumAyahs[sura - 1];
     info += context.getResources().getQuantityString(R.plurals.verses, ayahs,
         QuranUtils.getLocalizedNumber(context, ayahs));
     return info;
   }
 
-  public static VerseRange getVerseRangeForPage(int page) {
+  public VerseRange getVerseRangeForPage(int page) {
     int[] result = getPageBounds(page);
-    final int versesInRange = 1 + Math.abs(QuranInfo.getAyahId(result[0], result[1]) -
-                                           QuranInfo.getAyahId(result[2], result[3]));
+    final int versesInRange =
+        1 + Math.abs(getAyahId(result[0], result[1]) - getAyahId(result[2], result[3]));
     return new VerseRange(result[0], result[1], result[2], result[3], versesInRange);
   }
 
-  public static int getFirstAyahOnPage(int page) {
-    return QuranInfo.pageAyahStart[page - 1];
+  public int getFirstAyahOnPage(int page) {
+    return pageAyahStart[page - 1];
   }
 
   @NonNull
-  public static int[] getPageBounds(int page) {
+  public int[] getPageBounds(int page) {
     if (page > PAGES_LAST)
       page = PAGES_LAST;
     if (page < 1) page = 1;
@@ -216,7 +222,7 @@ public class QuranInfo {
     return bounds;
   }
 
-  public static int safelyGetSuraOnPage(int page) {
+  public int safelyGetSuraOnPage(int page) {
     if (page < PAGES_FIRST || page > PAGES_LAST) {
       Crashlytics.logException(new IllegalArgumentException("got page: " + page));
       page = 1;
@@ -224,7 +230,7 @@ public class QuranInfo {
     return pageSuraStart[page - 1];
   }
 
-  public static String getSuraNameFromPage(Context context, int page) {
+  private String getSuraNameFromPage(Context context, int page) {
     for (int i = 0; i < Constants.SURAS_COUNT; i++) {
       if (suraPageStart[i] == page) {
         return getSuraName(context, i + 1, false, false);
@@ -235,7 +241,7 @@ public class QuranInfo {
     return "";
   }
 
-  public static int getJuzFromPage(int page) {
+  public int getJuzFromPage(int page) {
     for (int i = 0; i < juzPageStart.length; i++) {
       if (juzPageStart[i] >= page) {
         return i + 1;
@@ -244,12 +250,12 @@ public class QuranInfo {
     return 30;
   }
 
-  public static int getRub3FromPage(int page) {
+  public int getRub3FromPage(int page) {
     if ((page > PAGES_LAST) || (page < 1)) return -1;
     return pageRub3Start[page - 1];
   }
 
-  public static int getPageFromSuraAyah(int sura, int ayah) {
+  public int getPageFromSuraAyah(int sura, int ayah) {
     // basic bounds checking
     if (ayah == 0) ayah = 1;
     if ((sura < 1) || (sura > Constants.SURAS_COUNT)
@@ -258,15 +264,15 @@ public class QuranInfo {
       return -1;
 
     // what page does the sura start on?
-    int index = QuranInfo.suraPageStart[sura - 1] - 1;
+    int index = suraPageStart[sura - 1] - 1;
     while (index < PAGES_LAST) {
       // what's the first sura in that page?
-      int ss = QuranInfo.pageSuraStart[index];
+      int ss = pageSuraStart[index];
 
       // if we've passed the sura, return the previous page
       // or, if we're at the same sura and passed the ayah
       if (ss > sura || ((ss == sura) &&
-          (QuranInfo.pageAyahStart[index] > ayah))) {
+          (pageAyahStart[index] > ayah))) {
         break;
       }
 
@@ -277,7 +283,7 @@ public class QuranInfo {
     return index;
   }
 
-  public static int getAyahId(int sura, int ayah) {
+  public int getAyahId(int sura, int ayah) {
     int ayahId = 0;
     for (int i = 0; i < sura - 1; i++) {
       ayahId += suraNumAyahs[i];
@@ -286,12 +292,12 @@ public class QuranInfo {
     return ayahId;
   }
 
-  public static int getNumAyahs(int sura) {
+  public int getNumAyahs(int sura) {
     if ((sura < 1) || (sura > Constants.SURAS_COUNT)) return -1;
     return suraNumAyahs[sura - 1];
   }
 
-  public static int getPageFromPos(int position, boolean dual) {
+  public  int getPageFromPos(int position, boolean dual) {
     int page = PAGES_LAST - position;
     if (dual) {
       page = (PAGES_LAST_DUAL - position) * 2;
@@ -299,7 +305,7 @@ public class QuranInfo {
     return page;
   }
 
-  public static int getPosFromPage(int page, boolean dual) {
+  public int getPosFromPage(int page, boolean dual) {
     int position = PAGES_LAST - page;
     if (dual) {
       if (page % 2 != 0) {
@@ -310,28 +316,28 @@ public class QuranInfo {
     return position;
   }
 
-  public static String getAyahString(int sura, int ayah, Context context) {
+  public String getAyahString(int sura, int ayah, Context context) {
     return getSuraName(context, sura, true) + " - " + context.getString(R.string.quran_ayah, ayah);
   }
 
-  public static String getAyahMetadata(int sura, int ayah, int page, Context context) {
+  public  String getAyahMetadata(int sura, int ayah, int page, Context context) {
     int juz = getJuzFromPage(page);
     return context.getString(R.string.quran_ayah_details, getSuraName(context, sura, true),
         QuranUtils.getLocalizedNumber(context, ayah), QuranUtils.getLocalizedNumber(context, juz));
   }
 
-  public static String getSuraNameString(Context context, int page) {
+  public  String getSuraNameString(Context context, int page) {
     return context.getString(R.string.quran_sura_title, getSuraNameFromPage(context, page));
   }
 
   // not ideal, should change this later
-  public static int[] getQuarterByIndex(int quarter) {
+  public  int[] getQuarterByIndex(int quarter) {
     return quarters[quarter];
   }
 
-  public static Set<String> getAyahKeysOnPage(int page, SuraAyah lowerBound, SuraAyah upperBound) {
+  public Set<String> getAyahKeysOnPage(int page, SuraAyah lowerBound, SuraAyah upperBound) {
     Set<String> ayahKeys = new LinkedHashSet<>();
-    int[] bounds = QuranInfo.getPageBounds(page);
+    int[] bounds = getPageBounds(page);
     SuraAyah start = new SuraAyah(bounds[0], bounds[1]);
     SuraAyah end = new SuraAyah(bounds[2], bounds[3]);
     if (lowerBound != null) {
@@ -340,7 +346,7 @@ public class QuranInfo {
     if (upperBound != null) {
       end = SuraAyah.min(end, upperBound);
     }
-    SuraAyahIterator iterator = new SuraAyahIterator(start, end);
+    SuraAyahIterator iterator = new SuraAyahIterator(this, start, end);
     while (iterator.next()) {
       ayahKeys.add(iterator.getSura() + ":" + iterator.getAyah());
     }

--- a/app/src/main/java/com/quran/labs/androidquran/data/QuranInfo.java
+++ b/app/src/main/java/com/quran/labs/androidquran/data/QuranInfo.java
@@ -175,7 +175,9 @@ public class QuranInfo {
 
   public static VerseRange getVerseRangeForPage(int page) {
     int[] result = getPageBounds(page);
-    return new VerseRange(result[0], result[1], result[2], result[3]);
+    final int versesInRange = 1 + Math.abs(QuranInfo.getAyahId(result[0], result[1]) -
+                                           QuranInfo.getAyahId(result[2], result[3]));
+    return new VerseRange(result[0], result[1], result[2], result[3], versesInRange);
   }
 
   public static int getFirstAyahOnPage(int page) {

--- a/app/src/main/java/com/quran/labs/androidquran/data/SuraAyah.java
+++ b/app/src/main/java/com/quran/labs/androidquran/data/SuraAyah.java
@@ -7,7 +7,6 @@ import android.support.annotation.NonNull;
 public class SuraAyah implements Comparable<SuraAyah>, Parcelable {
   public final int sura;
   public final int ayah;
-  private int page = -1;
 
   public SuraAyah(int sura, int ayah) {
     this.sura = sura;
@@ -42,10 +41,6 @@ public class SuraAyah implements Comparable<SuraAyah>, Parcelable {
           return new SuraAyah[size];
         }
       };
-
-  public int getPage() {
-    return page > 0 ? page : (page = QuranInfo.getPageFromSuraAyah(sura, ayah));
-  }
 
   @Override
   public int compareTo(@NonNull SuraAyah another) {

--- a/app/src/main/java/com/quran/labs/androidquran/data/SuraAyahIterator.java
+++ b/app/src/main/java/com/quran/labs/androidquran/data/SuraAyahIterator.java
@@ -9,7 +9,11 @@ public class SuraAyahIterator {
   private int curSura;
   private int curAyah;
 
-  public SuraAyahIterator(SuraAyah start, SuraAyah end) {
+  private final QuranInfo quranInfo;
+
+  public SuraAyahIterator(QuranInfo quranInfo, SuraAyah start, SuraAyah end) {
+    this.quranInfo = quranInfo;
+
     // Sanity check
     if (start.compareTo(end) <= 0) {
       this.start = start;
@@ -45,7 +49,7 @@ public class SuraAyahIterator {
     } else if (!hasNext()) {
       return false;
     }
-    if (curAyah < QuranInfo.getNumAyahs(curSura)) {
+    if (curAyah < quranInfo.getNumAyahs(curSura)) {
       curAyah++;
     } else {
       curAyah = 1;

--- a/app/src/main/java/com/quran/labs/androidquran/data/VerseRange.java
+++ b/app/src/main/java/com/quran/labs/androidquran/data/VerseRange.java
@@ -7,14 +7,11 @@ public class VerseRange {
   public final int endingAyah;
   public final int versesInRange;
 
-  public VerseRange(int startSura, int startAyah, int endingSura, int endingAyah) {
+  public VerseRange(int startSura, int startAyah, int endingSura, int endingAyah, int verses) {
     this.startSura = startSura;
     this.startAyah = startAyah;
     this.endingSura = endingSura;
     this.endingAyah = endingAyah;
-    int delta = QuranInfo.getAyahId(endingSura, endingAyah) -
-        QuranInfo.getAyahId(startSura, startAyah);
-    // adding 1 because in the case of a single ayah, there is 1 ayah in that range, not 0
-    versesInRange = 1 + (delta > 0 ? delta : -delta);
+    this.versesInRange = verses;
   }
 }

--- a/app/src/main/java/com/quran/labs/androidquran/database/DatabaseHandler.java
+++ b/app/src/main/java/com/quran/labs/androidquran/database/DatabaseHandler.java
@@ -14,7 +14,6 @@ import android.support.v4.content.ContextCompat;
 import com.crashlytics.android.Crashlytics;
 import com.quran.labs.androidquran.R;
 import com.quran.labs.androidquran.common.QuranText;
-import com.quran.labs.androidquran.data.QuranInfo;
 import com.quran.labs.androidquran.data.VerseRange;
 import com.quran.labs.androidquran.util.QuranFileUtils;
 
@@ -142,9 +141,8 @@ public class DatabaseHandler {
    */
   public Cursor getVerses(int minSura, int minAyah, int maxSura,
                           int maxAyah, String table) {
-    final int verseCount = 1 + Math.abs(
-        QuranInfo.getAyahId(minSura, minAyah) - QuranInfo.getAyahId(maxSura, maxAyah));
-    return getVersesInternal(new VerseRange(minSura, minAyah, maxSura, maxAyah, verseCount), table);
+    // pass -1 for verses since this is used internally only and the field isn't needed.
+    return getVersesInternal(new VerseRange(minSura, minAyah, maxSura, maxAyah, -1), table);
   }
 
   public List<QuranText> getVerses(VerseRange verses, @TextType int textType) {

--- a/app/src/main/java/com/quran/labs/androidquran/database/DatabaseHandler.java
+++ b/app/src/main/java/com/quran/labs/androidquran/database/DatabaseHandler.java
@@ -14,6 +14,7 @@ import android.support.v4.content.ContextCompat;
 import com.crashlytics.android.Crashlytics;
 import com.quran.labs.androidquran.R;
 import com.quran.labs.androidquran.common.QuranText;
+import com.quran.labs.androidquran.data.QuranInfo;
 import com.quran.labs.androidquran.data.VerseRange;
 import com.quran.labs.androidquran.util.QuranFileUtils;
 
@@ -141,7 +142,9 @@ public class DatabaseHandler {
    */
   public Cursor getVerses(int minSura, int minAyah, int maxSura,
                           int maxAyah, String table) {
-    return getVersesInternal(new VerseRange(minSura, minAyah, maxSura, maxAyah), table);
+    final int verseCount = 1 + Math.abs(
+        QuranInfo.getAyahId(minSura, minAyah) - QuranInfo.getAyahId(maxSura, maxAyah));
+    return getVersesInternal(new VerseRange(minSura, minAyah, maxSura, maxAyah, verseCount), table);
   }
 
   public List<QuranText> getVerses(VerseRange verses, @TextType int textType) {

--- a/app/src/main/java/com/quran/labs/androidquran/model/translation/ArabicDatabaseUtils.java
+++ b/app/src/main/java/com/quran/labs/androidquran/model/translation/ArabicDatabaseUtils.java
@@ -30,11 +30,13 @@ public class ArabicDatabaseUtils {
   @VisibleForTesting static final int NUMBER_OF_WORDS = 4;
 
   private final Context appContext;
+  private final QuranInfo quranInfo;
   private DatabaseHandler arabicDatabaseHandler;
 
   @Inject
-  ArabicDatabaseUtils(Context context) {
+  ArabicDatabaseUtils(Context context, QuranInfo quranInfo) {
     this.appContext = context;
+    this.quranInfo = quranInfo;
     arabicDatabaseHandler = getArabicDatabaseHandler();
   }
 
@@ -78,7 +80,7 @@ public class ArabicDatabaseUtils {
     for (int i = 0, bookmarksSize = bookmarks.size(); i < bookmarksSize; i++) {
       Bookmark bookmark = bookmarks.get(i);
       if (!bookmark.isPageBookmark()) {
-        ayahIds.add(QuranInfo.getAyahId(bookmark.sura, bookmark.ayah));
+        ayahIds.add(quranInfo.getAyahId(bookmark.sura, bookmark.ayah));
       }
     }
 
@@ -120,7 +122,7 @@ public class ArabicDatabaseUtils {
         if (bookmark.isPageBookmark()) {
           toAdd = bookmark;
         } else {
-          String ayahText = ayahMap.get(QuranInfo.getAyahId(bookmark.sura, bookmark.ayah));
+          String ayahText = ayahMap.get(quranInfo.getAyahId(bookmark.sura, bookmark.ayah));
           toAdd = ayahText == null ? bookmark : bookmark.withAyahText(ayahText);
         }
         result.add(toAdd);

--- a/app/src/main/java/com/quran/labs/androidquran/presenter/bookmark/BookmarkPresenter.java
+++ b/app/src/main/java/com/quran/labs/androidquran/presenter/bookmark/BookmarkPresenter.java
@@ -47,6 +47,7 @@ public class BookmarkPresenter implements Presenter<BookmarksFragment> {
   private final Context appContext;
   private final BookmarkModel bookmarkModel;
   private final QuranSettings quranSettings;
+  private final QuranRowFactory quranRowFactory;
 
   private int sortOrder;
   private boolean groupByTags;
@@ -63,11 +64,14 @@ public class BookmarkPresenter implements Presenter<BookmarksFragment> {
   BookmarkPresenter(Context appContext,
                     BookmarkModel bookmarkModel,
                     QuranSettings quranSettings,
-                    ArabicDatabaseUtils arabicDatabaseUtils) {
+                    ArabicDatabaseUtils arabicDatabaseUtils,
+                    QuranRowFactory quranRowFactory) {
     this.appContext = appContext;
     this.quranSettings = quranSettings;
     this.bookmarkModel = bookmarkModel;
     this.arabicDatabaseUtils = arabicDatabaseUtils;
+    this.quranRowFactory = quranRowFactory;
+
     sortOrder = quranSettings.getBookmarksSortOrder();
     groupByTags = quranSettings.getBookmarksGroupedByTags();
     showRecents = quranSettings.getShowRecents();
@@ -302,13 +306,13 @@ public class BookmarkPresenter implements Presenter<BookmarksFragment> {
         // only show the last bookmark if show recents is off
         size = 1;
       }
-      rows.add(0, QuranRowFactory.fromRecentPageHeader(appContext, size));
+      rows.add(0, quranRowFactory.fromRecentPageHeader(appContext, size));
       for (int i = 0; i < size; i++) {
         int page = recentPages.get(i).getPage();
         if (page < Constants.PAGES_FIRST || page > Constants.PAGES_LAST) {
           page = 1;
         }
-        rows.add(i + 1, QuranRowFactory.fromCurrentPage(appContext, page));
+        rows.add(i + 1, quranRowFactory.fromCurrentPage(appContext, page));
       }
     }
 
@@ -321,19 +325,19 @@ public class BookmarkPresenter implements Presenter<BookmarksFragment> {
     Map<Long, List<Bookmark>> tagsMapping = generateTagsMapping(tags, bookmarks);
     for (int i = 0, tagsSize = tags.size(); i < tagsSize; i++) {
       Tag tag = tags.get(i);
-      rows.add(QuranRowFactory.fromTag(tag));
+      rows.add(quranRowFactory.fromTag(tag));
       List<Bookmark> tagBookmarks = tagsMapping.get(tag.getId());
       for (int j = 0, tagBookmarksSize = tagBookmarks.size(); j < tagBookmarksSize; j++) {
-        rows.add(QuranRowFactory.fromBookmark(appContext, tagBookmarks.get(j), tag.getId()));
+        rows.add(quranRowFactory.fromBookmark(appContext, tagBookmarks.get(j), tag.getId()));
       }
     }
 
     // add untagged bookmarks
     List<Bookmark> untagged = tagsMapping.get(BOOKMARKS_WITHOUT_TAGS_ID);
     if (untagged.size() > 0) {
-      rows.add(QuranRowFactory.fromNotTaggedHeader(appContext));
+      rows.add(quranRowFactory.fromNotTaggedHeader(appContext));
       for (int i = 0, untaggedSize = untagged.size(); i < untaggedSize; i++) {
-        rows.add(QuranRowFactory.fromBookmark(appContext, untagged.get(i)));
+        rows.add(quranRowFactory.fromBookmark(appContext, untagged.get(i)));
       }
     }
     return rows;
@@ -347,7 +351,7 @@ public class BookmarkPresenter implements Presenter<BookmarksFragment> {
     for (int i = 0, bookmarksSize = bookmarks.size(); i < bookmarksSize; i++) {
       Bookmark bookmark = bookmarks.get(i);
       if (bookmark.isPageBookmark()) {
-        rows.add(QuranRowFactory.fromBookmark(appContext, bookmark));
+        rows.add(quranRowFactory.fromBookmark(appContext, bookmark));
       } else {
         ayahBookmarks.add(bookmark);
       }
@@ -355,14 +359,14 @@ public class BookmarkPresenter implements Presenter<BookmarksFragment> {
 
     // add page bookmarks header if needed
     if (rows.size() > 0) {
-      rows.add(0, QuranRowFactory.fromPageBookmarksHeader(appContext));
+      rows.add(0, quranRowFactory.fromPageBookmarksHeader(appContext));
     }
 
     // add ayah bookmarks if any
     if (ayahBookmarks.size() > 0) {
-      rows.add(QuranRowFactory.fromAyahBookmarksHeader(appContext));
+      rows.add(quranRowFactory.fromAyahBookmarksHeader(appContext));
       for (int i = 0, ayahBookmarksSize = ayahBookmarks.size(); i < ayahBookmarksSize; i++) {
-        rows.add(QuranRowFactory.fromBookmark(appContext, ayahBookmarks.get(i)));
+        rows.add(quranRowFactory.fromBookmark(appContext, ayahBookmarks.get(i)));
       }
     }
 

--- a/app/src/main/java/com/quran/labs/androidquran/presenter/quran/ayahtracker/AyahImageTrackerItem.java
+++ b/app/src/main/java/com/quran/labs/androidquran/presenter/quran/ayahtracker/AyahImageTrackerItem.java
@@ -22,16 +22,22 @@ import java.util.Map;
 import java.util.Set;
 
 public class AyahImageTrackerItem extends AyahTrackerItem<HighlightingImageView> {
+  private final QuranInfo quranInfo;
   private final boolean isPageOnRightSide;
   @Nullable Map<String, List<AyahBounds>> coordinates;
 
-  public AyahImageTrackerItem(int page, @NonNull HighlightingImageView highlightingImageView) {
-    this(page, false, highlightingImageView);
+  public AyahImageTrackerItem(int page,
+                              QuranInfo quranInfo,
+                              @NonNull HighlightingImageView highlightingImageView) {
+    this(page, quranInfo, false, highlightingImageView);
   }
 
-  public AyahImageTrackerItem(int page, boolean isPageOnTheRight,
+  public AyahImageTrackerItem(int page,
+                              QuranInfo quranInfo,
+                              boolean isPageOnTheRight,
                               @NonNull HighlightingImageView highlightingImageView) {
     super(page, highlightingImageView);
+    this.quranInfo = quranInfo;
     this.isPageOnRightSide = isPageOnTheRight;
   }
 
@@ -41,10 +47,10 @@ public class AyahImageTrackerItem extends AyahTrackerItem<HighlightingImageView>
       // this is only called if overlayText is set
       ayahView.setPageBounds(bounds);
       Context context = ayahView.getContext();
-      String suraText = QuranInfo.getSuraNameFromPage(context, page, true);
-      String juzText = QuranInfo.getJuzString(context, page);
+      String suraText = quranInfo.getSuraNameFromPage(context, page, true);
+      String juzText = quranInfo.getJuzString(context, page);
       String pageText = QuranUtils.getLocalizedNumber(context, page);
-      String rub3Text = QuranDisplayHelper.displayRub3(context, page);
+      String rub3Text = QuranDisplayHelper.displayRub3(context, quranInfo, page);
       ayahView.setOverlayText(suraText, juzText, pageText, rub3Text);
     }
   }

--- a/app/src/main/java/com/quran/labs/androidquran/presenter/quran/ayahtracker/AyahScrollableImageTrackerItem.java
+++ b/app/src/main/java/com/quran/labs/androidquran/presenter/quran/ayahtracker/AyahScrollableImageTrackerItem.java
@@ -4,6 +4,7 @@ import android.graphics.Matrix;
 import android.graphics.RectF;
 import android.support.annotation.NonNull;
 
+import com.quran.labs.androidquran.data.QuranInfo;
 import com.quran.labs.androidquran.ui.helpers.HighlightType;
 import com.quran.labs.androidquran.ui.util.ImageAyahUtils;
 import com.quran.labs.androidquran.util.QuranScreenInfo;
@@ -15,9 +16,10 @@ public class AyahScrollableImageTrackerItem extends AyahImageTrackerItem {
   @NonNull private QuranPageLayout quranPageLayout;
 
   public AyahScrollableImageTrackerItem(int page,
+                                        QuranInfo quranInfo,
                                         @NonNull QuranPageLayout quranPageLayout,
                                         @NonNull HighlightingImageView highlightingImageView) {
-    super(page, highlightingImageView);
+    super(page, quranInfo, highlightingImageView);
     this.quranPageLayout = quranPageLayout;
   }
 

--- a/app/src/main/java/com/quran/labs/androidquran/presenter/quran/ayahtracker/AyahTrackerPresenter.java
+++ b/app/src/main/java/com/quran/labs/androidquran/presenter/quran/ayahtracker/AyahTrackerPresenter.java
@@ -30,10 +30,12 @@ public class AyahTrackerPresenter implements AyahTracker,
     Presenter<AyahTrackerPresenter.AyahInteractionHandler> {
   private AyahTrackerItem[] items;
   private HighlightInfo pendingHighlightInfo;
+  private final QuranInfo quranInfo;
 
   @Inject
-  public AyahTrackerPresenter() {
+  public AyahTrackerPresenter(QuranInfo quranInfo) {
     this.items = new AyahTrackerItem[0];
+    this.quranInfo = quranInfo;
   }
 
   public void setPageBounds(int page, RectF bounds) {
@@ -62,7 +64,7 @@ public class AyahTrackerPresenter implements AyahTracker,
   @Override
   public void highlightAyah(int sura, int ayah, HighlightType type, boolean scrollToAyah) {
     boolean handled = false;
-    int page = items.length == 1 ? items[0].page : QuranInfo.getPageFromSuraAyah(sura, ayah);
+    int page = items.length == 1 ? items[0].page : quranInfo.getPageFromSuraAyah(sura, ayah);
     for (AyahTrackerItem item : items) {
       handled = handled || item.onHighlightAyah(page, sura, ayah, type, scrollToAyah);
     }
@@ -83,7 +85,7 @@ public class AyahTrackerPresenter implements AyahTracker,
 
   @Override
   public void unHighlightAyah(int sura, int ayah, HighlightType type) {
-    int page = items.length == 1 ? items[0].page : QuranInfo.getPageFromSuraAyah(sura, ayah);
+    int page = items.length == 1 ? items[0].page : quranInfo.getPageFromSuraAyah(sura, ayah);
     for (AyahTrackerItem item : items) {
       item.onUnHighlightAyah(page, sura, ayah, type);
     }
@@ -99,7 +101,7 @@ public class AyahTrackerPresenter implements AyahTracker,
   @Override
   public AyahToolBar.AyahToolBarPosition getToolBarPosition(int sura, int ayah,
                                                             int toolBarWidth, int toolBarHeight) {
-    int page = items.length == 1 ? items[0].page : QuranInfo.getPageFromSuraAyah(sura, ayah);
+    int page = items.length == 1 ? items[0].page : quranInfo.getPageFromSuraAyah(sura, ayah);
     for (AyahTrackerItem item : items) {
       AyahToolBar.AyahToolBarPosition position =
           item.getToolBarPosition(page, sura, ayah, toolBarWidth, toolBarHeight);

--- a/app/src/main/java/com/quran/labs/androidquran/presenter/quran/ayahtracker/AyahTranslationTrackerItem.java
+++ b/app/src/main/java/com/quran/labs/androidquran/presenter/quran/ayahtracker/AyahTranslationTrackerItem.java
@@ -7,15 +7,19 @@ import com.quran.labs.androidquran.ui.helpers.HighlightType;
 import com.quran.labs.androidquran.ui.translation.TranslationView;
 
 public class AyahTranslationTrackerItem extends AyahTrackerItem<TranslationView> {
+  private final QuranInfo quranInfo;
 
-  public AyahTranslationTrackerItem(int page, @NonNull TranslationView ayahView) {
+  public AyahTranslationTrackerItem(int page,
+                                    QuranInfo quranInfo,
+                                    @NonNull TranslationView ayahView) {
     super(page, ayahView);
+    this.quranInfo = quranInfo;
   }
 
   @Override
   boolean onHighlightAyah(int page, int sura, int ayah, HighlightType type, boolean scrollToAyah) {
     if (this.page == page) {
-      ayahView.highlightAyah(QuranInfo.getAyahId(sura, ayah));
+      ayahView.highlightAyah(quranInfo.getAyahId(sura, ayah));
       return true;
     }
     ayahView.unhighlightAyat();

--- a/app/src/main/java/com/quran/labs/androidquran/presenter/translation/BaseTranslationPresenter.java
+++ b/app/src/main/java/com/quran/labs/androidquran/presenter/translation/BaseTranslationPresenter.java
@@ -6,6 +6,7 @@ import android.support.annotation.Nullable;
 import com.quran.labs.androidquran.common.LocalTranslation;
 import com.quran.labs.androidquran.common.QuranAyahInfo;
 import com.quran.labs.androidquran.common.QuranText;
+import com.quran.labs.androidquran.data.QuranInfo;
 import com.quran.labs.androidquran.data.SuraAyah;
 import com.quran.labs.androidquran.data.SuraAyahIterator;
 import com.quran.labs.androidquran.data.VerseRange;
@@ -31,15 +32,18 @@ class BaseTranslationPresenter<T> implements Presenter<T> {
   private final TranslationModel translationModel;
   private final TranslationsDBAdapter translationsAdapter;
   private final Map<String, LocalTranslation> translationMap;
+  private final QuranInfo quranInfo;
 
   @Nullable T translationScreen;
   Disposable disposable;
 
   BaseTranslationPresenter(TranslationModel translationModel,
-                           TranslationsDBAdapter translationsAdapter) {
+                           TranslationsDBAdapter translationsAdapter,
+                           QuranInfo quranInfo) {
     this.translationMap = new HashMap<>();
     this.translationModel = translationModel;
     this.translationsAdapter = translationsAdapter;
+    this.quranInfo = quranInfo;
   }
 
   Single<ResultHolder> getVerses(boolean getArabic,
@@ -137,14 +141,16 @@ class BaseTranslationPresenter<T> implements Presenter<T> {
         if (element != null) {
           String arabicText = arabicSize == 0 ? null : arabic.get(i).text;
           result.add(
-              new QuranAyahInfo(element.sura, element.ayah, arabicText, ayahTranslations));
+              new QuranAyahInfo(element.sura, element.ayah, arabicText, ayahTranslations,
+                  quranInfo.getAyahId(element.sura, element.ayah)));
         }
       }
     } else if (arabicSize > 0) {
       for (int i = 0; i < arabicSize; i++) {
         QuranText arabicItem = arabic.get(i);
         result.add(new QuranAyahInfo(arabicItem.sura, arabicItem.ayah,
-            arabicItem.text, Collections.emptyList()));
+            arabicItem.text, Collections.emptyList(),
+            quranInfo.getAyahId(arabicItem.sura, arabicItem.ayah)));
       }
     }
     return result;
@@ -174,7 +180,7 @@ class BaseTranslationPresenter<T> implements Presenter<T> {
     // ex. ibn katheer is missing 3 records, 1 in each of suras 5, 17, and 87.
     SuraAyah start = new SuraAyah(verseRange.startSura, verseRange.startAyah);
     SuraAyah end = new SuraAyah(verseRange.endingSura, verseRange.endingAyah);
-    SuraAyahIterator iterator = new SuraAyahIterator(start, end);
+    SuraAyahIterator iterator = new SuraAyahIterator(quranInfo, start, end);
 
     int i = 0;
     while (iterator.next()) {

--- a/app/src/main/java/com/quran/labs/androidquran/presenter/translation/InlineTranslationPresenter.java
+++ b/app/src/main/java/com/quran/labs/androidquran/presenter/translation/InlineTranslationPresenter.java
@@ -3,6 +3,7 @@ package com.quran.labs.androidquran.presenter.translation;
 import android.support.annotation.NonNull;
 
 import com.quran.labs.androidquran.common.QuranAyahInfo;
+import com.quran.labs.androidquran.data.QuranInfo;
 import com.quran.labs.androidquran.data.VerseRange;
 import com.quran.labs.androidquran.database.TranslationsDBAdapter;
 import com.quran.labs.androidquran.model.translation.TranslationModel;
@@ -22,8 +23,9 @@ public class InlineTranslationPresenter extends
   @Inject
   InlineTranslationPresenter(TranslationModel translationModel,
                              TranslationsDBAdapter dbAdapter,
-                             QuranSettings quranSettings) {
-    super(translationModel, dbAdapter);
+                             QuranSettings quranSettings,
+                             QuranInfo quranInfo) {
+    super(translationModel, dbAdapter, quranInfo);
     this.quranSettings = quranSettings;
   }
 

--- a/app/src/main/java/com/quran/labs/androidquran/presenter/translation/TranslationPresenter.java
+++ b/app/src/main/java/com/quran/labs/androidquran/presenter/translation/TranslationPresenter.java
@@ -27,15 +27,18 @@ public class TranslationPresenter extends
   private final Integer[] pages;
   private final ShareUtil shareUtil;
   private final QuranSettings quranSettings;
+  private final QuranInfo quranInfo;
 
   @Inject
   TranslationPresenter(TranslationModel translationModel,
                        QuranSettings quranSettings,
                        TranslationsDBAdapter translationsAdapter,
                        ShareUtil shareUtil,
+                       QuranInfo quranInfo,
                        Integer... pages) {
-    super(translationModel, translationsAdapter);
+    super(translationModel, translationsAdapter, quranInfo);
     this.pages = pages;
+    this.quranInfo = quranInfo;
     this.shareUtil = shareUtil;
     this.quranSettings = quranSettings;
   }
@@ -47,7 +50,7 @@ public class TranslationPresenter extends
 
     disposable = Observable.fromArray(pages)
         .flatMap(page -> getVerses(quranSettings.wantArabicInTranslationView(),
-            getTranslations(quranSettings), QuranInfo.getVerseRangeForPage(page))
+            getTranslations(quranSettings), quranInfo.getVerseRangeForPage(page))
             .toObservable())
         .observeOn(AndroidSchedulers.mainThread())
         .subscribeWith(new DisposableObserver<ResultHolder>() {
@@ -99,7 +102,7 @@ public class TranslationPresenter extends
       page = pages[0];
     } else {
       QuranAyahInfo ayahInfo = result.get(0);
-      page = QuranInfo.getPageFromSuraAyah(ayahInfo.sura, ayahInfo.ayah);
+      page = quranInfo.getPageFromSuraAyah(ayahInfo.sura, ayahInfo.ayah);
     }
     return page;
   }

--- a/app/src/main/java/com/quran/labs/androidquran/service/AudioService.java
+++ b/app/src/main/java/com/quran/labs/androidquran/service/AudioService.java
@@ -62,6 +62,7 @@ import android.support.v4.media.session.PlaybackStateCompat;
 import android.util.SparseIntArray;
 
 import com.crashlytics.android.Crashlytics;
+import com.quran.labs.androidquran.QuranApplication;
 import com.quran.labs.androidquran.R;
 import com.quran.labs.androidquran.data.QuranInfo;
 import com.quran.labs.androidquran.data.SuraAyah;
@@ -78,6 +79,8 @@ import com.quran.labs.androidquran.util.AudioUtils;
 import java.io.File;
 import java.io.IOException;
 import java.lang.ref.WeakReference;
+
+import javax.inject.Inject;
 
 import timber.log.Timber;
 
@@ -212,6 +215,8 @@ public class AudioService extends Service implements OnCompletionListener,
   private SparseIntArray gaplessSuraData = null;
   private AsyncTask<Integer, Void, SparseIntArray> timingTask = null;
 
+  @Inject AudioUtils audioUtils;
+
   public static final int MSG_START_AUDIO = 1;
   public static final int MSG_UPDATE_AUDIO_POS = 2;
 
@@ -276,6 +281,7 @@ public class AudioService extends Service implements OnCompletionListener,
     handler = new ServiceHandler(this);
 
     final Context appContext = getApplicationContext();
+    ((QuranApplication) appContext).getApplicationComponent().inject(this);
     wifiLock = ((WifiManager) appContext.getSystemService(Context.WIFI_SERVICE))
         .createWifiLock(WifiManager.WIFI_MODE_FULL, "QuranAudioLock");
     notificationManager = (NotificationManager) appContext.getSystemService(NOTIFICATION_SERVICE);
@@ -1140,19 +1146,19 @@ public class AudioService extends Service implements OnCompletionListener,
         PendingIntent.FLAG_UPDATE_CURRENT);
 
     final PendingIntent previousIntent = PendingIntent.getService(
-        appContext, REQUEST_CODE_PREVIOUS, AudioUtils.getAudioIntent(this, ACTION_REWIND),
+        appContext, REQUEST_CODE_PREVIOUS, audioUtils.getAudioIntent(this, ACTION_REWIND),
         PendingIntent.FLAG_UPDATE_CURRENT);
     final PendingIntent nextIntent = PendingIntent.getService(
-        appContext, REQUEST_CODE_SKIP, AudioUtils.getAudioIntent(this, ACTION_SKIP),
+        appContext, REQUEST_CODE_SKIP, audioUtils.getAudioIntent(this, ACTION_SKIP),
         PendingIntent.FLAG_UPDATE_CURRENT);
     final PendingIntent pauseIntent = PendingIntent.getService(
-        appContext, REQUEST_CODE_PAUSE, AudioUtils.getAudioIntent(this, ACTION_PAUSE),
+        appContext, REQUEST_CODE_PAUSE, audioUtils.getAudioIntent(this, ACTION_PAUSE),
         PendingIntent.FLAG_UPDATE_CURRENT);
     final PendingIntent resumeIntent = PendingIntent.getService(
-        appContext, REQUEST_CODE_RESUME, AudioUtils.getAudioIntent(this, ACTION_PLAYBACK),
+        appContext, REQUEST_CODE_RESUME, audioUtils.getAudioIntent(this, ACTION_PLAYBACK),
         PendingIntent.FLAG_UPDATE_CURRENT);
     final PendingIntent stopIntent = PendingIntent.getService(
-        appContext, REQUEST_CODE_STOP, AudioUtils.getAudioIntent(this, ACTION_STOP),
+        appContext, REQUEST_CODE_STOP, audioUtils.getAudioIntent(this, ACTION_STOP),
         PendingIntent.FLAG_UPDATE_CURRENT);
 
     // if the notification icon is null, let's try to build it

--- a/app/src/main/java/com/quran/labs/androidquran/service/QuranDownloadService.java
+++ b/app/src/main/java/com/quran/labs/androidquran/service/QuranDownloadService.java
@@ -108,6 +108,7 @@ public class QuranDownloadService extends Service implements
   private Map<String, Boolean> mSuccessfulZippedDownloads = null;
   private Map<String, Intent> mRecentlyFailedDownloads = null;
 
+  @Inject QuranInfo quranInfo;
   @Inject OkHttpClient mOkHttpClient;
 
   private final class ServiceHandler extends Handler {
@@ -350,11 +351,11 @@ public class QuranDownloadService extends Service implements
       } else {
         // add the number ayahs from suras in between start and end
         for (int i = startSura + 1; i < endSura; i++) {
-          totalAyahs += QuranInfo.getNumAyahs(i);
+          totalAyahs += quranInfo.getNumAyahs(i);
         }
 
         // add the number of ayahs from the start sura
-        totalAyahs += QuranInfo.getNumAyahs(startSura) - startAyah + 1;
+        totalAyahs += quranInfo.getNumAyahs(startSura) - startAyah + 1;
 
         // add the number of ayahs from the last sura
         totalAyahs += endAyah;
@@ -375,7 +376,7 @@ public class QuranDownloadService extends Service implements
 
     boolean result;
     for (int i = startSura; i <= endSura; i++) {
-      int lastAyah = QuranInfo.getNumAyahs(i);
+      int lastAyah = quranInfo.getNumAyahs(i);
       if (i == endSura) {
         lastAyah = endAyah;
       }

--- a/app/src/main/java/com/quran/labs/androidquran/service/util/AudioRequest.java
+++ b/app/src/main/java/com/quran/labs/androidquran/service/util/AudioRequest.java
@@ -41,7 +41,7 @@ public abstract class AudioRequest implements Parcelable {
 
   public abstract boolean haveSuraAyah(int sura, int ayah);
 
-  AudioRequest(String baseUrl, SuraAyah verse) {
+  AudioRequest(String baseUrl, SuraAyah verse, int verseCountInSura) {
     this.baseUrl = baseUrl;
     final int startSura = verse.sura;
     final int startAyah = verse.ayah;
@@ -52,7 +52,7 @@ public abstract class AudioRequest implements Parcelable {
 
     currentSura = startSura;
     currentAyah = startAyah;
-    ayahsInThisSura = QuranInfo.getNumAyahs(currentSura);
+    ayahsInThisSura = verseCountInSura;
 
     repeatInfo = new RepeatInfo(0);
     repeatInfo.setCurrentVerse(currentSura, currentAyah);
@@ -129,7 +129,7 @@ public abstract class AudioRequest implements Parcelable {
     return repeatInfo;
   }
 
-  public SuraAyah setCurrentAyah(int sura, int ayah) {
+  public SuraAyah setCurrentAyah(QuranInfo quranInfo, int sura, int ayah) {
     Timber.d("got setCurrentAyah of: %d:%d", sura, ayah);
     if (repeatInfo.shouldRepeat()) {
       repeatInfo.incrementRepeat();
@@ -149,7 +149,7 @@ public abstract class AudioRequest implements Parcelable {
       }
 
       if (currentSura >= 1 && currentSura <= 114) {
-        ayahsInThisSura = QuranInfo.getNumAyahs(currentSura);
+        ayahsInThisSura = quranInfo.getNumAyahs(currentSura);
       }
       repeatInfo.setCurrentVerse(currentSura, currentAyah);
     }
@@ -217,8 +217,8 @@ public abstract class AudioRequest implements Parcelable {
     return String.format(Locale.US, baseUrl, sura, ayah);
   }
 
-  public String getTitle(Context context) {
-    return QuranInfo.getSuraAyahString(context, currentSura, currentAyah);
+  public String getTitle(Context context, QuranInfo quranInfo) {
+    return quranInfo.getSuraAyahString(context, currentSura, currentAyah);
   }
 
   public int getCurrentSura() {
@@ -229,7 +229,7 @@ public abstract class AudioRequest implements Parcelable {
     return currentAyah;
   }
 
-  public boolean gotoNextAyah(boolean force) {
+  public boolean gotoNextAyah(QuranInfo quranInfo, boolean force) {
     // don't go to next ayah if we haven't played basmallah yet
     if (justPlayedBasmallah) {
       return false;
@@ -258,7 +258,7 @@ public abstract class AudioRequest implements Parcelable {
       currentAyah = 1;
       currentSura++;
       if (currentSura <= 114) {
-        ayahsInThisSura = QuranInfo.getNumAyahs(currentSura);
+        ayahsInThisSura = quranInfo.getNumAyahs(currentSura);
         repeatInfo.setCurrentVerse(currentSura, currentAyah);
       }
     } else {
@@ -267,12 +267,12 @@ public abstract class AudioRequest implements Parcelable {
     return true;
   }
 
-  public void gotoPreviousAyah() {
+  public void gotoPreviousAyah(QuranInfo quranInfo) {
     currentAyah--;
     if (currentAyah < 1) {
       currentSura--;
       if (currentSura > 0) {
-        ayahsInThisSura = QuranInfo.getNumAyahs(currentSura);
+        ayahsInThisSura = quranInfo.getNumAyahs(currentSura);
         currentAyah = ayahsInThisSura;
       }
     } else if (currentAyah == 1 && !isGapless()) {

--- a/app/src/main/java/com/quran/labs/androidquran/service/util/DownloadAudioRequest.java
+++ b/app/src/main/java/com/quran/labs/androidquran/service/util/DownloadAudioRequest.java
@@ -13,8 +13,8 @@ public class DownloadAudioRequest extends AudioRequest {
   private String localDirectoryPath = null;
 
   public DownloadAudioRequest(String baseUrl, SuraAyah verse,
-      @NonNull QariItem qariItem, String localPath) {
-    super(baseUrl, verse);
+      @NonNull QariItem qariItem, String localPath, int versesInThisSura) {
+    super(baseUrl, verse, versesInThisSura);
     this.qariItem = qariItem;
     localDirectoryPath = localPath;
   }

--- a/app/src/main/java/com/quran/labs/androidquran/service/util/StreamingAudioRequest.java
+++ b/app/src/main/java/com/quran/labs/androidquran/service/util/StreamingAudioRequest.java
@@ -6,8 +6,8 @@ import com.quran.labs.androidquran.data.SuraAyah;
 
 public class StreamingAudioRequest extends AudioRequest {
 
-  public StreamingAudioRequest(String baseUrl, SuraAyah verse) {
-    super(baseUrl, verse);
+  public StreamingAudioRequest(String baseUrl, SuraAyah verse, int versesInThisSura) {
+    super(baseUrl, verse, versesInThisSura);
   }
 
   protected StreamingAudioRequest(Parcel in) {

--- a/app/src/main/java/com/quran/labs/androidquran/ui/AudioManagerActivity.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/AudioManagerActivity.java
@@ -33,6 +33,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import javax.inject.Inject;
+
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.observers.DisposableSingleObserver;
@@ -50,9 +52,12 @@ public class AudioManagerActivity extends QuranActionBarActivity
   private String basePath;
   private List<QariItem> qariItems;
 
+  @Inject AudioUtils audioUtils;
+
   @Override
   protected void onCreate(Bundle savedInstanceState) {
     QuranApplication quranApp = (QuranApplication) getApplication();
+    quranApp.getApplicationComponent().inject(this);
     quranApp.refreshLocale(this, false);
 
     super.onCreate(savedInstanceState);
@@ -69,7 +74,7 @@ public class AudioManagerActivity extends QuranActionBarActivity
     recyclerView.setLayoutManager(new LinearLayoutManager(this));
     recyclerView.setItemAnimator(new DefaultItemAnimator());
 
-    qariItems = AudioUtils.getQariList(this);
+    qariItems = audioUtils.getQariList(this);
     shuyookhAdapter = new ShuyookhAdapter(qariItems);
     recyclerView.setAdapter(shuyookhAdapter);
 
@@ -145,7 +150,7 @@ public class AudioManagerActivity extends QuranActionBarActivity
 
     String sheikhName = qariItem.getName();
     Intent intent = ServiceIntentHelper.getDownloadIntent(this,
-        AudioUtils.getQariUrl(qariItem),
+        audioUtils.getQariUrl(qariItem),
         baseUri, sheikhName, AUDIO_DOWNLOAD_KEY, QuranDownloadService.DOWNLOAD_TYPE_AUDIO);
     intent.putExtra(QuranDownloadService.EXTRA_START_VERSE, new SuraAyah(1, 1));
     intent.putExtra(QuranDownloadService.EXTRA_END_VERSE, new SuraAyah(114, 6));

--- a/app/src/main/java/com/quran/labs/androidquran/ui/AudioManagerActivity.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/AudioManagerActivity.java
@@ -19,6 +19,7 @@ import android.widget.TextView;
 import com.quran.labs.androidquran.QuranApplication;
 import com.quran.labs.androidquran.R;
 import com.quran.labs.androidquran.common.QariItem;
+import com.quran.labs.androidquran.data.QuranInfo;
 import com.quran.labs.androidquran.data.SuraAyah;
 import com.quran.labs.androidquran.service.QuranDownloadService;
 import com.quran.labs.androidquran.service.util.DefaultDownloadReceiver;
@@ -53,6 +54,7 @@ public class AudioManagerActivity extends QuranActionBarActivity
   private List<QariItem> qariItems;
 
   @Inject AudioUtils audioUtils;
+  @Inject QuranInfo quranInfo;
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
@@ -88,7 +90,7 @@ public class AudioManagerActivity extends QuranActionBarActivity
     if (disposable != null) {
       disposable.dispose();
     }
-    disposable = AudioManagerUtils.shuyookhDownloadObservable(basePath, qariItems)
+    disposable = AudioManagerUtils.shuyookhDownloadObservable(quranInfo, basePath, qariItems)
         .observeOn(AndroidSchedulers.mainThread())
         .subscribeWith(mOnDownloadInfo);
   }

--- a/app/src/main/java/com/quran/labs/androidquran/ui/PagerActivity.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/PagerActivity.java
@@ -354,7 +354,8 @@ public class PagerActivity extends QuranActionBarActivity implements
       public void onPageScrolled(int position, float positionOffset,
                                  int positionOffsetPixels) {
         if (ayahToolBar.isShowing() && ayahToolBarPos != null) {
-          int barPos = QuranInfo.getPosFromPage(start.getPage(), isDualPages);
+          final int startPage = QuranInfo.getPageFromSuraAyah(start.sura, start.ayah);
+          int barPos = QuranInfo.getPosFromPage(startPage, isDualPages);
           if (position == barPos) {
             // Swiping to next ViewPager page (i.e. prev quran page)
             ayahToolBarPos.xScroll = 0 - positionOffsetPixels;
@@ -406,7 +407,8 @@ public class PagerActivity extends QuranActionBarActivity implements
 
         // If we're more than 1 page away from ayah selection end ayah mode
         if (isInAyahMode) {
-          int ayahPos = QuranInfo.getPosFromPage(start.getPage(), isDualPages);
+          final int startPage = QuranInfo.getPageFromSuraAyah(start.sura, start.ayah);
+          int ayahPos = QuranInfo.getPosFromPage(startPage, isDualPages);
           if (Math.abs(ayahPos - position) > 1) {
             endAyahMode();
           }
@@ -1069,8 +1071,9 @@ public class PagerActivity extends QuranActionBarActivity implements
 
   private void onBookmarksChanged() {
     if (isInAyahMode) {
+      final int startPage = QuranInfo.getPageFromSuraAyah(start.sura, start.ayah);
       compositeDisposable.add(
-          bookmarkModel.getIsBookmarkedObservable(start.sura, start.ayah, start.getPage())
+          bookmarkModel.getIsBookmarkedObservable(start.sura, start.ayah, startPage)
               .observeOn(AndroidSchedulers.mainThread())
               .subscribeWith(new DisposableSingleObserver<Boolean>() {
                 @Override
@@ -1870,7 +1873,7 @@ public class PagerActivity extends QuranActionBarActivity implements
   }
 
   private void selectAyah(SuraAyah s) {
-    final int page = s.getPage();
+    final int page = QuranInfo.getPageFromSuraAyah(s.sura, s.ayah);
     final int position = QuranInfo.getPosFromPage(page, isDualPages);
     Fragment f = pagerAdapter.getFragmentIfExists(position);
     if (f instanceof QuranPage && f.isVisible()) {
@@ -1915,8 +1918,9 @@ public class PagerActivity extends QuranActionBarActivity implements
   //endregion
 
   private void updateToolbarPosition(final SuraAyah start, AyahTracker tracker) {
+    final int startPage = QuranInfo.getPageFromSuraAyah(start.sura, start.ayah);
     compositeDisposable.add(bookmarkModel
-        .getIsBookmarkedObservable(start.sura, start.ayah, start.getPage())
+        .getIsBookmarkedObservable(start.sura, start.ayah, startPage)
         .observeOn(AndroidSchedulers.mainThread())
         .subscribeWith(new DisposableSingleObserver<Boolean>() {
           @Override
@@ -1969,8 +1973,10 @@ public class PagerActivity extends QuranActionBarActivity implements
 
   private void showAyahModeRangeHighlights() {
     // Determine the start and end of the selection
-    int minPage = Math.min(start.getPage(), end.getPage());
-    int maxPage = Math.max(start.getPage(), end.getPage());
+    final int startPage = QuranInfo.getPageFromSuraAyah(start.sura, start.ayah);
+    final int endingPage = QuranInfo.getPageFromSuraAyah(end.sura, end.ayah);
+    int minPage = Math.min(startPage, endingPage);
+    int maxPage = Math.max(startPage, endingPage);
     SuraAyah start = SuraAyah.min(this.start, end);
     SuraAyah end = SuraAyah.max(this.start, this.end);
     // Iterate from beginning to end
@@ -1990,7 +1996,9 @@ public class PagerActivity extends QuranActionBarActivity implements
 
   private void clearAyahModeHighlights() {
     if (isInAyahMode) {
-      for (int i = start.getPage(); i <= end.getPage(); i++) {
+      final int startPage = QuranInfo.getPageFromSuraAyah(start.sura, start.ayah);
+      final int endingPage = QuranInfo.getPageFromSuraAyah(end.sura, end.ayah);
+      for (int i = startPage; i <= endingPage; i++) {
         QuranPage fragment = pagerAdapter.getFragmentIfExistsForPage(i);
         if (fragment != null) {
           fragment.getAyahTracker().unHighlightAyahs(HighlightType.SELECTION);
@@ -2009,7 +2017,8 @@ public class PagerActivity extends QuranActionBarActivity implements
 
       switch (item.getItemId()) {
         case R.id.cab_bookmark_ayah:
-          toggleBookmark(start.sura, start.ayah, start.getPage());
+          final int startPage = QuranInfo.getPageFromSuraAyah(start.sura, start.ayah);
+          toggleBookmark(start.sura, start.ayah, startPage);
           break;
         case R.id.cab_tag_ayah:
           sliderPage = slidingPagerAdapter.getPagePosition(TAG_PAGE);

--- a/app/src/main/java/com/quran/labs/androidquran/ui/QuranActivity.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/QuranActivity.java
@@ -85,6 +85,7 @@ public class QuranActivity extends QuranActionBarActivity
   private QuranSettings settings;
   private Observable<Integer> recentPages;
 
+  @Inject AudioUtils audioUtils;
   @Inject RecentPageModel recentPageModel;
   @Inject TranslationManagerPresenter translationManagerPresenter;
 
@@ -159,7 +160,7 @@ public class QuranActivity extends QuranActionBarActivity
       finish();
       startActivity(i);
     } else {
-      startService(AudioUtils.getAudioIntent(this, AudioService.ACTION_STOP));
+      startService(audioUtils.getAudioIntent(this, AudioService.ACTION_STOP));
     }
     isPaused = false;
   }

--- a/app/src/main/java/com/quran/labs/androidquran/ui/fragment/AyahPlaybackFragment.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/fragment/AyahPlaybackFragment.java
@@ -135,8 +135,8 @@ public class AyahPlaybackFragment extends AyahActionFragment {
         // different range or not playing, so make a new request
         updatedRange = true;
         if (this.start != null) {
-          final int origPage = decidedStart == null ?
-              this.start.getPage() : decidedStart.getPage();
+          final SuraAyah starting = decidedStart == null ? this.start : decidedStart;
+          final int origPage = QuranInfo.getPageFromSuraAyah(starting.sura, starting.ayah);
           if (page != origPage) {
             pagerActivity.highlightAyah(currentStart.sura,
                 currentStart.ayah, HighlightType.AUDIO);
@@ -270,7 +270,8 @@ public class AyahPlaybackFragment extends AyahActionFragment {
       } else {
         start = this.start;
         if (this.start.equals(end)) {
-          final int[] pageBounds = QuranInfo.getPageBounds(start.getPage());
+          final int startPage = QuranInfo.getPageFromSuraAyah(start.sura, start.ayah);
+          final int[] pageBounds = QuranInfo.getPageBounds(startPage);
           ending = new SuraAyah(pageBounds[2], pageBounds[3]);
           shouldEnforce = false;
         } else {

--- a/app/src/main/java/com/quran/labs/androidquran/ui/fragment/AyahPlaybackFragment.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/fragment/AyahPlaybackFragment.java
@@ -11,6 +11,7 @@ import android.widget.ArrayAdapter;
 import android.widget.Button;
 import android.widget.CheckBox;
 
+import com.quran.labs.androidquran.QuranApplication;
 import com.quran.labs.androidquran.R;
 import com.quran.labs.androidquran.data.QuranInfo;
 import com.quran.labs.androidquran.data.SuraAyah;
@@ -19,6 +20,8 @@ import com.quran.labs.androidquran.ui.PagerActivity;
 import com.quran.labs.androidquran.ui.helpers.HighlightType;
 import com.quran.labs.androidquran.util.QuranUtils;
 import com.quran.labs.androidquran.widgets.QuranSpinner;
+
+import javax.inject.Inject;
 
 public class AyahPlaybackFragment extends AyahActionFragment {
   private static final int REPEAT_MAX = 3;
@@ -41,6 +44,8 @@ public class AyahPlaybackFragment extends AyahActionFragment {
   private CheckBox restrictToRange;
   private ArrayAdapter<CharSequence> startAyahAdapter;
   private ArrayAdapter<CharSequence> endingAyahAdapter;
+  
+  @Inject QuranInfo quranInfo;
 
   @Override
   public View onCreateView(LayoutInflater inflater,
@@ -90,6 +95,12 @@ public class AyahPlaybackFragment extends AyahActionFragment {
     return view;
   }
 
+  @Override
+  public void onAttach(Context context) {
+    super.onAttach(context);
+    ((QuranApplication) context.getApplicationContext()).getApplicationComponent().inject(this);
+  }
+
   private View.OnClickListener mOnClickListener = v -> {
     switch (v.getId()) {
       case R.id.apply: {
@@ -120,8 +131,7 @@ public class AyahPlaybackFragment extends AyahActionFragment {
         currentEnding = start;
       }
 
-      final int page = QuranInfo.getPageFromSuraAyah(
-          currentStart.sura, currentStart.ayah);
+      final int page = quranInfo.getPageFromSuraAyah(currentStart.sura, currentStart.ayah);
       final int verseRepeat = positionToRepeat(
           repeatVerseSpinner.getSelectedItemPosition());
       final int rangeRepeat = positionToRepeat(
@@ -136,7 +146,7 @@ public class AyahPlaybackFragment extends AyahActionFragment {
         updatedRange = true;
         if (this.start != null) {
           final SuraAyah starting = decidedStart == null ? this.start : decidedStart;
-          final int origPage = QuranInfo.getPageFromSuraAyah(starting.sura, starting.ayah);
+          final int origPage = quranInfo.getPageFromSuraAyah(starting.sura, starting.ayah);
           if (page != origPage) {
             pagerActivity.highlightAyah(currentStart.sura,
                 currentStart.ayah, HighlightType.AUDIO);
@@ -180,7 +190,7 @@ public class AyahPlaybackFragment extends AyahActionFragment {
           @Override
           public void onItemSelected(AdapterView<?> parent, View view, int position, long rowId) {
             int sura = position + 1;
-            int ayahCount = QuranInfo.getNumAyahs(sura);
+            int ayahCount = quranInfo.getNumAyahs(sura);
             CharSequence[] ayahs = new String[ayahCount];
             for (int i = 0; i < ayahCount; i++){
               ayahs[i] = QuranUtils.getLocalizedNumber(context, (i + 1));
@@ -270,8 +280,8 @@ public class AyahPlaybackFragment extends AyahActionFragment {
       } else {
         start = this.start;
         if (this.start.equals(end)) {
-          final int startPage = QuranInfo.getPageFromSuraAyah(start.sura, start.ayah);
-          final int[] pageBounds = QuranInfo.getPageBounds(startPage);
+          final int startPage = quranInfo.getPageFromSuraAyah(start.sura, start.ayah);
+          final int[] pageBounds = quranInfo.getPageBounds(startPage);
           ending = new SuraAyah(pageBounds[2], pageBounds[3]);
           shouldEnforce = false;
         } else {
@@ -285,14 +295,14 @@ public class AyahPlaybackFragment extends AyahActionFragment {
         applyButton.setText(R.string.play_apply_and_play);
       }
 
-      final int maxAyat = QuranInfo.getNumAyahs(start.sura);
+      final int maxAyat = quranInfo.getNumAyahs(start.sura);
       if (maxAyat == -1) {
         return;
       }
 
       updateAyahSpinner(startAyahSpinner, startAyahAdapter, maxAyat, start.ayah);
       final int endAyat = (ending.sura == start.sura) ? maxAyat :
-          QuranInfo.getNumAyahs(ending.sura);
+          quranInfo.getNumAyahs(ending.sura);
       updateAyahSpinner(endingAyahSpinner, endingAyahAdapter,
           endAyat, ending.ayah);
       startSuraSpinner.setSelection(start.sura - 1);

--- a/app/src/main/java/com/quran/labs/androidquran/ui/fragment/AyahTranslationFragment.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/fragment/AyahTranslationFragment.java
@@ -13,6 +13,7 @@ import android.widget.ProgressBar;
 import com.quran.labs.androidquran.R;
 import com.quran.labs.androidquran.common.LocalTranslation;
 import com.quran.labs.androidquran.common.QuranAyahInfo;
+import com.quran.labs.androidquran.data.QuranInfo;
 import com.quran.labs.androidquran.data.VerseRange;
 import com.quran.labs.androidquran.presenter.translation.InlineTranslationPresenter;
 import com.quran.labs.androidquran.ui.PagerActivity;
@@ -143,7 +144,9 @@ public class AyahTranslationFragment extends AyahActionFragment
         translationControls.setVisibility(View.GONE);
       }
 
-      VerseRange verseRange = new VerseRange(start.sura, start.ayah, end.sura, end.ayah);
+      final int verses = 1 + Math.abs(
+          QuranInfo.getAyahId(start.sura, start.ayah) - QuranInfo.getAyahId(end.sura, end.ayah));
+      VerseRange verseRange = new VerseRange(start.sura, start.ayah, end.sura, end.ayah, verses);
       translationPresenter.refresh(verseRange);
     }
   }

--- a/app/src/main/java/com/quran/labs/androidquran/ui/fragment/AyahTranslationFragment.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/fragment/AyahTranslationFragment.java
@@ -38,6 +38,7 @@ public class AyahTranslationFragment extends AyahActionFragment
   private TranslationsSpinnerAdapter translationAdapter;
   private List<LocalTranslation> translations;
 
+  @Inject QuranInfo quranInfo;
   @Inject QuranSettings quranSettings;
   @Inject InlineTranslationPresenter translationPresenter;
 
@@ -145,7 +146,7 @@ public class AyahTranslationFragment extends AyahActionFragment
       }
 
       final int verses = 1 + Math.abs(
-          QuranInfo.getAyahId(start.sura, start.ayah) - QuranInfo.getAyahId(end.sura, end.ayah));
+          quranInfo.getAyahId(start.sura, start.ayah) - quranInfo.getAyahId(end.sura, end.ayah));
       VerseRange verseRange = new VerseRange(start.sura, start.ayah, end.sura, end.ayah, verses);
       translationPresenter.refresh(verseRange);
     }

--- a/app/src/main/java/com/quran/labs/androidquran/ui/fragment/JumpFragment.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/fragment/JumpFragment.java
@@ -23,6 +23,7 @@ import android.widget.Filter;
 import android.widget.Filterable;
 import android.widget.TextView;
 
+import com.quran.labs.androidquran.QuranApplication;
 import com.quran.labs.androidquran.R;
 import com.quran.labs.androidquran.data.Constants;
 import com.quran.labs.androidquran.data.QuranInfo;
@@ -34,10 +35,14 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import javax.inject.Inject;
+
 import timber.log.Timber;
 
 public class JumpFragment extends DialogFragment {
   public static final String TAG = "JumpFragment";
+  
+  @Inject QuranInfo quranInfo;
 
   public JumpFragment() {
   }
@@ -127,9 +132,9 @@ public class JumpFragment extends DialogFragment {
         Object suraTag = suraInput.getTag();
         if (suraTag != null) {
           int sura = (int) suraTag;
-          int ayahCount = QuranInfo.getNumAyahs(sura);
+          int ayahCount = quranInfo.getNumAyahs(sura);
           ayah = Math.max(1, Math.min(ayahCount, ayah)); // ensure in 1..ayahCount
-          int page = QuranInfo.getPageFromSuraAyah(sura, ayah);
+          int page = quranInfo.getPageFromSuraAyah(sura, ayah);
           pageInput.setHint(QuranUtils.getLocalizedNumber(context, page));
           pageInput.setText(null);
         }
@@ -167,6 +172,12 @@ public class JumpFragment extends DialogFragment {
     });
 
     return builder.create();
+  }
+
+  @Override
+  public void onAttach(Context context) {
+    super.onAttach(context);
+    ((QuranApplication) context.getApplicationContext()).getApplicationComponent().inject(this);
   }
 
   @Override

--- a/app/src/main/java/com/quran/labs/androidquran/ui/fragment/JuzListFragment.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/fragment/JuzListFragment.java
@@ -12,6 +12,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
+import com.quran.labs.androidquran.QuranApplication;
 import com.quran.labs.androidquran.R;
 import com.quran.labs.androidquran.data.Constants;
 import com.quran.labs.androidquran.data.QuranInfo;
@@ -21,6 +22,8 @@ import com.quran.labs.androidquran.ui.helpers.QuranRow;
 import com.quran.labs.androidquran.util.QuranSettings;
 import com.quran.labs.androidquran.util.QuranUtils;
 import com.quran.labs.androidquran.widgets.JuzView;
+
+import javax.inject.Inject;
 
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.Disposable;
@@ -35,6 +38,8 @@ public class JuzListFragment extends Fragment {
 
   private RecyclerView mRecyclerView;
   private Disposable disposable;
+
+  @Inject QuranInfo quranInfo;
 
   public static JuzListFragment newInstance() {
     return new JuzListFragment();
@@ -58,6 +63,12 @@ public class JuzListFragment extends Fragment {
   }
 
   @Override
+  public void onAttach(Context context) {
+    super.onAttach(context);
+    ((QuranApplication) context.getApplicationContext()).getApplicationComponent().inject(this);
+  }
+
+  @Override
   public void onPause() {
     if (disposable != null) {
       disposable.dispose();
@@ -77,7 +88,7 @@ public class JuzListFragment extends Fragment {
             @Override
             public void onSuccess(Integer recentPage) {
               if (recentPage != Constants.NO_PAGE) {
-                int juz = QuranInfo.getJuzFromPage(recentPage);
+                int juz = quranInfo.getJuzFromPage(recentPage);
                 int position = (juz - 1) * 9;
                 mRecyclerView.scrollToPosition(position);
               }
@@ -109,8 +120,8 @@ public class JuzListFragment extends Fragment {
 
     int ctr = 0;
     for (int i = 0; i < (8 * JUZ2_COUNT); i++) {
-      int[] pos = QuranInfo.getQuarterByIndex(i);
-      int page = QuranInfo.getPageFromSuraAyah(pos[0], pos[1]);
+      int[] pos = quranInfo.getQuarterByIndex(i);
+      int page = quranInfo.getPageFromSuraAyah(pos[0], pos[1]);
 
       if (i % 8 == 0) {
         int juz = 1 + (i / 8);
@@ -119,12 +130,12 @@ public class JuzListFragment extends Fragment {
         final QuranRow.Builder builder = new QuranRow.Builder()
             .withType(QuranRow.HEADER)
             .withText(juzTitle)
-            .withPage(QuranInfo.getStartingPageForJuz(juz));
+            .withPage(quranInfo.getStartingPageForJuz(juz));
         elements[ctr++] = builder.build();
       }
 
       final String metadata = getString(R.string.sura_ayah_notification_str, 
-          QuranInfo.getSuraName(activity, pos[0], false), pos[1]);
+          quranInfo.getSuraName(activity, pos[0], false), pos[1]);
       final QuranRow.Builder builder = new QuranRow.Builder()
           .withText(quarters[i])
           .withMetadata(metadata)

--- a/app/src/main/java/com/quran/labs/androidquran/ui/fragment/QuranPageFragment.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/fragment/QuranPageFragment.java
@@ -15,6 +15,7 @@ import android.view.ViewGroup;
 
 import com.quran.labs.androidquran.common.AyahBounds;
 import com.quran.labs.androidquran.dao.Bookmark;
+import com.quran.labs.androidquran.data.QuranInfo;
 import com.quran.labs.androidquran.module.fragment.QuranPageModule;
 import com.quran.labs.androidquran.presenter.quran.QuranPagePresenter;
 import com.quran.labs.androidquran.presenter.quran.QuranPageScreen;
@@ -48,6 +49,7 @@ public class QuranPageFragment extends Fragment implements PageController,
   private int pageNumber;
   private AyahTrackerItem[] ayahTrackerItems;
 
+  @Inject QuranInfo quranInfo;
   @Inject QuranSettings quranSettings;
   @Inject QuranPagePresenter quranPagePresenter;
   @Inject AyahTrackerPresenter ayahTrackerPresenter;
@@ -108,8 +110,8 @@ public class QuranPageFragment extends Fragment implements PageController,
     if (ayahTrackerItems == null) {
       ayahTrackerItems = new AyahTrackerItem[]{
         quranPageLayout.canScroll() ?
-            new AyahScrollableImageTrackerItem(pageNumber, quranPageLayout, imageView) :
-            new AyahImageTrackerItem(pageNumber, imageView)
+            new AyahScrollableImageTrackerItem(pageNumber, quranInfo, quranPageLayout, imageView) :
+            new AyahImageTrackerItem(pageNumber, quranInfo, imageView)
       };
     }
     return ayahTrackerItems;

--- a/app/src/main/java/com/quran/labs/androidquran/ui/fragment/SuraListFragment.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/fragment/SuraListFragment.java
@@ -11,6 +11,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
+import com.quran.labs.androidquran.QuranApplication;
 import com.quran.labs.androidquran.R;
 import com.quran.labs.androidquran.data.Constants;
 import com.quran.labs.androidquran.data.QuranInfo;
@@ -19,6 +20,8 @@ import com.quran.labs.androidquran.ui.helpers.QuranListAdapter;
 import com.quran.labs.androidquran.ui.helpers.QuranRow;
 import com.quran.labs.androidquran.util.QuranSettings;
 import com.quran.labs.androidquran.util.QuranUtils;
+
+import javax.inject.Inject;
 
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.Disposable;
@@ -32,6 +35,8 @@ public class SuraListFragment extends Fragment {
 
   private RecyclerView mRecyclerView;
   private Disposable disposable;
+
+  @Inject QuranInfo quranInfo;
 
   public static SuraListFragment newInstance() {
     return new SuraListFragment();
@@ -55,6 +60,12 @@ public class SuraListFragment extends Fragment {
   }
 
   @Override
+  public void onAttach(Context context) {
+    super.onAttach(context);
+    ((QuranApplication) context.getApplicationContext()).getApplicationComponent().inject(this);
+  }
+
+  @Override
   public void onPause() {
     if (disposable != null) {
       disposable.dispose();
@@ -74,8 +85,8 @@ public class SuraListFragment extends Fragment {
             @Override
             public void onSuccess(Integer recentPage) {
               if (recentPage != Constants.NO_PAGE) {
-                int sura = QuranInfo.safelyGetSuraOnPage(recentPage);
-                int juz = QuranInfo.getJuzFromPage(recentPage);
+                int sura = quranInfo.safelyGetSuraOnPage(recentPage);
+                int juz = quranInfo.getJuzFromPage(recentPage);
                 int position = sura + juz - 1;
                 mRecyclerView.scrollToPosition(position);
               }
@@ -113,17 +124,17 @@ public class SuraListFragment extends Fragment {
       final QuranRow.Builder headerBuilder = new QuranRow.Builder()
           .withType(QuranRow.HEADER)
           .withText(headerTitle)
-          .withPage(QuranInfo.getStartingPageForJuz(juz));
+          .withPage(quranInfo.getStartingPageForJuz(juz));
       elements[pos++] = headerBuilder.build();
       next = (juz == JUZ2_COUNT) ? PAGES_LAST + 1 :
-          QuranInfo.getStartingPageForJuz(juz + 1);
+          quranInfo.getStartingPageForJuz(juz + 1);
 
-      while ((sura <= SURAS_COUNT) && (QuranInfo.getPageNumberForSura(sura) < next)) {
+      while ((sura <= SURAS_COUNT) && (quranInfo.getPageNumberForSura(sura) < next)) {
         final QuranRow.Builder builder = new QuranRow.Builder()
-            .withText(QuranInfo.getSuraName(activity, sura, wantPrefix, wantTranslation))
-            .withMetadata(QuranInfo.getSuraListMetaString(activity, sura))
+            .withText(quranInfo.getSuraName(activity, sura, wantPrefix, wantTranslation))
+            .withMetadata(quranInfo.getSuraListMetaString(activity, sura))
             .withSura(sura)
-            .withPage(QuranInfo.getPageNumberForSura(sura));
+            .withPage(quranInfo.getPageNumberForSura(sura));
         elements[pos++] = builder.build();
         sura++;
       }

--- a/app/src/main/java/com/quran/labs/androidquran/ui/fragment/TabletFragment.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/fragment/TabletFragment.java
@@ -84,6 +84,7 @@ public class TabletFragment extends Fragment
   @Inject Lazy<QuranPagePresenter> quranPagePresenter;
   @Inject Lazy<TranslationPresenter> translationPresenter;
   @Inject AyahSelectedListener ayahSelectedListener;
+  @Inject QuranInfo quranInfo;
 
   public static TabletFragment newInstance(int firstPage, int mode) {
     final TabletFragment f = new TabletFragment();
@@ -198,11 +199,11 @@ public class TabletFragment extends Fragment
       AyahTrackerItem left;
       AyahTrackerItem right;
       if (mode == Mode.ARABIC) {
-        left = new AyahImageTrackerItem(pageNumber, false, leftImageView);
-        right = new AyahImageTrackerItem(pageNumber - 1, true, rightImageView);
+        left = new AyahImageTrackerItem(pageNumber, quranInfo,false, leftImageView);
+        right = new AyahImageTrackerItem(pageNumber - 1, quranInfo, true, rightImageView);
       } else if (mode == Mode.TRANSLATION) {
-        left = new AyahTranslationTrackerItem(pageNumber, leftTranslation);
-        right = new AyahTranslationTrackerItem(pageNumber - 1, rightTranslation);
+        left = new AyahTranslationTrackerItem(pageNumber, quranInfo, leftTranslation);
+        right = new AyahTranslationTrackerItem(pageNumber - 1, quranInfo, rightTranslation);
       } else {
         return new AyahTrackerItem[0];
       }
@@ -240,7 +241,7 @@ public class TabletFragment extends Fragment
           .onTranslationAction((PagerActivity) activity, ayah, translationNames, actionId);
     }
 
-    int page = QuranInfo.getPageFromSuraAyah(ayah.sura, ayah.ayah);
+    int page = quranInfo.getPageFromSuraAyah(ayah.sura, ayah.ayah);
     TranslationView translationView = page == pageNumber ? leftTranslation : rightTranslation;
     translationView.unhighlightAyat();
   }
@@ -277,9 +278,9 @@ public class TabletFragment extends Fragment
                         @NonNull String[] translations,
                         @NonNull List<QuranAyahInfo> verses) {
     if (page == pageNumber) {
-      leftTranslation.setVerses(translations, verses);
+      leftTranslation.setVerses(quranInfo, translations, verses);
     } else if (page == pageNumber - 1) {
-      rightTranslation.setVerses(translations, verses);
+      rightTranslation.setVerses(quranInfo, translations, verses);
     }
   }
 

--- a/app/src/main/java/com/quran/labs/androidquran/ui/fragment/TagBookmarkDialog.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/fragment/TagBookmarkDialog.java
@@ -36,6 +36,7 @@ public class TagBookmarkDialog extends DialogFragment {
   private static final String EXTRA_BOOKMARK_IDS = "bookmark_ids";
 
   private TagsAdapter mAdapter;
+  @Inject QuranInfo quranInfo;
   @Inject TagBookmarkPresenter mTagBookmarkPresenter;
 
 
@@ -61,7 +62,7 @@ public class TagBookmarkDialog extends DialogFragment {
   }
 
   public void updateAyah(@NonNull SuraAyah suraAyah) {
-    final int page = QuranInfo.getPageFromSuraAyah(suraAyah.sura, suraAyah.ayah);
+    final int page = quranInfo.getPageFromSuraAyah(suraAyah.sura, suraAyah.ayah);
     mTagBookmarkPresenter.setAyahBookmarkMode(suraAyah.sura, suraAyah.ayah, page);
   }
 

--- a/app/src/main/java/com/quran/labs/androidquran/ui/fragment/TagBookmarkDialog.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/fragment/TagBookmarkDialog.java
@@ -20,6 +20,7 @@ import android.widget.TextView;
 import com.quran.labs.androidquran.QuranApplication;
 import com.quran.labs.androidquran.R;
 import com.quran.labs.androidquran.dao.Tag;
+import com.quran.labs.androidquran.data.QuranInfo;
 import com.quran.labs.androidquran.data.SuraAyah;
 import com.quran.labs.androidquran.presenter.bookmark.TagBookmarkPresenter;
 
@@ -60,7 +61,8 @@ public class TagBookmarkDialog extends DialogFragment {
   }
 
   public void updateAyah(@NonNull SuraAyah suraAyah) {
-    mTagBookmarkPresenter.setAyahBookmarkMode(suraAyah.sura, suraAyah.ayah, suraAyah.getPage());
+    final int page = QuranInfo.getPageFromSuraAyah(suraAyah.sura, suraAyah.ayah);
+    mTagBookmarkPresenter.setAyahBookmarkMode(suraAyah.sura, suraAyah.ayah, page);
   }
 
   @Override

--- a/app/src/main/java/com/quran/labs/androidquran/ui/fragment/TranslationFragment.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/fragment/TranslationFragment.java
@@ -10,6 +10,7 @@ import android.view.View;
 import android.view.ViewGroup;
 
 import com.quran.labs.androidquran.common.QuranAyahInfo;
+import com.quran.labs.androidquran.data.QuranInfo;
 import com.quran.labs.androidquran.module.fragment.QuranPageModule;
 import com.quran.labs.androidquran.presenter.quran.ayahtracker.AyahTrackerItem;
 import com.quran.labs.androidquran.presenter.quran.ayahtracker.AyahTrackerPresenter;
@@ -45,6 +46,7 @@ public class TranslationFragment extends Fragment implements
   private QuranTranslationPageLayout mainView;
   private AyahTrackerItem[] ayahTrackerItems;
 
+  @Inject QuranInfo quranInfo;
   @Inject QuranSettings quranSettings;
   @Inject TranslationPresenter presenter;
   @Inject AyahTrackerPresenter ayahTrackerPresenter;
@@ -132,7 +134,7 @@ public class TranslationFragment extends Fragment implements
   public AyahTrackerItem[] getAyahTrackerItems() {
     if (ayahTrackerItems == null) {
       ayahTrackerItems = new AyahTrackerItem[] {
-          new AyahTranslationTrackerItem(pageNumber, translationView) };
+          new AyahTranslationTrackerItem(pageNumber, quranInfo, translationView) };
     }
     return ayahTrackerItems;
   }
@@ -156,7 +158,7 @@ public class TranslationFragment extends Fragment implements
   public void setVerses(int page,
                         @NonNull String[] translations,
                         @NonNull List<QuranAyahInfo> verses) {
-    translationView.setVerses(translations, verses);
+    translationView.setVerses(quranInfo, translations, verses);
     if (highlightedAyah > 0) {
       translationView.highlightAyah(highlightedAyah);
     }

--- a/app/src/main/java/com/quran/labs/androidquran/ui/helpers/QuranDisplayHelper.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/helpers/QuranDisplayHelper.java
@@ -41,12 +41,14 @@ public class QuranDisplayHelper {
     return response;
   }
 
-  public static long displayMarkerPopup(Context context, int page,
-      long lastPopupTime) {
+  public static long displayMarkerPopup(Context context,
+                                        QuranInfo quranInfo,
+                                        int page,
+                                        long lastPopupTime) {
     if (System.currentTimeMillis() - lastPopupTime < 3000) {
       return lastPopupTime;
     }
-    int rub3 = QuranInfo.getRub3FromPage(page);
+    int rub3 = quranInfo.getRub3FromPage(page);
     if (rub3 == -1) {
       return lastPopupTime;
     }
@@ -76,8 +78,8 @@ public class QuranDisplayHelper {
   }
 
   // same logic used in displayMarkerPopup method
-  public static String displayRub3(Context context, int page){
-    int rub3 = QuranInfo.getRub3FromPage(page);
+  public static String displayRub3(Context context, QuranInfo quranInfo, int page){
+    int rub3 = quranInfo.getRub3FromPage(page);
     if (rub3 == -1) {
       return "";
     }

--- a/app/src/main/java/com/quran/labs/androidquran/ui/helpers/QuranPageAdapter.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/helpers/QuranPageAdapter.java
@@ -19,10 +19,13 @@ public class QuranPageAdapter extends FragmentStatePagerAdapter {
 
   private boolean mIsShowingTranslation = false;
   private boolean mIsDualPages = false;
+  private final QuranInfo quranInfo;
 
   public QuranPageAdapter(FragmentManager fm, boolean dualPages,
-                          boolean isShowingTranslation) {
+                          boolean isShowingTranslation,
+                          QuranInfo quranInfo) {
     super(fm, dualPages ? "dualPages" : "singlePage");
+    this.quranInfo = quranInfo;
     mIsDualPages = dualPages;
     mIsShowingTranslation = isShowingTranslation;
   }
@@ -71,7 +74,7 @@ public class QuranPageAdapter extends FragmentStatePagerAdapter {
 
   @Override
   public Fragment getItem(int position) {
-    int page = QuranInfo.getPageFromPos(position, mIsDualPages);
+    int page = quranInfo.getPageFromPos(position, mIsDualPages);
     Timber.d("getting page: %d", page);
     if (mIsDualPages) {
       return TabletFragment.newInstance(page,
@@ -105,7 +108,7 @@ public class QuranPageAdapter extends FragmentStatePagerAdapter {
     if (page < Constants.PAGES_FIRST || PAGES_LAST < page) {
       return null;
     }
-    int position = QuranInfo.getPosFromPage(page, mIsDualPages);
+    int position = quranInfo.getPosFromPage(page, mIsDualPages);
     Fragment fragment = getFragmentIfExists(position);
     return fragment instanceof QuranPage && fragment.isAdded() ? (QuranPage) fragment : null;
   }

--- a/app/src/main/java/com/quran/labs/androidquran/ui/helpers/QuranRowFactory.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/helpers/QuranRowFactory.java
@@ -15,8 +15,11 @@ import dagger.Reusable;
 @Reusable
 public class QuranRowFactory {
 
+  private final QuranInfo quranInfo;
+  
   @Inject
-  QuranRowFactory() {
+  QuranRowFactory(QuranInfo quranInfo) {
+    this.quranInfo = quranInfo;
   }
 
   public QuranRow fromRecentPageHeader(Context context, int count) {
@@ -40,9 +43,9 @@ public class QuranRowFactory {
 
   public QuranRow fromCurrentPage(Context context, int page) {
     return new QuranRow.Builder()
-        .withText(QuranInfo.getSuraNameString(context, page))
-        .withMetadata(QuranInfo.getPageSubtitle(context, page))
-        .withSura(QuranInfo.safelyGetSuraOnPage(page))
+        .withText(quranInfo.getSuraNameString(context, page))
+        .withMetadata(quranInfo.getPageSubtitle(context, page))
+        .withSura(quranInfo.safelyGetSuraOnPage(page))
         .withPage(page)
         .withImageResource(R.drawable.bookmark_currentpage).build();
   }
@@ -55,9 +58,9 @@ public class QuranRowFactory {
     final QuranRow.Builder builder = new QuranRow.Builder();
 
     if (bookmark.isPageBookmark()) {
-      final int sura = QuranInfo.getSuraNumberFromPage(bookmark.page);
-      builder.withText(QuranInfo.getSuraNameString(context, bookmark.page))
-          .withMetadata(QuranInfo.getPageSubtitle(context, bookmark.page))
+      final int sura = quranInfo.getSuraNumberFromPage(bookmark.page);
+      builder.withText(quranInfo.getSuraNameString(context, bookmark.page))
+          .withMetadata(quranInfo.getPageSubtitle(context, bookmark.page))
           .withType(QuranRow.PAGE_BOOKMARK)
           .withBookmark(bookmark)
           .withSura(sura)
@@ -68,11 +71,11 @@ public class QuranRowFactory {
       final String title;
       final String metadata;
       if (ayahText == null) {
-        title = QuranInfo.getAyahString(bookmark.sura, bookmark.ayah, context);
-        metadata = QuranInfo.getPageSubtitle(context, bookmark.page);
+        title = quranInfo.getAyahString(bookmark.sura, bookmark.ayah, context);
+        metadata = quranInfo.getPageSubtitle(context, bookmark.page);
       } else {
         title = ayahText;
-        metadata = QuranInfo.getAyahMetadata(bookmark.sura, bookmark.ayah, bookmark.page, context);
+        metadata = quranInfo.getAyahMetadata(bookmark.sura, bookmark.ayah, bookmark.page, context);
       }
 
       builder.withText(title)

--- a/app/src/main/java/com/quran/labs/androidquran/ui/helpers/QuranRowFactory.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/helpers/QuranRowFactory.java
@@ -8,28 +8,37 @@ import com.quran.labs.androidquran.dao.Bookmark;
 import com.quran.labs.androidquran.dao.Tag;
 import com.quran.labs.androidquran.data.QuranInfo;
 
+import javax.inject.Inject;
+
+import dagger.Reusable;
+
+@Reusable
 public class QuranRowFactory {
 
-  public static QuranRow fromRecentPageHeader(Context context, int count) {
+  @Inject
+  QuranRowFactory() {
+  }
+
+  public QuranRow fromRecentPageHeader(Context context, int count) {
     return new QuranRow.Builder()
         .withText(context.getResources().getQuantityString(R.plurals.plural_recent_pages, count))
         .withType(QuranRow.HEADER)
         .build();
   }
 
-  public static QuranRow fromPageBookmarksHeader(Context context) {
+  public QuranRow fromPageBookmarksHeader(Context context) {
     return new QuranRow.Builder()
         .withText(context.getString(R.string.menu_bookmarks_page))
         .withType(QuranRow.HEADER).build();
   }
 
-  public static QuranRow fromAyahBookmarksHeader(Context context) {
+  public QuranRow fromAyahBookmarksHeader(Context context) {
     return new QuranRow.Builder()
         .withText(context.getString(R.string.menu_bookmarks_ayah))
         .withType(QuranRow.HEADER).build();
   }
 
-  public static QuranRow fromCurrentPage(Context context, int page) {
+  public QuranRow fromCurrentPage(Context context, int page) {
     return new QuranRow.Builder()
         .withText(QuranInfo.getSuraNameString(context, page))
         .withMetadata(QuranInfo.getPageSubtitle(context, page))
@@ -38,11 +47,11 @@ public class QuranRowFactory {
         .withImageResource(R.drawable.bookmark_currentpage).build();
   }
 
-  public static QuranRow fromBookmark(Context context, Bookmark bookmark) {
+  public QuranRow fromBookmark(Context context, Bookmark bookmark) {
     return fromBookmark(context, bookmark, null);
   }
 
-  public static QuranRow fromBookmark(Context context, Bookmark bookmark, Long tagId) {
+  public QuranRow fromBookmark(Context context, Bookmark bookmark, Long tagId) {
     final QuranRow.Builder builder = new QuranRow.Builder();
 
     if (bookmark.isPageBookmark()) {
@@ -80,7 +89,7 @@ public class QuranRowFactory {
     return builder.build();
   }
 
-  public static QuranRow fromTag(Tag tag) {
+  public QuranRow fromTag(Tag tag) {
     return new QuranRow.Builder()
         .withType(QuranRow.BOOKMARK_HEADER)
         .withText(tag.getName())

--- a/app/src/main/java/com/quran/labs/androidquran/ui/translation/TranslationAdapter.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/translation/TranslationAdapter.java
@@ -17,7 +17,6 @@ import android.widget.TextView;
 
 import com.quran.labs.androidquran.R;
 import com.quran.labs.androidquran.common.QuranAyahInfo;
-import com.quran.labs.androidquran.data.QuranInfo;
 import com.quran.labs.androidquran.model.translation.ArabicDatabaseUtils;
 import com.quran.labs.androidquran.ui.helpers.UthmaniSpan;
 import com.quran.labs.androidquran.util.QuranSettings;
@@ -234,7 +233,7 @@ class TranslationAdapter extends RecyclerView.Adapter<TranslationAdapter.RowView
     if (holder.text != null) {
       final CharSequence text;
       if (row.type == TranslationViewRow.Type.SURA_HEADER) {
-        text = QuranInfo.getSuraName(context, row.ayahInfo.sura, true);
+        text = row.data;
         holder.text.setBackgroundColor(suraHeaderColor);
       } else if (row.type == TranslationViewRow.Type.BASMALLAH ||
           row.type == TranslationViewRow.Type.QURAN_TEXT) {

--- a/app/src/main/java/com/quran/labs/androidquran/ui/translation/TranslationView.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/translation/TranslationView.java
@@ -13,6 +13,7 @@ import android.widget.FrameLayout;
 
 import com.quran.labs.androidquran.R;
 import com.quran.labs.androidquran.common.QuranAyahInfo;
+import com.quran.labs.androidquran.data.QuranInfo;
 import com.quran.labs.androidquran.util.QuranSettings;
 import com.quran.labs.androidquran.widgets.AyahToolBar;
 
@@ -69,7 +70,9 @@ public class TranslationView extends FrameLayout implements View.OnClickListener
         context.getResources().getDimensionPixelSize(R.dimen.toolbar_total_height));
   }
 
-  public void setVerses(@NonNull String[] translations, @NonNull List<QuranAyahInfo> verses) {
+  public void setVerses(@NonNull QuranInfo quranInfo,
+                        @NonNull String[] translations,
+                        @NonNull List<QuranAyahInfo> verses) {
     this.translations = translations;
 
     List<TranslationViewRow> rows = new ArrayList<>();
@@ -79,7 +82,8 @@ public class TranslationView extends FrameLayout implements View.OnClickListener
       QuranAyahInfo verse = verses.get(i);
       int sura = verse.sura;
       if (sura != currentSura) {
-        rows.add(new TranslationViewRow(TranslationViewRow.Type.SURA_HEADER, verse));
+        rows.add(new TranslationViewRow(TranslationViewRow.Type.SURA_HEADER, verse,
+            quranInfo.getSuraName(getContext(), sura, true)));
         currentSura = sura;
       }
 

--- a/app/src/main/java/com/quran/labs/androidquran/util/AudioManagerUtils.java
+++ b/app/src/main/java/com/quran/labs/androidquran/util/AudioManagerUtils.java
@@ -39,7 +39,7 @@ public class AudioManagerUtils {
 
   @NonNull
   public static Single<List<QariDownloadInfo>> shuyookhDownloadObservable(
-      final String basePath, List<QariItem> qariItems) {
+      QuranInfo quranInfo,  String basePath, List<QariItem> qariItems) {
     return Observable.fromIterable(qariItems)
         .flatMap(new Function<QariItem, ObservableSource<QariDownloadInfo>>() {
           @Override
@@ -52,7 +52,7 @@ public class AudioManagerUtils {
             File baseFile = new File(basePath, item.getPath());
             return !baseFile.exists() ? Observable.just(new QariDownloadInfo(item)) :
                 item.isGapless() ? getGaplessSheikhObservable(baseFile, item).toObservable() :
-                    getGappedSheikhObservable(baseFile, item).toObservable();
+                    getGappedSheikhObservable(quranInfo, baseFile, item).toObservable();
           }
         })
         .doOnNext(qariDownloadInfo -> sCache.put(qariDownloadInfo.qariItem, qariDownloadInfo))
@@ -73,12 +73,12 @@ public class AudioManagerUtils {
 
   @NonNull
   private static Single<QariDownloadInfo> getGappedSheikhObservable(
-      final File basePath, final QariItem qariItem) {
+      final QuranInfo quranInfo, final File basePath, final QariItem qariItem) {
     return Observable.range(1, 114)
         .map(sura -> new SuraFileName(sura, new File(basePath, String.valueOf(sura))))
         .filter(suraFile -> suraFile.file.exists())
         .map(sf -> new Pair<>(sf.sura,
-            sf.file.listFiles().length >= QuranInfo.getNumAyahs(sf.sura)))
+            sf.file.listFiles().length >= quranInfo.getNumAyahs(sf.sura)))
         .toList()
         .map(downloaded -> QariDownloadInfo.withPartials(qariItem, downloaded));
   }

--- a/app/src/main/java/com/quran/labs/androidquran/util/AudioUtils.java
+++ b/app/src/main/java/com/quran/labs/androidquran/util/AudioUtils.java
@@ -20,10 +20,14 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 
+import javax.inject.Inject;
+
+import dagger.Reusable;
 import timber.log.Timber;
 
 import static com.quran.labs.androidquran.data.Constants.PAGES_LAST;
 
+@Reusable
 public class AudioUtils {
 
   public static final String AUDIO_EXTENSION = ".mp3";
@@ -41,6 +45,10 @@ public class AudioUtils {
     static final int MAX = 3;
   }
 
+  @Inject
+  public AudioUtils() {
+  }
+
   /**
    * Get a list of QariItem representing the qaris to show
    *
@@ -50,7 +58,7 @@ public class AudioUtils {
    * @param context the current context
    * @return a list of QariItem representing the qaris to show.
    */
-  public static List<QariItem> getQariList(@NonNull Context context) {
+  public List<QariItem> getQariList(@NonNull Context context) {
     final Resources resources = context.getResources();
     final String[] shuyookh = resources.getStringArray(R.array.quran_readers_name);
     final String[] paths = resources.getStringArray(R.array.quran_readers_path);
@@ -75,7 +83,7 @@ public class AudioUtils {
     return items;
   }
 
-  public static String getQariUrl(@NonNull QariItem item) {
+  public String getQariUrl(@NonNull QariItem item) {
     String url = item.getUrl();
     if (item.isGapless()) {
       url += "%03d" + AudioUtils.AUDIO_EXTENSION;
@@ -85,12 +93,12 @@ public class AudioUtils {
     return url;
   }
 
-  public static String getLocalQariUrl(@NonNull Context context, @NonNull QariItem item) {
+  public String getLocalQariUrl(@NonNull Context context, @NonNull QariItem item) {
     String rootDirectory = QuranFileUtils.getQuranAudioDirectory(context);
     return rootDirectory == null ? null : rootDirectory + item.getPath();
   }
 
-  public static String getQariDatabasePathIfGapless(
+  public String getQariDatabasePathIfGapless(
       @NonNull Context context, @NonNull QariItem item) {
     String databaseName = item.getDatabaseName();
     if (databaseName != null) {
@@ -102,7 +110,7 @@ public class AudioUtils {
     return databaseName;
   }
 
-  public static boolean shouldDownloadGaplessDatabase(DownloadAudioRequest request) {
+  public boolean shouldDownloadGaplessDatabase(DownloadAudioRequest request) {
     if (!request.isGapless()) {
       return false;
     }
@@ -115,7 +123,7 @@ public class AudioUtils {
     return !f.exists();
   }
 
-  public static String getGaplessDatabaseUrl(DownloadAudioRequest request) {
+  public String getGaplessDatabaseUrl(DownloadAudioRequest request) {
     if (!request.isGapless()) {
       return null;
     }
@@ -125,7 +133,7 @@ public class AudioUtils {
     return QuranFileUtils.getGaplessDatabaseRootUrl() + "/" + dbname;
   }
 
-  public static SuraAyah getLastAyahToPlay(SuraAyah startAyah,
+  public SuraAyah getLastAyahToPlay(SuraAyah startAyah,
       int page, int mode, boolean isDualPages) {
     if (isDualPages && mode == LookAheadAmount.PAGE && (page % 2 == 1)) {
       // if we download page by page and we are currently in tablet mode
@@ -191,7 +199,7 @@ public class AudioUtils {
     return new SuraAyah(pageLastSura, pageLastAyah);
   }
 
-  public static boolean shouldDownloadBasmallah(DownloadAudioRequest request) {
+  public boolean shouldDownloadBasmallah(DownloadAudioRequest request) {
     if (request.isGapless()) {
       return false;
     }
@@ -220,7 +228,7 @@ public class AudioUtils {
     return f.exists();
   }
 
-  private static boolean doesRequireBasmallah(AudioRequest request) {
+  private boolean doesRequireBasmallah(AudioRequest request) {
     SuraAyah minAyah = request.getMinAyah();
     int startSura = minAyah.sura;
     int startAyah = minAyah.ayah;
@@ -253,13 +261,13 @@ public class AudioUtils {
     return false;
   }
 
-  private static boolean haveAnyFiles(Context context, String path) {
+  private boolean haveAnyFiles(Context context, String path) {
     final String basePath = QuranFileUtils.getQuranAudioDirectory(context);
     final File file = new File(basePath, path);
     return file.isDirectory() && file.list().length > 0;
   }
 
-  public static boolean haveAllFiles(DownloadAudioRequest request) {
+  public boolean haveAllFiles(DownloadAudioRequest request) {
     String baseDirectory = request.getLocalPath();
     if (TextUtils.isEmpty(baseDirectory)) {
       return false;
@@ -317,7 +325,7 @@ public class AudioUtils {
     return true;
   }
 
-  public static Intent getAudioIntent(Context context, String action) {
+  public Intent getAudioIntent(Context context, String action) {
     final Intent intent = new Intent(context, AudioService.class);
     intent.setAction(action);
     return intent;

--- a/app/src/main/java/com/quran/labs/androidquran/util/AudioUtils.java
+++ b/app/src/main/java/com/quran/labs/androidquran/util/AudioUtils.java
@@ -45,8 +45,11 @@ public class AudioUtils {
     static final int MAX = 3;
   }
 
+  private final QuranInfo quranInfo;
+
   @Inject
-  public AudioUtils() {
+  public AudioUtils(QuranInfo quranInfo) {
+    this.quranInfo = quranInfo;
   }
 
   /**
@@ -148,9 +151,9 @@ public class AudioUtils {
       return null;
     }
     if (page < PAGES_LAST) {
-      int nextPageSura = QuranInfo.safelyGetSuraOnPage(page);
+      int nextPageSura = quranInfo.safelyGetSuraOnPage(page);
       // using [page+1] as an index because we literally want the next page
-      int nextPageAyah = QuranInfo.getFirstAyahOnPage(page + 1);
+      int nextPageAyah = quranInfo.getFirstAyahOnPage(page + 1);
 
       pageLastSura = nextPageSura;
       pageLastAyah = nextPageAyah - 1;
@@ -159,13 +162,13 @@ public class AudioUtils {
         if (pageLastSura < 1) {
           pageLastSura = 1;
         }
-        pageLastAyah = QuranInfo.getNumAyahs(pageLastSura);
+        pageLastAyah = quranInfo.getNumAyahs(pageLastSura);
       }
     }
 
     if (mode == LookAheadAmount.SURA) {
       int sura = startAyah.sura;
-      int lastAyah = QuranInfo.getNumAyahs(sura);
+      int lastAyah = quranInfo.getNumAyahs(sura);
       if (lastAyah == -1) {
         return null;
       }
@@ -173,22 +176,22 @@ public class AudioUtils {
       // if we start playback between two suras, download both suras
       if (pageLastSura > sura) {
         sura = pageLastSura;
-        lastAyah = QuranInfo.getNumAyahs(sura);
+        lastAyah = quranInfo.getNumAyahs(sura);
       }
       return new SuraAyah(sura, lastAyah);
     } else if (mode == LookAheadAmount.JUZ) {
-      int juz = QuranInfo.getJuzFromPage(page);
+      int juz = quranInfo.getJuzFromPage(page);
       if (juz == 30) {
         return new SuraAyah(114, 6);
       } else if (juz >= 1 && juz < 30) {
-        int[] endJuz = QuranInfo.getQuarterByIndex(juz * 8);
+        int[] endJuz = quranInfo.getQuarterByIndex(juz * 8);
         if (pageLastSura > endJuz[0]) {
           // ex between jathiya and a7qaf
-          endJuz = QuranInfo.getQuarterByIndex((juz + 1) * 8);
+          endJuz = quranInfo.getQuarterByIndex((juz + 1) * 8);
         } else if (pageLastSura == endJuz[0] &&
             pageLastAyah > endJuz[1]) {
           // ex surat al anfal
-          endJuz = QuranInfo.getQuarterByIndex((juz + 1) * 8);
+          endJuz = quranInfo.getQuarterByIndex((juz + 1) * 8);
         }
 
         return new SuraAyah(endJuz[0], endJuz[1]);
@@ -240,7 +243,7 @@ public class AudioUtils {
     Timber.d("seeing if need basmalla...");
 
     for (int i = startSura; i <= endSura; i++) {
-      int lastAyah = QuranInfo.getNumAyahs(i);
+      int lastAyah = quranInfo.getNumAyahs(i);
       if (i == endSura) {
         lastAyah = endAyah;
       }
@@ -289,7 +292,7 @@ public class AudioUtils {
     int endAyah = maxAyah.ayah;
 
     for (int i = startSura; i <= endSura; i++) {
-      int lastAyah = QuranInfo.getNumAyahs(i);
+      int lastAyah = quranInfo.getNumAyahs(i);
       if (i == endSura) {
         lastAyah = endAyah;
       }

--- a/app/src/main/java/com/quran/labs/androidquran/util/QuranAppUtils.java
+++ b/app/src/main/java/com/quran/labs/androidquran/util/QuranAppUtils.java
@@ -28,9 +28,12 @@ import timber.log.Timber;
 
 @Reusable
 public class QuranAppUtils {
+  private final QuranInfo quranInfo;
 
   @Inject
-  QuranAppUtils() {}
+  QuranAppUtils(QuranInfo quranInfo) {
+    this.quranInfo = quranInfo;
+  }
 
   public Single<String> getQuranAppUrlObservable(final String key,
                                                  final SuraAyah start,
@@ -39,7 +42,7 @@ public class QuranAppUtils {
       int sura = start.sura;
       int startAyah = start.ayah;
       // quranapp only supports sharing within a sura
-      int endAyah = end.sura == start.sura ? end.ayah : QuranInfo.getNumAyahs(start.sura);
+      int endAyah = end.sura == start.sura ? end.ayah : quranInfo.getNumAyahs(start.sura);
       return getQuranAppUrl(key, sura, startAyah, endAyah);
     }).subscribeOn(Schedulers.io());
   }

--- a/app/src/main/java/com/quran/labs/androidquran/util/ShareUtil.java
+++ b/app/src/main/java/com/quran/labs/androidquran/util/ShareUtil.java
@@ -21,9 +21,12 @@ import dagger.Reusable;
 
 @Reusable
 public class ShareUtil {
+  private final QuranInfo quranInfo;
 
   @Inject
-  ShareUtil() {}
+  ShareUtil(QuranInfo quranInfo) {
+    this.quranInfo = quranInfo;
+  }
 
   public void copyVerses(Activity activity, List<QuranText> verses) {
     String text = getShareText(activity, verses);
@@ -69,7 +72,7 @@ public class ShareUtil {
         .append("\n\n");
     }
     sb.append('-')
-      .append(QuranInfo.getSuraAyahString(context, ayahInfo.sura, ayahInfo.ayah));
+      .append(quranInfo.getSuraAyahString(context, ayahInfo.sura, ayahInfo.ayah));
 
     return sb.toString();
   }
@@ -91,14 +94,14 @@ public class ShareUtil {
     sb.append("[");
 
     final QuranText firstAyah = verses.get(0);
-    sb.append(QuranInfo.getSuraName(activity, firstAyah.sura, true));
+    sb.append(quranInfo.getSuraName(activity, firstAyah.sura, true));
     sb.append(" ");
     sb.append(firstAyah.ayah);
     if (size > 1) {
       final QuranText lastAyah = verses.get(size - 1);
       sb.append(" - ");
       if (firstAyah.sura != lastAyah.sura) {
-        sb.append(QuranInfo.getSuraName(activity, lastAyah.sura, true));
+        sb.append(quranInfo.getSuraName(activity, lastAyah.sura, true));
         sb.append(" ");
       }
       sb.append(lastAyah.ayah);

--- a/app/src/main/java/com/quran/labs/androidquran/widgets/AudioStatusBar.java
+++ b/app/src/main/java/com/quran/labs/androidquran/widgets/AudioStatusBar.java
@@ -27,7 +27,6 @@ import android.widget.TextView;
 import com.quran.labs.androidquran.R;
 import com.quran.labs.androidquran.common.QariItem;
 import com.quran.labs.androidquran.data.Constants;
-import com.quran.labs.androidquran.util.AudioUtils;
 import com.quran.labs.androidquran.util.QuranScreenInfo;
 import com.quran.labs.androidquran.util.QuranSettings;
 import com.quran.labs.androidquran.util.QuranUtils;
@@ -123,9 +122,9 @@ public class AudioStatusBar extends LeftToRightLinearLayout {
           itemBackground);
       ta.recycle();
     }
+  }
 
-    List<QariItem> qariList = AudioUtils.getQariList(this.context);
-
+  public void setQariList(List<QariItem> qariList) {
     // TODO: optimize - PREF_DEFAULT_QARI is the qari id, should introduce a helper pref for pos
     final int qaris = qariList.size();
     if (currentQari >= qaris || qariList.get(currentQari).getId() != currentQari) {

--- a/app/src/test/java/com/quran/labs/androidquran/presenter/translation/BaseTranslationPresenterTest.java
+++ b/app/src/test/java/com/quran/labs/androidquran/presenter/translation/BaseTranslationPresenterTest.java
@@ -54,7 +54,7 @@ public class BaseTranslationPresenterTest {
 
   @Test
   public void testCombineAyahDataOneVerse() throws Exception {
-    VerseRange verseRange = new VerseRange(1, 1, 1, 1);
+    VerseRange verseRange = new VerseRange(1, 1, 1, 1, 1);
     List<QuranText> arabic = Collections.singletonList(new QuranText(1, 1, "first ayah"));
     List<QuranAyahInfo> info = presenter.combineAyahData(verseRange, arabic,
         Collections.singletonList(Collections.singletonList(new QuranText(1, 1, "translation"))));
@@ -70,7 +70,7 @@ public class BaseTranslationPresenterTest {
 
   @Test
   public void testCombineAyahDataOneVerseEmpty() throws Exception {
-    VerseRange verseRange = new VerseRange(1, 1, 1, 1);
+    VerseRange verseRange = new VerseRange(1, 1, 1, 1, 1);
     List<QuranText> arabic = Collections.emptyList();
     List<QuranAyahInfo> info =
         presenter.combineAyahData(verseRange, arabic, Collections.emptyList());
@@ -79,7 +79,7 @@ public class BaseTranslationPresenterTest {
 
   @Test
   public void testCombineAyahDataOneVerseNoArabic() throws Exception {
-    VerseRange verseRange = new VerseRange(1, 1, 1, 1);
+    VerseRange verseRange = new VerseRange(1, 1, 1, 1, 1);
     List<QuranText> arabic = Collections.emptyList();
     List<QuranAyahInfo> info = presenter.combineAyahData(verseRange, arabic,
         Collections.singletonList(Collections.singletonList(new QuranText(1, 1, "translation"))));
@@ -95,7 +95,7 @@ public class BaseTranslationPresenterTest {
 
   @Test
   public void testCombineAyahDataArabicEmptyTranslations() throws Exception {
-    VerseRange verseRange = new VerseRange(1, 1, 1, 2);
+    VerseRange verseRange = new VerseRange(1, 1, 1, 2, 2);
     List<QuranText> arabic = Arrays.asList(
         new QuranText(1, 1, "first ayah"),
         new QuranText(1, 2, "second ayah")
@@ -114,7 +114,7 @@ public class BaseTranslationPresenterTest {
 
   @Test
   public void testEnsureProperTranslations() {
-    VerseRange verseRange = new VerseRange(1, 1, 1, 2);
+    VerseRange verseRange = new VerseRange(1, 1, 1, 2, 2);
 
     List<QuranText> text = new ArrayList<>();
     text.add(new QuranText(1, 1, "bismillah"));

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Sep 11 23:58:41 GST 2017
+#Sat Jan 13 11:45:45 GST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip


### PR DESCRIPTION
This patch makes the usages of `QuranInfo` (and, consequently, a number of other classes) non-static. This is an important step that insha'Allah paves the way for passing a data source dynamically and being able to eventually change the page type within the app.