### PR TITLE
Fix a bug with playback in Arabic

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/data/SuraAyah.java
+++ b/app/src/main/java/com/quran/labs/androidquran/data/SuraAyah.java
@@ -2,6 +2,7 @@ package com.quran.labs.androidquran.data;
 
 import android.os.Parcel;
 import android.os.Parcelable;
+
 import androidx.annotation.NonNull;
 
 public class SuraAyah implements Comparable<SuraAyah>, Parcelable {
@@ -56,7 +57,7 @@ public class SuraAyah implements Comparable<SuraAyah>, Parcelable {
   @Override
   public boolean equals(Object o) {
     if (this == o) { return true; }
-    if (o == null || getClass() != o.getClass()) { return false; }
+    if (!(o instanceof SuraAyah)) {  return false; }
     SuraAyah suraAyah = (SuraAyah) o;
     return sura == suraAyah.sura &&
         ayah == suraAyah.ayah;

--- a/app/src/main/java/com/quran/labs/androidquran/presenter/audio/service/AudioQueue.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/presenter/audio/service/AudioQueue.kt
@@ -5,6 +5,7 @@ import com.quran.labs.androidquran.dao.audio.AudioRequest
 import com.quran.labs.androidquran.data.QuranInfo
 import com.quran.labs.androidquran.data.SuraAyah
 import com.quran.labs.androidquran.extension.requiresBasmallah
+import java.util.Locale
 
 /**
  * This class maintains a virtual audio queue for playback.
@@ -79,7 +80,7 @@ class AudioQueue(private val quranInfo: QuranInfo,
     }
 
     val (sura, ayah) = if (playbackInfo.shouldPlayBasmallah) 1 to 1 else currentSura to currentAyah
-    return String.format(audioRequest.audioPathInfo.urlFormat, sura, ayah)
+    return String.format(Locale.US, audioRequest.audioPathInfo.urlFormat, sura, ayah)
   }
 
   fun withUpdatedAudioRequest(audioRequest: AudioRequest): AudioQueue {

--- a/app/src/main/java/com/quran/labs/androidquran/service/AudioService.java
+++ b/app/src/main/java/com/quran/labs/androidquran/service/AudioService.java
@@ -933,6 +933,10 @@ public class AudioService extends Service implements OnCompletionListener,
   }
 
   private void playAudio(boolean playRepeatSeparator) {
+    if (!isSetupAsForeground) {
+      setUpAsForeground();
+    }
+
     state = State.Stopped;
     relaxResources(false, false); // release everything except MediaPlayer
     playerOverride = false;
@@ -1009,9 +1013,6 @@ public class AudioService extends Service implements OnCompletionListener,
       }
 
       state = State.Preparing;
-      if (!isSetupAsForeground) {
-        setUpAsForeground();
-      }
 
       // starts preparing the media player in the background. When it's
       // done, it will call our OnPreparedListener (that is, the


### PR DESCRIPTION
This patch fixes a bad bug - was calling String.format without passing
in the locale, which meant that in Arabic, the url was wrong. This fixes
the problem by passing the locale in. It also moves setting foreground to
the top of the play function.