### PR TITLE
Hard code more string in Arabic for now

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/ui/translation/TranslationAdapter.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/translation/TranslationAdapter.kt
@@ -280,7 +280,7 @@ internal class TranslationAdapter(private val context: Context,
       val lastSpace = text.indexOf(' ', MAX_TAFSEER_LENGTH)
       if (lastSpace != -1) {
         val builder = SpannableStringBuilder(text.subSequence(0, lastSpace + 1))
-        builder.append(context.getString(R.string.more))
+        builder.append(context.getString(R.string.more_arabic))
         builder.setSpan(ExpandTafseerSpan(expandClickListener),
             lastSpace + 1,
             builder.length,

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -138,7 +138,6 @@
   <string name="dialog_ok">موافق</string>
 
   <!-- tafaseer -->
-  <string name="more">المزيد…</string>
   <string name="see_tafseer_of_verse">انظر تفسير الآية %d.</string>
 
   <!-- translation updates -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -229,7 +229,7 @@
   <!-- Preferences End -->
 
   <!-- tafaseer -->
-  <string name="more">More…</string>
+  <string name="more_arabic" translatable="false">المزيد…</string>
   <string name="see_tafseer_of_verse">See tafseer for ayah %d.</string>
 
   <!-- translation updates -->


### PR DESCRIPTION
For now, use an Arabic "more" string since all the translations or
tafaseer that can be truncated are Arabic for now.