### PR TITLE
Remove translation by filename upon upgrading

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/database/TranslationsDBAdapter.java
+++ b/app/src/main/java/com/quran/labs/androidquran/database/TranslationsDBAdapter.java
@@ -92,6 +92,11 @@ public class TranslationsDBAdapter {
     return items;
   }
 
+  public void deleteTranslationByFile(String filename) {
+    db.execSQL("DELETE FROM " + TranslationsTable.TABLE_NAME + " WHERE " +
+        TranslationsTable.FILENAME + " = ?", new Object[] { filename });
+  }
+
   public boolean writeTranslationUpdates(List<TranslationItem> updates) {
     boolean result = true;
     db.beginTransaction();

--- a/app/src/main/java/com/quran/labs/androidquran/presenter/translation/TranslationManagerPresenter.java
+++ b/app/src/main/java/com/quran/labs/androidquran/presenter/translation/TranslationManagerPresenter.java
@@ -28,6 +28,7 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 
 import androidx.annotation.VisibleForTesting;
+import io.reactivex.Completable;
 import io.reactivex.Observable;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.observers.DisposableMaybeObserver;
@@ -117,6 +118,13 @@ public class TranslationManagerPresenter implements Presenter<TranslationManager
   public void updateItem(final TranslationItem item) {
     Observable.fromCallable(() ->
         translationsDBAdapter.writeTranslationUpdates(Collections.singletonList(item))
+    ).subscribeOn(Schedulers.io())
+        .subscribe();
+  }
+
+  public void removeByFilename(final String filename) {
+    Completable.fromAction(() ->
+        translationsDBAdapter.deleteTranslationByFile(filename)
     ).subscribeOn(Schedulers.io())
         .subscribe();
   }

--- a/app/src/main/java/com/quran/labs/androidquran/ui/TranslationManagerActivity.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/TranslationManagerActivity.java
@@ -1,15 +1,10 @@
 package com.quran.labs.androidquran.ui;
 
+import com.google.android.material.snackbar.Snackbar;
+
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.os.Bundle;
-import com.google.android.material.snackbar.Snackbar;
-import androidx.localbroadcastmanager.content.LocalBroadcastManager;
-import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
-import androidx.appcompat.app.ActionBar;
-import androidx.appcompat.app.AlertDialog;
-import androidx.recyclerview.widget.LinearLayoutManager;
-import androidx.recyclerview.widget.RecyclerView;
 import android.util.SparseIntArray;
 import android.view.MenuItem;
 
@@ -34,6 +29,12 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
+import androidx.appcompat.app.ActionBar;
+import androidx.appcompat.app.AlertDialog;
+import androidx.localbroadcastmanager.content.LocalBroadcastManager;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 import io.reactivex.disposables.Disposable;
 import timber.log.Timber;
 
@@ -135,6 +136,13 @@ public class TranslationManagerActivity extends QuranActionBarActivity
           Timber.d(e, "error removing old database file");
         }
       }
+
+      // for upgrades, remove the old file to stop the tafseer from showing up
+      // twice. this happens because old and new tafaseer (ex ibn kathir) have
+      // different ids when they target different schema versions, and so the
+      // old file needs to be removed from the database explicitly
+      presenter.removeByFilename(downloadingItem.getTranslation().getFileName());
+
       TranslationItem updated = downloadingItem.withTranslationVersion(
           downloadingItem.getTranslation().getCurrentVersion());
       updateTranslationItem(updated);


### PR DESCRIPTION
Because the old id for ibn kathir downloads the old version of the tafseer
(without footnotes, etc) and the new id downloads the new one, the ids
are different. Therefore, when upgrading tafaseer, remove any matching
items by name before updating to avoid getting 2 copies of the same
tafseer (one for the old id and one for the new, both thinking their
file is the correct one).