### PR TITLE
Fix dual pages on tablet and in landscape

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/presenter/translation/TranslationPresenter.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/presenter/translation/TranslationPresenter.kt
@@ -75,8 +75,11 @@ internal class TranslationPresenter @Inject internal constructor(translationMode
   }
 
   private fun getPage(result: List<QuranAyahInfo>): Int {
-    return pages.firstOrNull() ?: result[0].let { ayahInfo ->
-      quranInfo.getPageFromSuraAyah(ayahInfo.sura, ayahInfo.ayah)
+    val firstPage = pages.first()
+    return if (pages.size == 1 && firstPage != null) {
+      firstPage
+    } else {
+      quranInfo.getPageFromSuraAyah(result[0].sura, result[0].ayah)
     }
   }
 


### PR DESCRIPTION
Dual pages in tablet mode (or in landscape with the dual page mode
option) was only rendering one translation page due to a bug during
which only the first page was always returned as the source page.
This patch fixes the bug. Fixes #1084.