### PR TITLE
fixed juz for pages 121 and 201

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/data/QuranInfo.java
+++ b/app/src/main/java/com/quran/labs/androidquran/data/QuranInfo.java
@@ -259,6 +259,11 @@ public class QuranInfo {
   }
 
   public int getJuzFromPage(int page) {
+    if (page == 121) {
+      return 6;
+    } else if (page == 201) {
+      return 10;
+    }
     for (int i = 0; i < juzPageStart.length; i++) {
       if (juzPageStart[i] > page) {
         return i;


### PR DESCRIPTION
This is in response to issue #970 that I've just opened.
Yes, I know it seems like a bad idea to hard code it but these are just two cases in the entire Quran.
I also preferred that because the data is correct, page 121 is indeed where Juz 7 starts and the same for page 201. It is just what is displayed on the page is what had to be changed.