### PR TITLE
Fix a bug with finding databases in non-madani

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/util/QuranFileUtils.java
+++ b/app/src/main/java/com/quran/labs/androidquran/util/QuranFileUtils.java
@@ -502,7 +502,7 @@ public class QuranFileUtils {
       if (ayahInfoFile.exists() && baseDir != null) {
         final File base = new File(baseDir);
         final File translationsFile = new File(base, QuranDataProvider.QURAN_ARABIC_DATABASE);
-        if (base.mkdir()) {
+        if (base.exists() || base.mkdir()) {
           try {
             copyFile(ayahInfoFile, translationsFile);
             return true;


### PR DESCRIPTION
Because the directory for databases might already exist, the app might
continuously think that the database file doesn't exist and keep
prompting to download it.