### PR TITLE
Keep the screen on when downloading translations

### DIFF
--- a/app/src/main/res/layout/translation_manager.xml
+++ b/app/src/main/res/layout/translation_manager.xml
@@ -3,7 +3,8 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/translation_swipe_refresh"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:keepScreenOn="true">
   <androidx.recyclerview.widget.RecyclerView
       android:id="@+id/translation_recycler"
       android:layout_width="match_parent"


### PR DESCRIPTION
When the screen turns off during the downloading of translations, the
download cuts off. This patch temporarily works around it by allowing the
screen to stay on while translations are being downloaded. This should
be fixed properly in the future.