### PR TITLE
Don't start audio service in foreground

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/ui/PagerActivity.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/PagerActivity.java
@@ -1485,17 +1485,17 @@ public class PagerActivity extends QuranActionBarActivity implements
 
   public void handlePlayback(AudioRequest request) {
     needsPermissionToDownloadOver3g = true;
-    Intent i = new Intent(this, AudioService.class);
-    i.setAction(AudioService.ACTION_PLAYBACK);
+    final Intent intent = new Intent(this, AudioService.class);
+    intent.setAction(AudioService.ACTION_PLAYBACK);
     if (request != null) {
-      i.putExtra(AudioService.EXTRA_PLAY_INFO, request);
+      intent.putExtra(AudioService.EXTRA_PLAY_INFO, request);
       lastAudioRequest = request;
       audioStatusBar.setRepeatCount(request.getRepeatInfo());
       audioStatusBar.switchMode(AudioStatusBar.LOADING_MODE);
     }
 
-    Crashlytics.log("starting foreground service for audio playback");
-    ContextCompat.startForegroundService(this, i);
+    Crashlytics.log("starting service for audio playback");
+    startService(intent);
   }
 
   @Override


### PR DESCRIPTION
Since the audio service is always started when the app is in the
foreground, and since there are still many ANRs due to not calling
startForeground quickly enough (though it's the earliest thing that
happens in the service), there is likely a race condition in which at
certain points of time, audio playback is stopped and removes the
notification and stops the service before startForeground is called. As
a workaround, just start the service in the background. This is possible
since the app is in the foreground at this point in time.