### PR TITLE
Disable sharing for non-hafs flavors

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/ui/PagerActivity.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/PagerActivity.java
@@ -1209,6 +1209,7 @@ public class PagerActivity extends QuranActionBarActivity implements
   public void handleDownloadSuccess() {
     refreshQuranPages();
     audioPresenter.onDownloadSuccess();
+    audioStatusBar.switchMode(AudioStatusBar.STOPPED_MODE);
   }
 
   @Override

--- a/app/src/main/java/com/quran/labs/androidquran/ui/translation/TranslationView.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/translation/TranslationView.java
@@ -1,16 +1,13 @@
 package com.quran.labs.androidquran.ui.translation;
 
 import android.content.Context;
-import androidx.annotation.NonNull;
-import androidx.recyclerview.widget.DefaultItemAnimator;
-import androidx.recyclerview.widget.LinearLayoutManager;
-import androidx.recyclerview.widget.RecyclerView;
 import android.text.TextUtils;
 import android.util.AttributeSet;
 import android.view.MenuItem;
 import android.view.View;
 import android.widget.FrameLayout;
 
+import com.quran.labs.androidquran.BuildConfig;
 import com.quran.labs.androidquran.R;
 import com.quran.labs.androidquran.common.QuranAyahInfo;
 import com.quran.labs.androidquran.data.QuranInfo;
@@ -19,6 +16,11 @@ import com.quran.labs.androidquran.widgets.AyahToolBar;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.DefaultItemAnimator;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
 
 public class TranslationView extends FrameLayout implements View.OnClickListener,
     TranslationAdapter.OnVerseSelectedListener,
@@ -66,8 +68,12 @@ public class TranslationView extends FrameLayout implements View.OnClickListener
     ayahToolBar = new AyahToolBar(context, R.menu.share_menu);
     ayahToolBar.setOnItemSelectedListener(this);
     ayahToolBar.setVisibility(View.GONE);
-    addView(ayahToolBar, LayoutParams.WRAP_CONTENT,
-        context.getResources().getDimensionPixelSize(R.dimen.toolbar_total_height));
+
+    //noinspection ConstantConditions
+    if (!BuildConfig.FLAVOR.equals("warsh") && !BuildConfig.FLAVOR.equals("qaloon")) {
+      addView(ayahToolBar, LayoutParams.WRAP_CONTENT,
+          context.getResources().getDimensionPixelSize(R.dimen.toolbar_total_height));
+    }
   }
 
   public void setVerses(@NonNull QuranInfo quranInfo,

--- a/app/src/main/java/com/quran/labs/androidquran/widgets/AyahToolBar.java
+++ b/app/src/main/java/com/quran/labs/androidquran/widgets/AyahToolBar.java
@@ -4,9 +4,6 @@ import android.annotation.TargetApi;
 import android.content.Context;
 import android.content.res.Resources;
 import android.os.Build;
-import androidx.annotation.MenuRes;
-import androidx.core.content.ContextCompat;
-import androidx.appcompat.widget.PopupMenu;
 import android.util.AttributeSet;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -17,7 +14,12 @@ import android.widget.ImageButton;
 import android.widget.LinearLayout;
 import android.widget.Toast;
 
+import com.quran.labs.androidquran.BuildConfig;
 import com.quran.labs.androidquran.R;
+
+import androidx.annotation.MenuRes;
+import androidx.appcompat.widget.PopupMenu;
+import androidx.core.content.ContextCompat;
 
 public class AyahToolBar extends ViewGroup implements
     View.OnClickListener, View.OnLongClickListener {
@@ -125,6 +127,15 @@ public class AyahToolBar extends ViewGroup implements
     if (currentMenu == menu) {
       // no need to re-draw
       return;
+    }
+
+    // disable sharing for warsh and qaloon
+    MenuItem menuItem = menu.findItem(R.id.cab_share_ayah);
+    //noinspection ConstantConditions
+    if (menuItem != null &&
+        (BuildConfig.FLAVOR.equals("warsh") ||
+            BuildConfig.FLAVOR.equals("qaloon"))) {
+      menuItem.setVisible(false);
     }
 
     menuLayout.removeAllViews();


### PR DESCRIPTION
For warsh and qaloon, sharing today shares hafs text or links. This
patch disables sharing for warsh and qaloon for the time being (until
there is data for non-hafs flavors). Fixes #783.