### PR TITLE
Fallback to Google DNS if DNS lookup fails

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -105,6 +105,7 @@ if (new File(rootDir, 'extras/extras.gradle').exists()) {
 
 dependencies {
   implementation project(path: ':common:data')
+  implementation project(path: ':common:networking')
   implementation project(path: ':common:pages')
 
   implementation deps.kotlin.stdlib

--- a/app/src/debug/java/com/quran/labs/androidquran/module/application/DebugNetworkModule.java
+++ b/app/src/debug/java/com/quran/labs/androidquran/module/application/DebugNetworkModule.java
@@ -1,6 +1,7 @@
 package com.quran.labs.androidquran.module.application;
 
 import com.facebook.stetho.okhttp3.StethoInterceptor;
+import com.quran.common.networking.dns.DnsModule;
 
 import java.util.concurrent.TimeUnit;
 
@@ -8,9 +9,10 @@ import javax.inject.Singleton;
 
 import dagger.Module;
 import dagger.Provides;
+import okhttp3.Dns;
 import okhttp3.OkHttpClient;
 
-@Module
+@Module(includes = { DnsModule.class })
 public class DebugNetworkModule {
 
   private static final int DEFAULT_READ_TIMEOUT_SECONDS = 20;
@@ -18,11 +20,12 @@ public class DebugNetworkModule {
 
   @Provides
   @Singleton
-  static OkHttpClient provideOkHttpClient() {
+  static OkHttpClient provideOkHttpClient(Dns dns) {
     return new OkHttpClient.Builder()
         .readTimeout(DEFAULT_READ_TIMEOUT_SECONDS, TimeUnit.SECONDS)
         .connectTimeout(DEFAULT_CONNECT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
         .addNetworkInterceptor(new StethoInterceptor())
+        .dns(dns)
         .build();
   }
 }

--- a/app/src/main/java/com/quran/labs/androidquran/component/application/ApplicationComponent.java
+++ b/app/src/main/java/com/quran/labs/androidquran/component/application/ApplicationComponent.java
@@ -10,7 +10,7 @@ import com.quran.labs.androidquran.data.QuranDataModule;
 import com.quran.labs.androidquran.data.QuranDataProvider;
 import com.quran.labs.androidquran.module.application.ApplicationModule;
 import com.quran.labs.androidquran.module.application.DatabaseModule;
-import com.quran.labs.androidquran.module.application.NetworkModule;
+import com.quran.common.networking.NetworkModule;
 import com.quran.labs.androidquran.pageselect.PageSelectActivity;
 import com.quran.labs.androidquran.service.AudioService;
 import com.quran.labs.androidquran.service.QuranDownloadService;

--- a/app/src/main/java/com/quran/labs/androidquran/module/application/ApplicationModule.java
+++ b/app/src/main/java/com/quran/labs/androidquran/module/application/ApplicationModule.java
@@ -12,6 +12,8 @@ import com.quran.data.source.PageProvider;
 import com.quran.data.source.PageSizeCalculator;
 import com.quran.labs.androidquran.util.QuranSettings;
 
+import java.io.File;
+
 import javax.inject.Singleton;
 
 import dagger.Module;
@@ -64,5 +66,10 @@ public class ApplicationModule {
   @Provides
   Scheduler provideMainThreadScheduler() {
     return AndroidSchedulers.mainThread();
+  }
+
+  @Provides
+  File provideCacheDirectory() {
+    return application.getCacheDir();
   }
 }

--- a/common/networking/build.gradle
+++ b/common/networking/build.gradle
@@ -1,0 +1,9 @@
+apply plugin: 'kotlin'
+apply plugin: 'kotlin-kapt'
+
+dependencies {
+  compile deps.kotlin.stdlib
+  kapt deps.dagger.apt
+  implementation deps.dagger.runtime
+  implementation "com.squareup.okhttp3:okhttp-dnsoverhttps:${okhttpVersion}"
+}

--- a/common/networking/src/main/java/com/quran/common/networking/NetworkModule.java
+++ b/common/networking/src/main/java/com/quran/common/networking/NetworkModule.java
@@ -1,4 +1,6 @@
-package com.quran.labs.androidquran.module.application;
+package com.quran.common.networking;
+
+import com.quran.common.networking.dns.DnsModule;
 
 import java.util.concurrent.TimeUnit;
 
@@ -6,19 +8,21 @@ import javax.inject.Singleton;
 
 import dagger.Module;
 import dagger.Provides;
+import okhttp3.Dns;
 import okhttp3.OkHttpClient;
 
-@Module
+@Module(includes = { DnsModule.class })
 public class NetworkModule {
   private static final int DEFAULT_READ_TIMEOUT_SECONDS = 20;
   private static final int DEFAULT_CONNECT_TIMEOUT_SECONDS = 15;
 
   @Provides
   @Singleton
-  static OkHttpClient provideOkHttpClient() {
+  static OkHttpClient provideOkHttpClient(Dns dns) {
     return new OkHttpClient.Builder()
         .readTimeout(DEFAULT_READ_TIMEOUT_SECONDS, TimeUnit.SECONDS)
         .connectTimeout(DEFAULT_CONNECT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+        .dns(dns)
         .build();
   }
 }

--- a/common/networking/src/main/java/com/quran/common/networking/dns/DnsModule.kt
+++ b/common/networking/src/main/java/com/quran/common/networking/dns/DnsModule.kt
@@ -1,0 +1,51 @@
+package com.quran.common.networking.dns
+
+import dagger.Module
+import dagger.Provides
+import okhttp3.Cache
+import okhttp3.Dns
+import okhttp3.HttpUrl
+import okhttp3.OkHttpClient
+import okhttp3.dnsoverhttps.DnsOverHttps
+import java.io.File
+import java.net.InetAddress
+import java.net.UnknownHostException
+
+@Module
+class DnsModule {
+
+  @Provides
+  fun providesDns(servers: List<@JvmSuppressWildcards Dns>): Dns {
+    return MultiDns(servers)
+  }
+
+  @Provides
+  fun provideDnsCache(cacheDirectory: File): Cache {
+    return Cache(cacheDirectory, 5 * 1024 * 1024L)
+  }
+
+  @Provides
+  fun provideServers(dnsCache: Cache): List<Dns> {
+    val bootstrapClient = OkHttpClient.Builder()
+        .cache(dnsCache)
+        .build()
+
+    val googleDns = provideGoogleDns(bootstrapClient)
+    return if (googleDns != null) {
+      listOf(Dns.SYSTEM, googleDns)
+    } else { listOf(Dns.SYSTEM) }
+  }
+
+  private fun provideGoogleDns(bootstrapClient: OkHttpClient): Dns? {
+    return try {
+      DnsOverHttps.Builder()
+          .client(bootstrapClient)
+          .url(HttpUrl.get("https://dns.google.com/experimental"))
+          .bootstrapDnsHosts(InetAddress.getByName("216.58.204.78"),
+              InetAddress.getByName("2a00:1450:4009:814:0:0:0:200e"))
+          .build()
+    } catch (exception: UnknownHostException) {
+      null
+    }
+  }
+}

--- a/common/networking/src/main/java/com/quran/common/networking/dns/MultiDns.kt
+++ b/common/networking/src/main/java/com/quran/common/networking/dns/MultiDns.kt
@@ -1,0 +1,21 @@
+package com.quran.common.networking.dns
+
+import okhttp3.Dns
+import java.net.InetAddress
+import java.net.UnknownHostException
+
+class MultiDns(private val servers: List<Dns>) : Dns {
+
+  override fun lookup(hostname: String): MutableList<InetAddress> {
+    var lastException: Exception? = null
+    for (i in 0 until servers.size) {
+      try {
+        return servers[i].lookup(hostname)
+      } catch (unknownHostException: UnknownHostException) {
+        lastException = unknownHostException
+      }
+    }
+
+    throw lastException!!
+  }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,6 @@
 include ':app'
 include ':common:data'
+include ':common:networking'
 include ':common:pages'
 include ':pages:madani'
 


### PR DESCRIPTION
Whenever DNS lookup fails, fall back to Google DNS (over https). This patch
also introduces a network module and moves some code there.