### PR TITLE
Start services as foreground sooner

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/service/AudioService.java
+++ b/app/src/main/java/com/quran/labs/androidquran/service/AudioService.java
@@ -357,6 +357,12 @@ public class AudioService extends Service implements OnCompletionListener,
     }
 
     final String action = intent.getAction();
+    if (ACTION_PLAYBACK.equals(action)) {
+      // this is the only action with startForegroundService, so
+      // go to the foreground as quickly as possible.
+      setUpAsForeground();
+    }
+
     if (ACTION_CONNECT.equals(action)) {
       if (State.Stopped == state) {
         processStopRequest(true);
@@ -399,12 +405,6 @@ public class AudioService extends Service implements OnCompletionListener,
               new AudioPlaybackInfo(start, 1, 1, basmallah));
           Crashlytics.log("audio request has changed...");
         }
-      }
-
-      // this is the only action called with startForegroundService, so go into the foreground
-      // as quickly as possible.
-      if (!isSetupAsForeground) {
-        setUpAsForeground();
       }
 
       if (intent.getBooleanExtra(EXTRA_STOP_IF_PLAYING, false)) {

--- a/app/src/main/java/com/quran/labs/androidquran/service/util/QuranDownloadNotifier.java
+++ b/app/src/main/java/com/quran/labs/androidquran/service/util/QuranDownloadNotifier.java
@@ -7,14 +7,15 @@ import android.app.Service;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Build;
-import androidx.annotation.RequiresApi;
-import androidx.core.app.NotificationCompat;
-import androidx.core.content.ContextCompat;
-import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 
 import com.crashlytics.android.Crashlytics;
 import com.quran.labs.androidquran.QuranDataActivity;
 import com.quran.labs.androidquran.R;
+
+import androidx.annotation.RequiresApi;
+import androidx.core.app.NotificationCompat;
+import androidx.core.content.ContextCompat;
+import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 
 public class QuranDownloadNotifier {
   // error messages
@@ -271,6 +272,16 @@ public class QuranDownloadNotifier {
     progressIntent.putExtra(ProgressIntent.ERROR_CODE, errorCode);
     broadcastManager.sendBroadcast(progressIntent);
     return progressIntent;
+  }
+
+  public void notifyDownloadStarting(){
+    String title = appContext.getString(R.string.downloading_title);
+    notificationManager.cancel(DOWNLOADING_ERROR_NOTIFICATION);
+
+    lastMaximum = -1;
+    lastProgress = -1;
+    showNotification(title, appContext.getString(R.string.downloading_message),
+        DOWNLOADING_NOTIFICATION, true, true);
   }
 
   public void stopForeground() {

--- a/app/src/main/java/com/quran/labs/androidquran/ui/PagerActivity.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/PagerActivity.java
@@ -782,6 +782,7 @@ public class PagerActivity extends QuranActionBarActivity implements
 
   @Override
   public void onNewIntent(Intent intent) {
+    super.onNewIntent(intent);
     if (intent == null) {
       return;
     }


### PR DESCRIPTION
Whenever a service is started as foreground, make the startForeground
call (along with showing the notification) one of the first things that
the service does.