### PR TITLE
Get more information about images disappearing

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/ui/fragment/QuranAdvancedSettingsFragment.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/fragment/QuranAdvancedSettingsFragment.java
@@ -382,7 +382,9 @@ public class QuranAdvancedSettingsFragment extends PreferenceFragmentCompat {
       if (!isPaused) {
         dialog.dismiss();
         if (result) {
-          QuranSettings.getInstance(appContext).setAppCustomLocation(newLocation);
+          final QuranSettings quranSettings = QuranSettings.getInstance(appContext);
+          quranSettings.setAppCustomLocation(newLocation);
+          quranSettings.setDownloadedPages(false);
           if (listStoragePref != null) {
             listStoragePref.setValue(newLocation);
           }

--- a/app/src/main/java/com/quran/labs/androidquran/util/QuranSettings.java
+++ b/app/src/main/java/com/quran/labs/androidquran/util/QuranSettings.java
@@ -246,15 +246,18 @@ public class QuranSettings {
   }
 
   public String getAppCustomLocation() {
-    return perInstallationPrefs.getString(Constants.PREF_APP_LOCATION,
-        Environment.getExternalStorageDirectory().getAbsolutePath());
+    return perInstallationPrefs.getString(Constants.PREF_APP_LOCATION, getDefaultLocation());
+  }
+
+  public String getDefaultLocation() {
+    return Environment.getExternalStorageDirectory().getAbsolutePath();
   }
 
   public void setAppCustomLocation(String newLocation) {
     perInstallationPrefs.edit().putString(Constants.PREF_APP_LOCATION, newLocation).apply();
   }
 
-  private boolean isAppLocationSet() {
+  public boolean isAppLocationSet() {
     return perInstallationPrefs.getString(Constants.PREF_APP_LOCATION, null) != null;
   }
 


### PR DESCRIPTION
Whenever the images disappear, figure out whether or not the person had
granted permissions for external storage or not, and what sdk version
they were using. This might help figure out what happens.

Also fix a bug where if the app location is explicitly set to null, the
app never tries to find another location to store the app's files.