### PR TITLE
Improve translation list refreshing

### DIFF
--- a/app/src/test/java/com/quran/labs/androidquran/presenter/translation/TranslationManagerPresenterTest.java
+++ b/app/src/test/java/com/quran/labs/androidquran/presenter/translation/TranslationManagerPresenterTest.java
@@ -58,7 +58,7 @@ public class TranslationManagerPresenterTest {
   @Test
   public void testGetCachedTranslationListObservable() {
     TestObserver<TranslationList> testObserver = new TestObserver<>();
-    this.translationManager.getCachedTranslationListObservable(true)
+    this.translationManager.getCachedTranslationListObservable()
         .subscribe(testObserver);
     testObserver.awaitTerminalEvent();
     testObserver.assertNoValues();
@@ -85,7 +85,7 @@ public class TranslationManagerPresenterTest {
   }
 
   @Test
-  public void getRemoteTranslationListObservableIssue() throws Exception {
+  public void getRemoteTranslationListObservableIssue() {
     MockResponse mockResponse = new MockResponse();
     mockResponse.setResponseCode(500);
     this.mockWebServer.enqueue(mockResponse);


### PR DESCRIPTION
Show a spinner while refershing the list the first time. Also, when the
cache is stale, show the cached copy while the network copy is fetched.