### PR TITLE
Fix a bug causing new translations to disappear

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/ui/TranslationManagerActivity.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/TranslationManagerActivity.java
@@ -137,12 +137,6 @@ public class TranslationManagerActivity extends QuranActionBarActivity
         }
       }
 
-      // for upgrades, remove the old file to stop the tafseer from showing up
-      // twice. this happens because old and new tafaseer (ex ibn kathir) have
-      // different ids when they target different schema versions, and so the
-      // old file needs to be removed from the database explicitly
-      presenter.removeByFilename(downloadingItem.getTranslation().getFileName());
-
       TranslationItem updated = downloadingItem.withTranslationVersion(
           downloadingItem.getTranslation().getCurrentVersion());
       updateTranslationItem(updated);


### PR DESCRIPTION
Because some translations now have multiple entries for them with
different ids (an id on the old version and an id on the new version),
code was added to remove the old entry from the database asynchrnously,
while the updated entry was also set to be written asynchronously.
Consequently, it was possible for the addition to happen before the
remove, causing no entries to exist in the database. This fixes the
problem by combining them sequentially. It also gates it so the deletion
logic only happens for databases with a minimum schema version of v5,
since before that, no ids are shared across versions.