### PR TITLE
Fix a race condition while updating tafaseer

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/presenter/translation/TranslationManagerPresenter.java
+++ b/app/src/main/java/com/quran/labs/androidquran/presenter/translation/TranslationManagerPresenter.java
@@ -28,7 +28,6 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 
 import androidx.annotation.VisibleForTesting;
-import io.reactivex.Completable;
 import io.reactivex.Observable;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.observers.DisposableMaybeObserver;
@@ -123,17 +122,10 @@ public class TranslationManagerPresenter implements Presenter<TranslationManager
           // old file needs to be removed from the database explicitly
           final Translation translation = item.getTranslation();
           if (translation.getMinimumVersion() >= 5) {
-            removeByFilename(translation.getFileName());
+            translationsDBAdapter.deleteTranslationByFile(translation.getFileName());
           }
           return translationsDBAdapter.writeTranslationUpdates(Collections.singletonList(item));
         }
-    ).subscribeOn(Schedulers.io())
-        .subscribe();
-  }
-
-  private void removeByFilename(final String filename) {
-    Completable.fromAction(() ->
-        translationsDBAdapter.deleteTranslationByFile(filename)
     ).subscribeOn(Schedulers.io())
         .subscribe();
   }


### PR DESCRIPTION
When a tafseer is upgraded, there is code to remove entries with the old
filename from the database in certain cases. In these cases, the remove
was asynchronous despite the update itself being async, causing the
entry to usually be removed from the database after adding it. This
fixes this bug.