### PR TITLE
Support ayah grouping for tafaseer

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/common/TranslationMetadata.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/common/TranslationMetadata.kt
@@ -1,5 +1,8 @@
 package com.quran.labs.androidquran.common
 
+import com.quran.labs.androidquran.data.SuraAyah
+
 data class TranslationMetadata(val sura: Int,
                                val ayah: Int,
-                               val text: CharSequence)
+                               val text: CharSequence,
+                               val link: SuraAyah? = null)

--- a/app/src/main/java/com/quran/labs/androidquran/data/QuranInfo.java
+++ b/app/src/main/java/com/quran/labs/androidquran/data/QuranInfo.java
@@ -345,6 +345,15 @@ public class QuranInfo {
     return ayahId;
   }
 
+  public SuraAyah getSuraAyahFromAyahId(int ayahId) {
+    int sura = 0;
+    int ayahIdentifier = ayahId;
+    while (ayahIdentifier > suraNumAyahs[sura]) {
+      ayahIdentifier -= suraNumAyahs[sura++];
+    }
+    return new SuraAyah(sura + 1, ayahIdentifier);
+  }
+
   public int getNumAyahs(int sura) {
     if ((sura < 1) || (sura > Constants.SURAS_COUNT)) return -1;
     return suraNumAyahs[sura - 1];

--- a/app/src/main/java/com/quran/labs/androidquran/module/activity/PagerActivityModule.java
+++ b/app/src/main/java/com/quran/labs/androidquran/module/activity/PagerActivityModule.java
@@ -3,6 +3,7 @@ package com.quran.labs.androidquran.module.activity;
 import android.content.Context;
 
 import com.quran.labs.androidquran.R;
+import com.quran.labs.androidquran.data.QuranInfo;
 import com.quran.labs.androidquran.di.ActivityScope;
 import com.quran.labs.androidquran.ui.PagerActivity;
 import com.quran.labs.androidquran.ui.helpers.AyahSelectedListener;
@@ -35,7 +36,9 @@ public class PagerActivityModule {
 
   @Provides
   @ActivityScope
-  TranslationUtil provideTranslationUtil(Context context) {
-    return new TranslationUtil(context.getResources().getColor(R.color.translation_translator_color));
+  TranslationUtil provideTranslationUtil(Context context, QuranInfo quranInfo) {
+    return new TranslationUtil(
+        context.getResources().getColor(R.color.translation_translator_color),
+        quranInfo);
   }
 }

--- a/app/src/main/java/com/quran/labs/androidquran/ui/translation/TranslationAdapter.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/translation/TranslationAdapter.kt
@@ -15,6 +15,7 @@ import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.RecyclerView
 import com.quran.labs.androidquran.R
 import com.quran.labs.androidquran.common.QuranAyahInfo
+import com.quran.labs.androidquran.data.SuraAyah
 import com.quran.labs.androidquran.model.translation.ArabicDatabaseUtils
 import com.quran.labs.androidquran.ui.helpers.ExpandTafseerSpan
 import com.quran.labs.androidquran.ui.helpers.UthmaniSpan
@@ -223,10 +224,16 @@ internal class TranslationAdapter(private val context: Context,
             text = row.data
           } else {
             // translation
-            val rowText = row.data
-            text = if (rowText != null) {
-              truncateTextIfNeeded(rowText, row.ayahInfo.ayahId, row.translationIndex)
-            } else { rowText }
+            text = row.data?.let { rowText ->
+              val length = rowText.length
+              when {
+                row.link != null -> getAyahLink(row.link)
+                length > MAX_TAFSEER_LENGTH ->
+                  truncateTextIfNeeded(rowText, row.ayahInfo.ayahId, row.translationIndex)
+                else -> rowText
+              }
+            }
+
             holder.text.movementMethod = LinkMovementMethod.getInstance()
             holder.text.setTextColor(textColor)
             holder.text.textSize = fontSize.toFloat()
@@ -257,6 +264,10 @@ internal class TranslationAdapter(private val context: Context,
       }
     }
     updateHighlight(row, holder)
+  }
+
+  private fun getAyahLink(link: SuraAyah): CharSequence {
+    return context.getString(R.string.see_tafseer_of_verse, link.ayah)
   }
 
   private fun truncateTextIfNeeded(text: CharSequence,

--- a/app/src/main/java/com/quran/labs/androidquran/ui/translation/TranslationView.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/translation/TranslationView.java
@@ -10,6 +10,7 @@ import android.widget.FrameLayout;
 import com.quran.labs.androidquran.BuildConfig;
 import com.quran.labs.androidquran.R;
 import com.quran.labs.androidquran.common.QuranAyahInfo;
+import com.quran.labs.androidquran.common.TranslationMetadata;
 import com.quran.labs.androidquran.data.QuranInfo;
 import com.quran.labs.androidquran.util.QuranSettings;
 import com.quran.labs.androidquran.widgets.AyahToolBar;
@@ -108,14 +109,16 @@ public class TranslationView extends FrameLayout implements View.OnClickListener
       // added this to guard against a crash that happened when verse.texts was empty
       int verseTexts = verse.texts.size();
       for (int j = 0; j < translations.length; j++) {
-        CharSequence text = verseTexts > j ? verse.texts.get(j).getText() : "";
+        final TranslationMetadata metadata = verseTexts > j ? verse.texts.get(j) : null;
+        CharSequence text = metadata != null ? metadata.getText() : "";
         if (!TextUtils.isEmpty(text)) {
           if (wantTranslationHeaders) {
             rows.add(
                 new TranslationViewRow(TranslationViewRow.Type.TRANSLATOR, verse, translations[j]));
           }
           rows.add(new TranslationViewRow(
-              TranslationViewRow.Type.TRANSLATION_TEXT, verse, text, j));
+              TranslationViewRow.Type.TRANSLATION_TEXT, verse, text, j,
+              metadata == null ? null : metadata.getLink()));
         }
       }
 

