### PR TITLE
Always replace the playing request

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/service/AudioService.java
+++ b/app/src/main/java/com/quran/labs/androidquran/service/AudioService.java
@@ -158,12 +158,6 @@ public class AudioService extends Service implements OnCompletionListener,
   // so user can pass in a serializable LegacyAudioRequest to the intent
   public static final String EXTRA_PLAY_INFO = "com.quran.labs.androidquran.PLAY_INFO";
 
-  // ignore the passed in play info if we're already playing
-  public static final String EXTRA_IGNORE_IF_PLAYING = "com.quran.labs.androidquran.IGNORE_IF_PLAYING";
-
-  // used to override what is playing now (stop then play)
-  public static final String EXTRA_STOP_IF_PLAYING = "com.quran.labs.androidquran.STOP_IF_PLAYING";
-
   // indicates the state our service:
   private enum State {
     Stopped,    // media player is stopped and not prepared to play
@@ -415,20 +409,15 @@ public class AudioService extends Service implements OnCompletionListener,
     } else if (ACTION_PLAYBACK.equals(action)) {
       AudioRequest playInfo = intent.getParcelableExtra(EXTRA_PLAY_INFO);
       if (playInfo != null) {
-        if (State.Stopped == state ||
-            !intent.getBooleanExtra(EXTRA_IGNORE_IF_PLAYING, false)) {
-          audioRequest = playInfo;
+        audioRequest = playInfo;
 
-          final SuraAyah start = audioRequest.getStart();
-          final boolean basmallah = !playInfo.isGapless() &&
-              SuraAyahExtensionKt.requiresBasmallah(start);
-          audioQueue = new AudioQueue(quranInfo, audioRequest,
-              new AudioPlaybackInfo(start, 1, 1, basmallah));
-          Crashlytics.log("audio request has changed...");
-        }
-      }
+        final SuraAyah start = audioRequest.getStart();
+        final boolean basmallah = !playInfo.isGapless() &&
+            SuraAyahExtensionKt.requiresBasmallah(start);
+        audioQueue = new AudioQueue(quranInfo, audioRequest,
+            new AudioPlaybackInfo(start, 1, 1, basmallah));
+        Crashlytics.log("audio request has changed...");
 
-      if (intent.getBooleanExtra(EXTRA_STOP_IF_PLAYING, false)) {
         if (player != null) {
           player.stop();
         }

--- a/app/src/main/java/com/quran/labs/androidquran/ui/PagerActivity.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/PagerActivity.java
@@ -155,7 +155,6 @@ public class PagerActivity extends QuranActionBarActivity implements
   private int highlightedSura = -1;
   private int highlightedAyah = -1;
   private int ayahToolBarTotalHeight;
-  private boolean shouldOverridePlaying = false;
   private DefaultDownloadReceiver downloadReceiver;
   private boolean needsPermissionToDownloadOver3g = true;
   private AlertDialog promptDialog = null;
@@ -1442,7 +1441,7 @@ public class PagerActivity extends QuranActionBarActivity implements
 
   private void playFromAyah(int page, int startSura, int startAyah) {
     final SuraAyah start = new SuraAyah(startSura, startAyah);
-    playFromAyah(start, null, page, 0, 0, false, false);
+    playFromAyah(start, null, page, 0, 0, false);
   }
 
   public void playFromAyah(SuraAyah start,
@@ -1450,12 +1449,7 @@ public class PagerActivity extends QuranActionBarActivity implements
                            int page,
                            int verseRepeat,
                            int rangeRepeat,
-                           boolean enforceRange,
-                           boolean force) {
-    if (force) {
-      shouldOverridePlaying = true;
-    }
-
+                           boolean enforceRange) {
     final SuraAyah ending = end != null ? end :
         audioUtils.getLastAyahToPlay(start, page,
             quranSettings.getPreferredDownloadAmount(), isDualPages);
@@ -1499,16 +1493,6 @@ public class PagerActivity extends QuranActionBarActivity implements
       audioStatusBar.setRepeatCount(request.getRepeatInfo());
     }
 
-    if (shouldOverridePlaying) {
-      // force the current audio to stop and start playing new request
-      i.putExtra(AudioService.EXTRA_STOP_IF_PLAYING, true);
-      shouldOverridePlaying = false;
-    }
-    // just a playback request, so tell audio service to just continue
-    // playing (and don't store new audio data) if it was already playing
-    else {
-      i.putExtra(AudioService.EXTRA_IGNORE_IF_PLAYING, true);
-    }
     Crashlytics.log("starting foreground service for audio playback");
     ContextCompat.startForegroundService(this, i);
   }

--- a/app/src/main/java/com/quran/labs/androidquran/ui/fragment/AyahPlaybackFragment.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/fragment/AyahPlaybackFragment.java
@@ -153,7 +153,7 @@ public class AyahPlaybackFragment extends AyahActionFragment {
           }
         }
         pagerActivity.playFromAyah(currentStart, currentEnding, page, verseRepeat,
-            rangeRepeat, enforceRange, true);
+            rangeRepeat, enforceRange);
       } else if (shouldEnforce != enforceRange ||
           rangeRepeatCount != rangeRepeat ||
           verseRepeatCount != verseRepeat) {
@@ -162,7 +162,7 @@ public class AyahPlaybackFragment extends AyahActionFragment {
             rangeRepeat, verseRepeat, enforceRange)) {
           // audio stopped in the process, let's start it
           pagerActivity.playFromAyah(currentStart, currentEnding, page, verseRepeat,
-              rangeRepeat, enforceRange, true);
+              rangeRepeat, enforceRange);
         }
       }
       pagerActivity.endAyahMode();


### PR DESCRIPTION
Previously, in some cases, an audio playback request would be a
"suggestion" of sorts and would not actually cause the player to play.
This doesn't make sense, and so the app now always replaces the current
player request with the last player request made.