### PR TITLE
Include basmallah in shared text pre-L

### DIFF
--- a/app/src/madani/java/com/quran/labs/androidquran/data/QuranFileConstants.java
+++ b/app/src/madani/java/com/quran/labs/androidquran/data/QuranFileConstants.java
@@ -16,4 +16,6 @@ public class QuranFileConstants {
   public static final String ARABIC_SHARE_TABLE =
       Build.VERSION.SDK_INT >= 21 ?
           DatabaseHandler.SHARE_TEXT_TABLE : DatabaseHandler.ARABIC_TEXT_TABLE;
+
+  public static final boolean ARABIC_SHARE_TEXT_HAS_BASMALLAH = Build.VERSION.SDK_INT >= 21;
 }

--- a/app/src/main/java/com/quran/labs/androidquran/model/translation/ArabicDatabaseUtils.java
+++ b/app/src/main/java/com/quran/labs/androidquran/model/translation/ArabicDatabaseUtils.java
@@ -69,9 +69,18 @@ public class ArabicDatabaseUtils {
         cursor = arabicDatabaseHandler.getVerses(start.sura, start.ayah,
             end.sura, end.ayah, QuranFileConstants.ARABIC_SHARE_TABLE);
         while (cursor.moveToNext()) {
-          QuranText verse = new QuranText(cursor.getInt(1),
-              cursor.getInt(2),
-              cursor.getString(3),
+          final int sura = cursor.getInt(1);
+          final int ayah = cursor.getInt(2);
+          final String extra;
+          if ((!QuranFileConstants.ARABIC_SHARE_TEXT_HAS_BASMALLAH) &&
+              ayah == 1 && sura != 9 && sura != 1) {
+            extra = AR_BASMALLAH + " ";
+          } else {
+            extra = "";
+          }
+
+          QuranText verse = new QuranText(sura, ayah,
+              extra + cursor.getString(3),
               null);
           verses.add(verse);
         }

--- a/app/src/naskh/java/com/quran/labs/androidquran/data/QuranFileConstants.java
+++ b/app/src/naskh/java/com/quran/labs/androidquran/data/QuranFileConstants.java
@@ -1,9 +1,9 @@
 package com.quran.labs.androidquran.data;
 
+import android.os.Build;
+
 import com.quran.labs.androidquran.database.DatabaseHandler;
 import com.quran.labs.androidquran.ui.util.TypefaceManager;
-
-import android.os.Build;
 
 public class QuranFileConstants {
   // server urls
@@ -14,4 +14,6 @@ public class QuranFileConstants {
       Build.VERSION.SDK_INT > Build.VERSION_CODES.JELLY_BEAN_MR1 ?
           "quran.ar_naskh.db" : "quran.ar.db";
   public static final String ARABIC_SHARE_TABLE = DatabaseHandler.ARABIC_TEXT_TABLE;
+
+  public static final boolean ARABIC_SHARE_TEXT_HAS_BASMALLAH = false;
 }

--- a/app/src/qaloon/java/com/quran/labs/androidquran/data/QuranFileConstants.java
+++ b/app/src/qaloon/java/com/quran/labs/androidquran/data/QuranFileConstants.java
@@ -10,4 +10,5 @@ public class QuranFileConstants {
   // arabic database
   public static final String ARABIC_DATABASE = "quran.ar.db";
   public static final String ARABIC_SHARE_TABLE = DatabaseHandler.ARABIC_TEXT_TABLE;
+  public static final boolean ARABIC_SHARE_TEXT_HAS_BASMALLAH = true;
 }

--- a/app/src/shemerly/java/com/quran/labs/androidquran/data/QuranFileConstants.java
+++ b/app/src/shemerly/java/com/quran/labs/androidquran/data/QuranFileConstants.java
@@ -16,4 +16,5 @@ public class QuranFileConstants {
   public static final String ARABIC_SHARE_TABLE =
       Build.VERSION.SDK_INT >= 21 ?
           DatabaseHandler.SHARE_TEXT_TABLE : DatabaseHandler.ARABIC_TEXT_TABLE;
+  public static final boolean ARABIC_SHARE_TEXT_HAS_BASMALLAH = true;
 }

--- a/app/src/warsh/java/com/quran/labs/androidquran/data/QuranFileConstants.java
+++ b/app/src/warsh/java/com/quran/labs/androidquran/data/QuranFileConstants.java
@@ -10,4 +10,5 @@ public class QuranFileConstants {
   // arabic database
   public static final String ARABIC_DATABASE = "quran.ar.db";
   public static final String ARABIC_SHARE_TABLE = DatabaseHandler.ARABIC_TEXT_TABLE;
+  public static final boolean ARABIC_SHARE_TEXT_HAS_BASMALLAH = true;
 }


### PR DESCRIPTION
Before Android L, the database doesn't contain the basmallah before the
first ayah of each sura. This patch fixes sharing to include the
basmallah on those devices. Fixes #1092.