### PR TITLE
Disregard removed translations while sharing

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/util/ShareUtil.java
+++ b/app/src/main/java/com/quran/labs/androidquran/util/ShareUtil.java
@@ -64,13 +64,16 @@ public class ShareUtil {
     }
 
     for (int i = 0, size = ayahInfo.texts.size(); i < size; i++) {
-      if (i < translationNames.length) {
-        sb.append('(')
-          .append(translationNames[i].getTranslatorName())
-          .append(")\n");
+      final CharSequence text = ayahInfo.texts.get(i).getText();
+      if (text.length() > 0) {
+        if (i < translationNames.length) {
+          sb.append('(')
+              .append(translationNames[i].getTranslatorName())
+              .append(")\n");
+        }
+        sb.append(text)
+            .append("\n\n");
       }
-      sb.append(ayahInfo.texts.get(i).getText())
-        .append("\n\n");
     }
     sb.append('-')
       .append(quranInfo.getSuraAyahString(context, ayahInfo.sura, ayahInfo.ayah));


### PR DESCRIPTION
If a translation file is removed from the filesystem while the app still
knows about it, the shared text comes back empty for that translation.
The app still shows an empty "()" for the translation name, followed by
empty lines for the translation. This patch fixes it and removes empty
translation results from the text.