### PR TITLE
Improve Arabic tafaseer

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/common/QuranAyahInfo.java
+++ b/app/src/main/java/com/quran/labs/androidquran/common/QuranAyahInfo.java
@@ -1,10 +1,10 @@
 package com.quran.labs.androidquran.common;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-
 import java.util.Collections;
 import java.util.List;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 /**
  * QuranAyahInfo
@@ -16,12 +16,12 @@ public class QuranAyahInfo {
   public final int ayah;
   public final int ayahId;
   @Nullable public final String arabicText;
-  @NonNull public final List<String> texts;
+  @NonNull public final List<TranslationMetadata> texts;
 
   public QuranAyahInfo(int sura,
                        int ayah,
                        @Nullable String arabicText,
-                       @NonNull List<String> texts,
+                       @NonNull List<TranslationMetadata> texts,
                        int ayahId) {
     this.sura = sura;
     this.ayah = ayah;

--- a/app/src/main/java/com/quran/labs/androidquran/common/TranslationMetadata.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/common/TranslationMetadata.kt
@@ -1,0 +1,5 @@
+package com.quran.labs.androidquran.common
+
+data class TranslationMetadata(val sura: Int,
+                               val ayah: Int,
+                               val text: CharSequence)

--- a/app/src/main/java/com/quran/labs/androidquran/data/SuraAyah.java
+++ b/app/src/main/java/com/quran/labs/androidquran/data/SuraAyah.java
@@ -55,8 +55,11 @@ public class SuraAyah implements Comparable<SuraAyah>, Parcelable {
 
   @Override
   public boolean equals(Object o) {
-    return o != null && o.getClass() == SuraAyah.class &&
-        ((SuraAyah) o).sura == sura && ((SuraAyah) o).ayah == ayah;
+    if (this == o) { return true; }
+    if (o == null || getClass() != o.getClass()) { return false; }
+    SuraAyah suraAyah = (SuraAyah) o;
+    return sura == suraAyah.sura &&
+        ayah == suraAyah.ayah;
   }
 
   @Override

--- a/app/src/main/java/com/quran/labs/androidquran/module/activity/PagerActivityModule.java
+++ b/app/src/main/java/com/quran/labs/androidquran/module/activity/PagerActivityModule.java
@@ -1,10 +1,14 @@
 package com.quran.labs.androidquran.module.activity;
 
+import android.content.Context;
+
+import com.quran.labs.androidquran.R;
 import com.quran.labs.androidquran.di.ActivityScope;
 import com.quran.labs.androidquran.ui.PagerActivity;
 import com.quran.labs.androidquran.ui.helpers.AyahSelectedListener;
 import com.quran.labs.androidquran.util.QuranScreenInfo;
 import com.quran.labs.androidquran.util.QuranUtils;
+import com.quran.labs.androidquran.util.TranslationUtil;
 
 import dagger.Module;
 import dagger.Provides;
@@ -27,5 +31,11 @@ public class PagerActivityModule {
   String provideImageWidth(QuranScreenInfo screenInfo) {
     return QuranUtils.isDualPages(pagerActivity, screenInfo) ?
         screenInfo.getTabletWidthParam() : screenInfo.getWidthParam();
+  }
+
+  @Provides
+  @ActivityScope
+  TranslationUtil provideTranslationUtil(Context context) {
+    return new TranslationUtil(context.getResources().getColor(R.color.translation_translator_color));
   }
 }

--- a/app/src/main/java/com/quran/labs/androidquran/presenter/translation/InlineTranslationPresenter.java
+++ b/app/src/main/java/com/quran/labs/androidquran/presenter/translation/InlineTranslationPresenter.java
@@ -6,6 +6,7 @@ import com.quran.labs.androidquran.data.VerseRange;
 import com.quran.labs.androidquran.database.TranslationsDBAdapter;
 import com.quran.labs.androidquran.model.translation.TranslationModel;
 import com.quran.labs.androidquran.util.QuranSettings;
+import com.quran.labs.androidquran.util.TranslationUtil;
 
 import java.util.List;
 
@@ -22,9 +23,10 @@ public class InlineTranslationPresenter extends
   @Inject
   InlineTranslationPresenter(TranslationModel translationModel,
                              TranslationsDBAdapter dbAdapter,
+                             TranslationUtil translationUtil,
                              QuranSettings quranSettings,
                              QuranInfo quranInfo) {
-    super(translationModel, dbAdapter, quranInfo);
+    super(translationModel, dbAdapter, translationUtil, quranInfo);
     this.quranSettings = quranSettings;
   }
 

--- a/app/src/main/java/com/quran/labs/androidquran/presenter/translation/TranslationPresenter.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/presenter/translation/TranslationPresenter.kt
@@ -10,6 +10,7 @@ import com.quran.labs.androidquran.model.translation.TranslationModel
 import com.quran.labs.androidquran.ui.PagerActivity
 import com.quran.labs.androidquran.util.QuranSettings
 import com.quran.labs.androidquran.util.ShareUtil
+import com.quran.labs.androidquran.util.TranslationUtil
 import io.reactivex.Observable
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.observers.DisposableObserver
@@ -19,11 +20,12 @@ import javax.inject.Inject
 internal class TranslationPresenter @Inject internal constructor(translationModel: TranslationModel,
                      private val quranSettings: QuranSettings,
                      translationsAdapter: TranslationsDBAdapter,
+                     translationUtil: TranslationUtil,
                      private val shareUtil: ShareUtil,
                      private val quranInfo: QuranInfo,
                      private val pages: Array<Int?>) :
     BaseTranslationPresenter<TranslationPresenter.TranslationScreen>(
-        translationModel, translationsAdapter, quranInfo) {
+        translationModel, translationsAdapter, translationUtil, quranInfo) {
 
   fun refresh() {
     disposable?.dispose()

--- a/app/src/main/java/com/quran/labs/androidquran/ui/translation/TranslationView.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/translation/TranslationView.java
@@ -14,6 +14,8 @@ import com.quran.labs.androidquran.data.QuranInfo;
 import com.quran.labs.androidquran.util.QuranSettings;
 import com.quran.labs.androidquran.widgets.AyahToolBar;
 
+import org.jetbrains.annotations.NotNull;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -53,7 +55,7 @@ public class TranslationView extends FrameLayout implements View.OnClickListener
     addView(translationRecycler, LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT);
     translationRecycler.addOnScrollListener(new RecyclerView.OnScrollListener() {
       @Override
-      public void onScrolled(RecyclerView recyclerView, int dx, int dy) {
+      public void onScrolled(@NotNull RecyclerView recyclerView, int dx, int dy) {
         super.onScrolled(recyclerView, dx, dy);
 
         // do not modify the RecyclerView from this method or any method called from
@@ -106,7 +108,7 @@ public class TranslationView extends FrameLayout implements View.OnClickListener
       // added this to guard against a crash that happened when verse.texts was empty
       int verseTexts = verse.texts.size();
       for (int j = 0; j < translations.length; j++) {
-        String text = verseTexts > j ? verse.texts.get(j) : "";
+        CharSequence text = verseTexts > j ? verse.texts.get(j).getText() : "";
         if (!TextUtils.isEmpty(text)) {
           if (wantTranslationHeaders) {
             rows.add(

--- a/app/src/main/java/com/quran/labs/androidquran/ui/translation/TranslationViewRow.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/translation/TranslationViewRow.java
@@ -1,10 +1,10 @@
 package com.quran.labs.androidquran.ui.translation;
 
+import com.quran.labs.androidquran.common.QuranAyahInfo;
+
 import androidx.annotation.IntDef;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-
-import com.quran.labs.androidquran.common.QuranAyahInfo;
 
 class TranslationViewRow {
 
@@ -22,13 +22,13 @@ class TranslationViewRow {
 
   @Type final int type;
   @NonNull final QuranAyahInfo ayahInfo;
-  @Nullable final String data;
+  @Nullable final CharSequence data;
 
   TranslationViewRow(int type, @NonNull QuranAyahInfo ayahInfo) {
     this(type, ayahInfo, null);
   }
 
-  TranslationViewRow(int type, @NonNull QuranAyahInfo ayahInfo, @Nullable String data) {
+  TranslationViewRow(int type, @NonNull QuranAyahInfo ayahInfo, @Nullable CharSequence data) {
     this.type = type;
     this.ayahInfo = ayahInfo;
     this.data = data;

--- a/app/src/main/java/com/quran/labs/androidquran/util/TranslationUtil.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/util/TranslationUtil.kt
@@ -1,0 +1,30 @@
+package com.quran.labs.androidquran.util
+
+import android.text.SpannableString
+import android.text.Spanned
+import android.text.style.ForegroundColorSpan
+import androidx.annotation.ColorInt
+import com.quran.labs.androidquran.common.QuranText
+import com.quran.labs.androidquran.common.TranslationMetadata
+import dagger.Reusable
+
+@Reusable
+class TranslationUtil(@ColorInt private val color: Int) {
+  val ayahRegex = """([«{﴿][\s\S]*?[﴾}»])""".toRegex()
+  val footerRegex = """\[\[[\s\S]*?]]""".toRegex()
+
+
+  fun parseTranslationText(quranText: QuranText): TranslationMetadata {
+    val text = quranText.text
+    val withoutFooters = footerRegex.replace(text, "")
+    val spannable = SpannableString(withoutFooters)
+
+    ayahRegex.findAll(withoutFooters)
+        .forEach {
+          val span = ForegroundColorSpan(color)
+          val range = it.range
+          spannable.setSpan(span, range.start, range.last + 1, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+        }
+    return TranslationMetadata(quranText.sura, quranText.ayah, spannable)
+  }
+}

--- a/app/src/main/java/com/quran/labs/androidquran/widgets/InlineTranslationView.java
+++ b/app/src/main/java/com/quran/labs/androidquran/widgets/InlineTranslationView.java
@@ -4,7 +4,6 @@ import android.content.Context;
 import android.content.res.Resources;
 import android.graphics.Color;
 import android.graphics.Typeface;
-import androidx.annotation.StyleRes;
 import android.text.SpannableStringBuilder;
 import android.text.Spanned;
 import android.text.TextUtils;
@@ -17,9 +16,12 @@ import android.widget.TextView;
 
 import com.quran.labs.androidquran.R;
 import com.quran.labs.androidquran.common.QuranAyahInfo;
+import com.quran.labs.androidquran.common.TranslationMetadata;
 import com.quran.labs.androidquran.util.QuranSettings;
 
 import java.util.List;
+
+import androidx.annotation.StyleRes;
 
 public class InlineTranslationView extends ScrollView {
   private Context context;
@@ -120,7 +122,8 @@ public class InlineTranslationView extends ScrollView {
     boolean showHeader = translations.length > 1;
     SpannableStringBuilder builder = new SpannableStringBuilder();
     for (int i = 0; i < translations.length; i++) {
-      String translationText = ayah.texts.get(i);
+      final TranslationMetadata translationMetadata = ayah.texts.get(i);
+      final CharSequence translationText = translationMetadata.getText();
       if (!TextUtils.isEmpty(translationText)) {
         if (showHeader) {
           if (i > 0) {

--- a/app/src/test/java/com/quran/labs/androidquran/presenter/translation/BaseTranslationPresenterTest.kt
+++ b/app/src/test/java/com/quran/labs/androidquran/presenter/translation/BaseTranslationPresenterTest.kt
@@ -9,6 +9,7 @@ import com.quran.labs.androidquran.data.VerseRange
 import com.quran.labs.androidquran.database.TranslationsDBAdapter
 import com.quran.labs.androidquran.model.translation.TranslationModel
 import com.quran.labs.androidquran.presenter.Presenter
+import com.quran.labs.androidquran.util.TranslationUtil
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mockito
@@ -24,6 +25,7 @@ class BaseTranslationPresenterTest {
     presenter = BaseTranslationPresenter(
         Mockito.mock(TranslationModel::class.java),
         Mockito.mock(TranslationsDBAdapter::class.java),
+        TranslationUtil(0),
         QuranInfo(MadaniPageProvider()))
   }
 
@@ -38,7 +40,7 @@ class BaseTranslationPresenterTest {
       }
     }
 
-    val translations = presenter!!.getTranslationNames(databases, map)
+    val translations = presenter.getTranslationNames(databases, map)
     assertThat(translations).hasLength(2)
     assertThat(translations[0]).isEqualTo("First")
     assertThat(translations[1]).isEqualTo("Second")
@@ -49,7 +51,7 @@ class BaseTranslationPresenterTest {
     val databases = Arrays.asList("one.db", "two.db")
     val map = HashMap<String, LocalTranslation>()
 
-    val translations = presenter!!.getTranslationNames(databases, map)
+    val translations = presenter.getTranslationNames(databases, map)
     assertThat(translations).hasLength(2)
     assertThat(translations[0]).isEqualTo(databases[0])
     assertThat(translations[1]).isEqualTo(databases[1])
@@ -59,7 +61,7 @@ class BaseTranslationPresenterTest {
   fun testCombineAyahDataOneVerse() {
     val verseRange = VerseRange(1, 1, 1, 1, 1)
     val arabic = listOf(QuranText(1, 1, "first ayah"))
-    val info = presenter!!.combineAyahData(verseRange, arabic,
+    val info = presenter.combineAyahData(verseRange, arabic,
         listOf(listOf(QuranText(1, 1, "translation"))))
 
     assertThat(info).hasSize(1)
@@ -75,7 +77,7 @@ class BaseTranslationPresenterTest {
   fun testCombineAyahDataOneVerseEmpty() {
     val verseRange = VerseRange(1, 1, 1, 1, 1)
     val arabic = emptyList<QuranText>()
-    val info = presenter!!.combineAyahData(verseRange, arabic, emptyList())
+    val info = presenter.combineAyahData(verseRange, arabic, emptyList())
     assertThat(info).hasSize(0)
   }
 
@@ -83,7 +85,7 @@ class BaseTranslationPresenterTest {
   fun testCombineAyahDataOneVerseNoArabic() {
     val verseRange = VerseRange(1, 1, 1, 1, 1)
     val arabic = emptyList<QuranText>()
-    val info = presenter!!.combineAyahData(verseRange, arabic,
+    val info = presenter.combineAyahData(verseRange, arabic,
         listOf(listOf(QuranText(1, 1, "translation"))))
 
     assertThat(info).hasSize(1)
@@ -102,7 +104,7 @@ class BaseTranslationPresenterTest {
         QuranText(1, 1, "first ayah"),
         QuranText(1, 2, "second ayah")
     )
-    val info = presenter!!.combineAyahData(verseRange, arabic, ArrayList())
+    val info = presenter.combineAyahData(verseRange, arabic, ArrayList())
     assertThat(info).hasSize(2)
     assertThat(info[0].sura).isEqualTo(1)
     assertThat(info[0].ayah).isEqualTo(1)


### PR DESCRIPTION
This patch is the first in a set of patches to improve tafaseer (with
Arabic tafaseer in mind for the time being). It removes footnotes for
now, and also highlights ayah references.