### PR TITLE
Disable tablet images for Qaloon and Warsh

### DIFF
--- a/common/data/src/main/java/com/quran/data/pageinfo/common/size/NoOverridePageSizeCalculator.kt
+++ b/common/data/src/main/java/com/quran/data/pageinfo/common/size/NoOverridePageSizeCalculator.kt
@@ -8,4 +8,9 @@ class NoOverridePageSizeCalculator(displaySize: DisplaySize) :
   override fun setOverrideParameter(parameter: String) {
     // override parameter is irrelevant for these pages
   }
+
+  override fun getTabletWidthParameter(): String {
+    // use the same size for tablet landscape
+    return getWidthParameter()
+  }
 }


### PR DESCRIPTION
On some devices, Qaloon and warsh cannot download images because they
attempt to download tablet zips (zips with both portrait and landscape
images) which don't exist for qaloon nor warsh. Fixes #881.