### PR TITLE
Implement a way to expand tafseer links

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/common/QuranText.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/common/QuranText.kt
@@ -1,3 +1,3 @@
 package com.quran.labs.androidquran.common
 
-class QuranText(val sura: Int, val ayah: Int, val text: String)
+class QuranText(val sura: Int, val ayah: Int, val text: String, val extraData: String? = null)

--- a/app/src/main/java/com/quran/labs/androidquran/model/translation/ArabicDatabaseUtils.java
+++ b/app/src/main/java/com/quran/labs/androidquran/model/translation/ArabicDatabaseUtils.java
@@ -28,7 +28,9 @@ import io.reactivex.schedulers.Schedulers;
 
 @Singleton
 public class ArabicDatabaseUtils {
-  public static final String AR_BASMALLAH = "بِسۡمِ ٱللَّهِ ٱلرَّحۡمَـٰنِ ٱلرَّحِیمِ";
+  public static final String AR_BASMALLAH = "بِسْمِ اللَّهِ الرَّحْمَٰنِ الرَّحِيمِ";
+  static final String AR_BASMALLAH_IN_TEXT = "بِسۡمِ ٱللَّهِ ٱلرَّحۡمَـٰنِ ٱلرَّحِیمِ";
+
   @VisibleForTesting static final int NUMBER_OF_WORDS = 4;
 
   private final Context appContext;
@@ -67,7 +69,10 @@ public class ArabicDatabaseUtils {
         cursor = arabicDatabaseHandler.getVerses(start.sura, start.ayah,
             end.sura, end.ayah, QuranFileConstants.ARABIC_SHARE_TABLE);
         while (cursor.moveToNext()) {
-          QuranText verse = new QuranText(cursor.getInt(1), cursor.getInt(2), cursor.getString(3));
+          QuranText verse = new QuranText(cursor.getInt(1),
+              cursor.getInt(2),
+              cursor.getString(3),
+              null);
           verses.add(verse);
         }
       } catch (Exception e) {
@@ -158,8 +163,8 @@ public class ArabicDatabaseUtils {
     // note that ayahText.startsWith check is always true for now - but it's explicitly here so
     // that if we update quran.ar.db one day to fix this issue and older clients get a new copy of
     // the database, their code continues to work as before.
-    if (ayah == 1 && sura != 9 && sura != 1 && ayahText.startsWith(AR_BASMALLAH)) {
-      return ayahText.substring(AR_BASMALLAH.length() + 1);
+    if (ayah == 1 && sura != 9 && sura != 1 && ayahText.startsWith(AR_BASMALLAH_IN_TEXT)) {
+      return ayahText.substring(AR_BASMALLAH_IN_TEXT.length() + 1);
     }
     return ayahText;
   }

--- a/app/src/main/java/com/quran/labs/androidquran/util/TranslationUtil.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/util/TranslationUtil.kt
@@ -15,15 +15,21 @@ open class TranslationUtil(@ColorInt private val color: Int,
 
   open fun parseTranslationText(quranText: QuranText): TranslationMetadata {
     val text = quranText.text
-    if (text.length < 5) {
-      val ayahId = text.toIntOrNull()
-      if (ayahId != null) {
-        val suraAyah = quranInfo.getSuraAyahFromAyahId(ayahId)
-        return TranslationMetadata(quranText.sura, quranText.ayah, text, suraAyah)
-      }
+    val hyperlinkId = getHyperlinkAyahId(quranText)
+
+    val suraAyah = if (hyperlinkId != null) {
+      quranInfo.getSuraAyahFromAyahId(hyperlinkId)
+    } else {
+      null
     }
 
-    val withoutFooters = footerRegex.replace(text, "")
+    val textToParse = if (suraAyah != null && quranText.extraData != null) {
+      quranText.extraData
+    } else {
+      text
+    }
+
+    val withoutFooters = footerRegex.replace(textToParse, "")
     val spannable = SpannableString(withoutFooters)
 
     ayahRegex.findAll(withoutFooters)
@@ -32,12 +38,21 @@ open class TranslationUtil(@ColorInt private val color: Int,
           val range = it.range
           spannable.setSpan(span, range.start, range.last + 1, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
         }
-    return TranslationMetadata(quranText.sura, quranText.ayah, spannable)
+    return TranslationMetadata(quranText.sura, quranText.ayah, spannable, suraAyah)
   }
 
   companion object {
     private val ayahRegex = """([«{﴿][\s\S]*?[﴾}»])""".toRegex()
     private val footerRegex = """\[\[[\s\S]*?]]""".toRegex()
     const val MINIMUM_PROCESSING_VERSION = 5
+
+    @JvmStatic
+    fun getHyperlinkAyahId(quranText: QuranText): Int? {
+      val text = quranText.text
+      if (text.length < 5) {
+        return text.toIntOrNull()
+      }
+      return null
+    }
   }
 }

--- a/app/src/main/java/com/quran/labs/androidquran/widgets/InlineTranslationView.java
+++ b/app/src/main/java/com/quran/labs/androidquran/widgets/InlineTranslationView.java
@@ -18,7 +18,6 @@ import com.quran.labs.androidquran.R;
 import com.quran.labs.androidquran.common.LocalTranslation;
 import com.quran.labs.androidquran.common.QuranAyahInfo;
 import com.quran.labs.androidquran.common.TranslationMetadata;
-import com.quran.labs.androidquran.data.SuraAyah;
 import com.quran.labs.androidquran.util.QuranSettings;
 
 import java.util.List;
@@ -138,12 +137,8 @@ public class InlineTranslationView extends ScrollView {
           builder.append("\n\n");
         }
 
-        final SuraAyah link = translationMetadata.getLink();
-        if (link != null) {
-          builder.append(context.getString(R.string.see_tafseer_of_verse, link.ayah));
-        } else {
-          builder.append(translationText);
-        }
+        // irrespective of whether it's a link or not, show the text
+        builder.append(translationText);
       }
     }
     ayahView.append(builder);

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -138,7 +138,7 @@
   <string name="dialog_ok">موافق</string>
 
   <!-- tafaseer -->
-  <string name="see_tafseer_of_verse">انظر تفسير الآية %d.</string>
+  <string name="see_tafseer_of_verse">تفسير الآية تابع للآية %d (انقر للعرض).</string>
 
   <!-- translation updates -->
   <string name="update_available">هناك تحديثات</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -233,7 +233,7 @@
 
   <!-- tafaseer -->
   <string name="more_arabic" translatable="false">المزيد…</string>
-  <string name="see_tafseer_of_verse">See tafseer for ayah %d.</string>
+  <string name="see_tafseer_of_verse">This ayah\'s tafseer is included with the tafseer of ayah %d (Click to expand).</string>
 
   <!-- translation updates -->
   <string name="update_available">Update Available</string>

--- a/app/src/test/java/com/quran/labs/androidquran/model/translation/ArabicDatabaseUtilsTest.java
+++ b/app/src/test/java/com/quran/labs/androidquran/model/translation/ArabicDatabaseUtilsTest.java
@@ -109,7 +109,7 @@ public class ArabicDatabaseUtilsTest {
 
   @Test
   public void testGetAyahWithoutBasmallah() {
-    String basmallah = ArabicDatabaseUtils.AR_BASMALLAH;
+    String basmallah = ArabicDatabaseUtils.AR_BASMALLAH_IN_TEXT;
 
     String original = basmallah + " first ayah";
     assertThat(ArabicDatabaseUtils.getAyahWithoutBasmallah(1, 1, original)).isSameAs(original);


### PR DESCRIPTION
In some tafaseer, a single "entry" gives the translations for multiple
ayat. Previously, the app would just show a "same as translation for
ayah X." This made many people sad. This patch attemps to fix this by
adding the ability to tap the translation to actually display the
translation text.