### PR TITLE
Try to copy updated Arabic database from assets

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/util/CopyDatabaseUtil.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/util/CopyDatabaseUtil.kt
@@ -1,0 +1,43 @@
+package com.quran.labs.androidquran.util
+
+import android.content.Context
+import com.crashlytics.android.Crashlytics
+import io.reactivex.Single
+import okio.Okio
+import java.io.File
+import javax.inject.Inject
+
+class CopyDatabaseUtil @Inject constructor(val context: Context,
+                                           val quranFileUtils: QuranFileUtils) {
+
+  fun copyArabicDatabaseFromAssets(name: String): Single<Boolean> {
+    return Single.fromCallable {
+      val assets = context.assets
+      val files = assets.list("")
+      val filename = files?.firstOrNull { it.contains(name) }
+      if (filename != null) {
+        // do the copy
+        val destination = quranFileUtils.getQuranDatabaseDirectory(context)
+        Okio.source(assets.open(filename)).use { source ->
+          Okio.buffer(Okio.sink(File(destination, filename))).use { destination ->
+            destination.writeAll(source)
+          }
+        }
+
+        if (filename.endsWith(".zip")) {
+          val zipFile = destination + File.separator + filename
+          val result = ZipUtils.unzipFile(zipFile, destination, filename, null)
+          // delete the zip file, since there's no need to have it twice
+          File(zipFile).delete()
+          result
+        } else {
+          true
+        }
+      } else {
+        false
+      }
+    }
+    .doOnError { Crashlytics.logException(it) }
+    .onErrorReturn { false }
+  }
+}


### PR DESCRIPTION
Due to the upgrade done to the Arabic database (switching to a
completely separate one), people will have to download the updated
database or risk not being able to share, see the ayah text above pages,
and so on. Given that this affects everyone (and that there's
intentionally no fallback logic to the old database due to its text not
being uthmani text), support copying the database from assets if it
ships with the app.