### PR TITLE
Fix a bug with tagging

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/dao/bookmark/Bookmark.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/dao/bookmark/Bookmark.kt
@@ -12,7 +12,7 @@ data class Bookmark @JvmOverloads constructor(val id: Long,
   fun isPageBookmark() = sura == null && ayah == null
 
   fun withTags(tagIds: List<Long>): Bookmark {
-    return this.copy(tags = tagIds)
+    return this.copy(tags = mutableListOf<Long>().apply { addAll(tagIds) })
   }
 
   fun withAyahText(ayahText: String): Bookmark {


### PR DESCRIPTION
When the Bookmark class was switched to Kotlin, it didn't make a copy of
the list of tag ids. This was problematic because the calling code would
then clear it after it was done, resulting in all tag ids being gone.
This patch fixes it by making a copy.