### PR TITLE
Add one time upgrade logic to fix translations

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/presenter/translation/TranslationManagerPresenter.java
+++ b/app/src/main/java/com/quran/labs/androidquran/presenter/translation/TranslationManagerPresenter.java
@@ -28,6 +28,8 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 
 import androidx.annotation.VisibleForTesting;
+import androidx.annotation.WorkerThread;
+import io.reactivex.Completable;
 import io.reactivex.Observable;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.observers.DisposableMaybeObserver;
@@ -128,6 +130,13 @@ public class TranslationManagerPresenter implements Presenter<TranslationManager
         }
     ).subscribeOn(Schedulers.io())
         .subscribe();
+  }
+
+  @WorkerThread
+  public Observable<List<TranslationItem>> syncTranslationsWithCache() {
+    return getCachedTranslationListObservable(false)
+        .filter(translationList -> !translationList.getTranslations().isEmpty())
+        .map(translationList -> mergeWithServerTranslations(translationList.getTranslations()));
   }
 
   Observable<TranslationList> getCachedTranslationListObservable(final boolean forceDownload) {


### PR DESCRIPTION
This patch adds a one time upgrade to fix broken translations for people
upgrading from earlier 2.9.2 versions with the bug which allowed
downloading of tafaseer without adding them to the local database.