### PR TITLE
Record an exception when pages disappear

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/QuranDataActivity.java
+++ b/app/src/main/java/com/quran/labs/androidquran/QuranDataActivity.java
@@ -467,7 +467,9 @@ public class QuranDataActivity extends Activity implements
               .logCustom(new CustomEvent("imagesDisappeared")
                 .putCustomAttribute("permissionGranted", havePermission ? "true" : "false")
                 .putCustomAttribute("osVersion", Build.VERSION.SDK_INT)
-                .putCustomAttribute("storagePath", quranSettings.getAppCustomLocation()));
+                .putCustomAttribute("storagePath", quranSettings.getAppCustomLocation())
+                .putCustomAttribute("storageNotAvailable", storageNotAvailable? "true" : "false"));
+          Timber.e(new IllegalStateException("Deleted Data"), "Unable to Download Pages");
           quranSettings.setDownloadedPages(false);
         }
 


### PR DESCRIPTION
With the patch to let Timber log messages to Crashlytics upon a crash,
this can help the investigation process for these cases where pages
disappear by showing which pages are missing, what directories were
being looked at, and so on.