--- a/app/src/main/java/com/quran/labs/androidquran/ui/translation/TranslationViewRow.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/translation/TranslationViewRow.java
@@ -1,6 +1,7 @@
 package com.quran.labs.androidquran.ui.translation;
 
 import com.quran.labs.androidquran.common.QuranAyahInfo;
+import com.quran.labs.androidquran.data.SuraAyah;
 
 import androidx.annotation.IntDef;
 import androidx.annotation.NonNull;
@@ -24,22 +25,25 @@ class TranslationViewRow {
   @NonNull final QuranAyahInfo ayahInfo;
   @Nullable final CharSequence data;
   final int translationIndex;
+  @Nullable final SuraAyah link;
 
   TranslationViewRow(int type, @NonNull QuranAyahInfo ayahInfo) {
     this(type, ayahInfo, null);
   }
 
   TranslationViewRow(int type, @NonNull QuranAyahInfo ayahInfo, @Nullable CharSequence data) {
-    this(type, ayahInfo, data, -1);
+    this(type, ayahInfo, data, -1, null);
   }
 
   TranslationViewRow(int type,
                      @NonNull QuranAyahInfo ayahInfo,
                      @Nullable CharSequence data,
-                     int translationIndex) {
+                     int translationIndex,
+                     @Nullable SuraAyah link) {
     this.type = type;
     this.ayahInfo = ayahInfo;
     this.data = data;
     this.translationIndex = translationIndex;
+    this.link = link;
   }
 }

--- a/app/src/main/java/com/quran/labs/androidquran/util/TranslationUtil.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/util/TranslationUtil.kt
@@ -6,16 +6,26 @@ import android.text.style.ForegroundColorSpan
 import androidx.annotation.ColorInt
 import com.quran.labs.androidquran.common.QuranText
 import com.quran.labs.androidquran.common.TranslationMetadata
+import com.quran.labs.androidquran.data.QuranInfo
 import dagger.Reusable
 
 @Reusable
-open class TranslationUtil(@ColorInt private val color: Int) {
+open class TranslationUtil(@ColorInt private val color: Int,
+                           private val quranInfo: QuranInfo) {
   val ayahRegex = """([«{﴿][\s\S]*?[﴾}»])""".toRegex()
   val footerRegex = """\[\[[\s\S]*?]]""".toRegex()
 
 
   open fun parseTranslationText(quranText: QuranText): TranslationMetadata {
     val text = quranText.text
+    if (text.length < 5) {
+      val ayahId = text.toIntOrNull()
+      if (ayahId != null) {
+        val suraAyah = quranInfo.getSuraAyahFromAyahId(ayahId)
+        return TranslationMetadata(quranText.sura, quranText.ayah, text, suraAyah)
+      }
+    }
+
     val withoutFooters = footerRegex.replace(text, "")
     val spannable = SpannableString(withoutFooters)
 

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -137,8 +137,11 @@
   <string name="remove_button">احذف</string>
   <string name="dialog_ok">موافق</string>
 
-  <!-- translation updates -->
+  <!-- tafaseer -->
   <string name="more">المزيد…</string>
+  <string name="see_tafseer_of_verse">انظر تفسير الآية %d.</string>
+
+  <!-- translation updates -->
   <string name="update_available">هناك تحديثات</string>
   <string name="translation_updates_available">هناك تحديثات للتراجم والتفاسير. هل ترغب في تحميلها الآن؟</string>
   <string name="translation_dialog_yes">نعم</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -228,8 +228,11 @@
   <string name="please_grant_permissions">Please grant permission in application settings.</string>
   <!-- Preferences End -->
 
-  <!-- translation updates -->
+  <!-- tafaseer -->
   <string name="more">More…</string>
+  <string name="see_tafseer_of_verse">See tafseer for ayah %d.</string>
+
+  <!-- translation updates -->
   <string name="update_available">Update Available</string>
   <string name="translation_updates_available">An update is available for some of your translations. Visit the translations screen now?</string>
   <string name="translation_dialog_yes">Yes</string>

--- a/app/src/test/java/com/quran/labs/androidquran/presenter/translation/BaseTranslationPresenterTest.kt
+++ b/app/src/test/java/com/quran/labs/androidquran/presenter/translation/BaseTranslationPresenterTest.kt
@@ -26,7 +26,7 @@ class BaseTranslationPresenterTest {
     presenter = BaseTranslationPresenter(
         Mockito.mock(TranslationModel::class.java),
         Mockito.mock(TranslationsDBAdapter::class.java),
-        object : TranslationUtil(0) {
+        object : TranslationUtil(0, QuranInfo(MadaniPageProvider())) {
           override fun parseTranslationText(quranText: QuranText): TranslationMetadata {
             return TranslationMetadata(quranText.sura, quranText.ayah, quranText.text)
           }


### PR DESCRIPTION
Newer tafaseer will sometimes put a single number in the text to denote
a link to another ayah. This patch implements simple support for this
functionality.