### PR TITLE
Bump version to 2.9.2-p1 and disable R8

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,8 +17,8 @@ android {
   defaultConfig {
     minSdkVersion deps.android.build.minSdkVersion
     targetSdkVersion deps.android.build.targetSdkVersion
-    versionCode 2920
-    versionName "2.9.2"
+    versionCode 2921
+    versionName "2.9.2-p1"
     testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
   }
 

--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,15 @@ buildscript {
     ]
   }
 
+  // workaround for proguard failing to parse moshi's proguard rules
+  buildscript {
+    configurations.all {
+        resolutionStrategy {
+            force 'net.sf.proguard:proguard-gradle:6.1.0beta2'
+        }
+    }
+  }
+
   repositories {
     google()
     jcenter()

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,4 @@
 android.enableJetifier=true
 android.useAndroidX=true
 android.enableSeparateAnnotationProcessing=true
+android.enableR8=false


### PR DESCRIPTION
This updates Quran to 2.9.2-p1. It disables R8 because the line numbers
are all wrong during reported crashes. Consequently, switching back to
Proguard until it is fixed.