### PR TITLE
Properly support juz' overrides

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/data/QuranInfo.java
+++ b/app/src/main/java/com/quran/labs/androidquran/data/QuranInfo.java
@@ -1,7 +1,6 @@
 package com.quran.labs.androidquran.data;
 
 import android.content.Context;
-import androidx.annotation.NonNull;
 import android.text.TextUtils;
 
 import com.crashlytics.android.Crashlytics;
@@ -11,15 +10,20 @@ import com.quran.labs.androidquran.R;
 import com.quran.labs.androidquran.util.QuranUtils;
 
 import java.util.LinkedHashSet;
+import java.util.Map;
 import java.util.Set;
 
 import javax.inject.Inject;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.VisibleForTesting;
 
 public class QuranInfo {
   private final int[] suraPageStart;
   private final int[] pageSuraStart;
   private final int[] pageAyahStart;
   private final int[] juzPageStart;
+  private final Map<Integer, Integer> juzPageOverride;
   private final int[] pageRub3Start;
   private final int[] suraNumAyahs;
   private final boolean[] suraIsMakki;
@@ -35,6 +39,7 @@ public class QuranInfo {
     pageSuraStart = quranDataSource.getSuraForPageArray();
     pageAyahStart = quranDataSource.getAyahForPageArray();
     juzPageStart = quranDataSource.getPageForJuzArray();
+    juzPageOverride = quranDataSource.getJuzDisplayPageArrayOverride();
     pageRub3Start = quranDataSource.getQuarterStartByPage();
     suraNumAyahs = quranDataSource.getNumberOfAyahsForSuraArray();
     suraIsMakki = quranDataSource.getIsMakkiBySuraArray();
@@ -134,9 +139,10 @@ public class QuranInfo {
         QuranUtils.getLocalizedNumber(context, getJuzFromPage(page)));
   }
 
-  public String getJuzString(Context context, int page) {
+  public String getJuzDisplayStringForPage(Context context, int page) {
     String description = context.getString(R.string.juz2_description);
-    return String.format(description, QuranUtils.getLocalizedNumber(context, getJuzFromPage(page)));
+    return String.format(description, QuranUtils.getLocalizedNumber(context,
+        getJuzForDisplayFromPage(page)));
   }
 
   public String getSuraAyahString(Context context, int sura, int ayah) {
@@ -256,6 +262,21 @@ public class QuranInfo {
       }
     }
     return "";
+  }
+
+  /**
+   * Gets the juz' that should be printed at the top of the page
+   * This may be different than the actual juz' for the page (for example, juz' 7 starts at page
+   * 121, but despite this, the title of the page is juz' 6).
+   *
+   * @param page the page
+   * @return the display juz' display string for the page
+   */
+  @VisibleForTesting
+  int getJuzForDisplayFromPage(int page) {
+    final int actualJuz = getJuzFromPage(page);
+    final Integer overriddenJuz = juzPageOverride.get(page);
+    return overriddenJuz == null ? actualJuz : overriddenJuz;
   }
 
   public int getJuzFromPage(int page) {

--- a/app/src/main/java/com/quran/labs/androidquran/presenter/quran/ayahtracker/AyahImageTrackerItem.java
+++ b/app/src/main/java/com/quran/labs/androidquran/presenter/quran/ayahtracker/AyahImageTrackerItem.java
@@ -2,13 +2,8 @@ package com.quran.labs.androidquran.presenter.quran.ayahtracker;
 
 import android.content.Context;
 import android.graphics.RectF;
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
-import com.quran.page.common.data.AyahBounds;
 import com.quran.labs.androidquran.dao.bookmark.Bookmark;
-import com.quran.page.common.data.AyahCoordinates;
-import com.quran.page.common.data.PageCoordinates;
 import com.quran.labs.androidquran.data.QuranInfo;
 import com.quran.labs.androidquran.data.SuraAyah;
 import com.quran.labs.androidquran.ui.helpers.HighlightType;
@@ -17,11 +12,17 @@ import com.quran.labs.androidquran.ui.util.ImageAyahUtils;
 import com.quran.labs.androidquran.util.QuranUtils;
 import com.quran.labs.androidquran.widgets.AyahToolBar;
 import com.quran.labs.androidquran.widgets.HighlightingImageView;
+import com.quran.page.common.data.AyahBounds;
+import com.quran.page.common.data.AyahCoordinates;
+import com.quran.page.common.data.PageCoordinates;
 import com.quran.page.common.draw.ImageDrawHelper;
 
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 public class AyahImageTrackerItem extends AyahTrackerItem<HighlightingImageView> {
   private final QuranInfo quranInfo;
@@ -60,7 +61,7 @@ public class AyahImageTrackerItem extends AyahTrackerItem<HighlightingImageView>
         ayahView.setPageBounds(pageBounds);
         Context context = ayahView.getContext();
         String suraText = quranInfo.getSuraNameFromPage(context, page, true);
-        String juzText = quranInfo.getJuzString(context, page);
+        String juzText = quranInfo.getJuzDisplayStringForPage(context, page);
         String pageText = QuranUtils.getLocalizedNumber(context, page);
         String rub3Text = QuranDisplayHelper.displayRub3(context, quranInfo, page);
         ayahView.setOverlayText(suraText, juzText, pageText, rub3Text);

--- a/app/src/test/java/com/quran/labs/androidquran/data/QuranInfoTest.kt
+++ b/app/src/test/java/com/quran/labs/androidquran/data/QuranInfoTest.kt
@@ -49,4 +49,15 @@ class QuranInfoTest {
     }
   }
 
+  @Test
+  fun testDisplayJuz() {
+    val quranInfo = QuranInfo(MadaniPageProvider())
+    // make sure that juz' 7 starts on page 121, but the display juz' is 6
+    assertThat(quranInfo.getJuzForDisplayFromPage(121)).isEqualTo(6)
+    assertThat(quranInfo.getJuzFromPage(121)).isEqualTo(7)
+
+    // make sure that juz' 11 starts on page 201, but the display juz' is 10
+    assertThat(quranInfo.getJuzForDisplayFromPage(201)).isEqualTo(10)
+    assertThat(quranInfo.getJuzFromPage(201)).isEqualTo(11)
+  }
 }

--- a/common/data/src/main/java/com/quran/data/pageinfo/common/MadaniDataSource.kt
+++ b/common/data/src/main/java/com/quran/data/pageinfo/common/MadaniDataSource.kt
@@ -99,6 +99,8 @@ open class MadaniDataSource : QuranDataSource {
       /* 11 - 20 */ 201, 222, 242, 262, 282, 302, 322, 342, 362, 382,
       /* 21 - 30 */ 402, 422, 442, 462, 482, 502, 522, 542, 562, 582)
 
+  override fun getJuzDisplayPageArrayOverride() = mapOf(121 to 6, 201 to 10)
+
   override fun getNumberOfAyahsForSuraArray() = intArrayOf(
       /*  1 -  14 */ 7, 286, 200, 176, 120, 165, 206, 75, 129, 109, 123, 111, 43, 52,
       /* 15 -  28 */ 99, 128, 111, 110, 98, 135, 112, 78, 118, 64, 77, 227, 93, 88,

--- a/common/data/src/main/java/com/quran/data/source/QuranDataSource.kt
+++ b/common/data/src/main/java/com/quran/data/source/QuranDataSource.kt
@@ -6,6 +6,7 @@ interface QuranDataSource {
   fun getSuraForPageArray() : IntArray
   fun getAyahForPageArray() : IntArray
   fun getPageForJuzArray() : IntArray
+  fun getJuzDisplayPageArrayOverride(): Map<Int, Int>
   fun getNumberOfAyahsForSuraArray() : IntArray
   fun getIsMakkiBySuraArray() : BooleanArray
   fun getQuarterStartByPage() : IntArray


### PR DESCRIPTION
Two of the juz's (the 7th and 11th) start towards the end of their
respective pages. Consequently, the madani mushaf labels the top of
these pages with the previous page's juz'. This implements the same
behavior in Quran. Fixes #970.