### PR TITLE
Remove sura name from 9:1 in uthmani db

### DIFF
--- a/app/src/madani/java/com/quran/labs/androidquran/data/QuranFileConstants.java
+++ b/app/src/madani/java/com/quran/labs/androidquran/data/QuranFileConstants.java
@@ -11,7 +11,7 @@ public class QuranFileConstants {
 
   // arabic database
   public static final String ARABIC_DATABASE =
-      Build.VERSION.SDK_INT >= 21 ? "quran.ar.uthmani.db" : "quran.ar.uthmani_simple.db";
+      Build.VERSION.SDK_INT >= 21 ? "quran.ar.uthmani.v2.db" : "quran.ar.uthmani_simple.db";
 
   public static final String ARABIC_SHARE_TABLE =
       Build.VERSION.SDK_INT >= 21 ?

--- a/app/src/main/java/com/quran/labs/androidquran/QuranDataActivity.java
+++ b/app/src/main/java/com/quran/labs/androidquran/QuranDataActivity.java
@@ -511,8 +511,11 @@ public class QuranDataActivity extends Activity implements
     // people to get them, the app will bundle them with the apk for a few releases.
     // if the database doesn't exist, let's try to copy it if we can. Only check this
     // if we have all the files, since if not, they come bundled with the full pages
-    // zip file anyway.
-    if (!quranFileUtils.hasArabicSearchDatabase(getApplicationContext())) {
+    // zip file anyway. Note that, for now, this only applies for the madani app.
+
+    //noinspection ConstantConditions
+    if ("madani".equals(BuildConfig.FLAVOR) &&
+        !quranFileUtils.hasArabicSearchDatabase(getApplicationContext())) {
       final boolean success =
           copyDatabaseUtil.copyArabicDatabaseFromAssets(QuranDataProvider.QURAN_ARABIC_DATABASE)
               .blockingGet();

--- a/app/src/shemerly/java/com/quran/labs/androidquran/data/QuranFileConstants.java
+++ b/app/src/shemerly/java/com/quran/labs/androidquran/data/QuranFileConstants.java
@@ -11,7 +11,7 @@ public class QuranFileConstants {
 
   // arabic database
   public static final String ARABIC_DATABASE =
-      Build.VERSION.SDK_INT >= 21 ? "quran.ar.uthmani.db" : "quran.ar.uthmani_simple.db";
+      Build.VERSION.SDK_INT >= 21 ? "quran.ar.uthmani.v2.db" : "quran.ar.uthmani_simple.db";
 
   public static final String ARABIC_SHARE_TABLE =
       Build.VERSION.SDK_INT >= 21 ?


### PR DESCRIPTION
In the uthmani database for api 21 and above, sura Tawbah's first ayah
started with the sura name - this updates the database that is pointed
to in order to remove it. Also, ensure copying from assets only happens
on the madani flavor for now. Fixes #1088.