### PR TITLE
Fix audio database location

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/presenter/audio/AudioPresenter.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/presenter/audio/AudioPresenter.kt
@@ -84,7 +84,7 @@ constructor(private val quranInfo: QuranInfo,
     return if (!quranFileUtils.haveAyaPositionFile(context)) {
       getDownloadIntent(context,
           quranFileUtils.ayaPositionFileUrl,
-          quranFileUtils.getQuranDatabaseDirectory(context),
+          quranFileUtils.getQuranAyahDatabaseDirectory(context),
           context.getString(R.string.highlighting_database))
     } else if (gaplessDb != null && !File(gaplessDb).exists()) {
       getDownloadIntent(context,


### PR DESCRIPTION
When downloading audio data, the database path used for checking if the
database existed was incorrect. This could cause an infinite loop of
downloads in certain situations. Fixes #857.