### PR TITLE
Fix highlight overlapping

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/data/AyahInfoDatabaseProvider.java
+++ b/app/src/main/java/com/quran/labs/androidquran/data/AyahInfoDatabaseProvider.java
@@ -1,12 +1,13 @@
 package com.quran.labs.androidquran.data;
 
 import android.content.Context;
-import androidx.annotation.Nullable;
 
 import com.quran.labs.androidquran.di.ActivityScope;
 import com.quran.labs.androidquran.util.QuranFileUtils;
 
 import javax.inject.Inject;
+
+import androidx.annotation.Nullable;
 
 @ActivityScope
 public class AyahInfoDatabaseProvider {
@@ -30,5 +31,9 @@ public class AyahInfoDatabaseProvider {
           AyahInfoDatabaseHandler.getAyahInfoDatabaseHandler(context, filename, quranFileUtils);
     }
     return databaseHandler;
+  }
+
+  public int getPageWidth() {
+    return Integer.valueOf(widthParameter.substring(1));
   }
 }


### PR DESCRIPTION
This patch fixes highlight overlapping by removing rectangles that
overlap each other. It also changes the threshold of considering a line
to be a "full line" to be a percentage of the page size, which should
help fix some cases where the highlighting on the left or right side
does not form a straight vertical line. Fixes #951.