### PR TITLE
Only use network for forced translation refresh

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/presenter/translation/TranslationManagerPresenter.java
+++ b/app/src/main/java/com/quran/labs/androidquran/presenter/translation/TranslationManagerPresenter.java
@@ -79,7 +79,12 @@ public class TranslationManagerPresenter implements Presenter<TranslationManager
     final Observable<TranslationList> source =
         Observable.concat(getCachedTranslationListObservable(), getRemoteTranslationListObservable());
     final Observable<TranslationList> observableSource;
-    if (isCacheStale || forceDownload) {
+    if (forceDownload) {
+      // we only force if we pulled to refresh or are refreshing in the background,
+      // implying that we have data on the screen already (or don't need data in the
+      // background case), so just get remote data.
+      observableSource = getRemoteTranslationListObservable();
+    } else if (isCacheStale) {
       observableSource = source;
     } else {
       observableSource = source.take(1);


### PR DESCRIPTION
When a force download happens for a translation list (via pull to
refresh or via a background check every few days), don't bother trying
to get the cached copy.