### PR TITLE
Fix copy failing for people without the db dir

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/util/CopyDatabaseUtil.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/util/CopyDatabaseUtil.kt
@@ -15,9 +15,14 @@ class CopyDatabaseUtil @Inject constructor(val context: Context,
       val assets = context.assets
       val files = assets.list("")
       val filename = files?.firstOrNull { it.contains(name) }
-      if (filename != null) {
+      val destination = quranFileUtils.getQuranDatabaseDirectory(context)
+      if (filename != null && destination != null) {
+        val destinationFile = File(destination)
+        if (!destinationFile.isDirectory) {
+          destinationFile.mkdirs()
+        }
+
         // do the copy
-        val destination = quranFileUtils.getQuranDatabaseDirectory(context)
         Okio.source(assets.open(filename)).use { source ->
           Okio.buffer(Okio.sink(File(destination, filename))).use { destination ->
             destination.writeAll(source)


### PR DESCRIPTION
If the database directory doesn't exist, the copy of the arabic database
from assets fails. This just makes the directory if it is needed before
attempting the copy.