### PR TITLE
Use Play Store badge instead of app logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
-[![Build Status](https://travis-ci.org/quran/quran_android.svg?branch=master)](https://travis-ci.org/quran/quran_android)   
+[![Build Status](https://travis-ci.org/quran/quran_android.svg?branch=master)](https://travis-ci.org/quran/quran_android)
+# Quran for Android
+[<img align="right" alt="Get it on Google Play" height="128" src="https://play.google.com/intl/en_us/badges/images/generic/en_badge_web_generic.png">](https://play.google.com/store/apps/details?id=com.quran.labs.androidquran)
 
-[![Get it on Google Play](https://play.google.com/intl/en_us/badges/images/generic/en_badge_web_generic.png)](https://play.google.com/store/apps/details?id=com.quran.labs.androidquran)
-# Quran for Android 
-[<img align="right" src="https://raw.githubusercontent.com/quran/quran_android/master/app/src/madani/res/drawable-xxxhdpi/icon.png" />](https://play.google.com/store/apps/details?id=com.quran.labs.androidquran)
-
-this is a simple (madani based) quran app for android.
+This is a simple (Madani based) Quran app for Android.
 
 * madani images from [quran images project](https://github.com/quran/quran.com-images) on github.
 * qaloon images used with permission of Nous Memes Editions Et Diffusion (Tunisia).


### PR DESCRIPTION
Hopefully, this makes the image purpose more intuitive and gives the correct message.

Follow-up for #988.