### PR TITLE
Prompt for Arabic db download when sharing

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/ui/PagerActivity.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/PagerActivity.java
@@ -1923,6 +1923,9 @@ public class PagerActivity extends QuranActionBarActivity implements
   private void shareAyah(SuraAyah start, SuraAyah end, final boolean isCopy) {
     if (start == null || end == null) {
       return;
+    } else if (!quranFileUtils.hasArabicSearchDatabase(this)) {
+      showGetRequiredFilesDialog();
+      return;
     }
 
     compositeDisposable.add(


### PR DESCRIPTION
Whenever an ayah is shared, if the Arabic database doesn't exist
(especially after the recent rename of the database, resulting in it not
existing in many cases), nothing will happen. This patch lets it prompt
for (and actually download) the database in this case.