### PR TITLE
Update legacy madani pages to v6

### DIFF
--- a/pages/madani/src/main/java/com/quran/data/page/provider/madani/MadaniPageProvider.kt
+++ b/pages/madani/src/main/java/com/quran/data/page/provider/madani/MadaniPageProvider.kt
@@ -16,7 +16,7 @@ class MadaniPageProvider : PageProvider {
   override fun getPageSizeCalculator(displaySize: DisplaySize): PageSizeCalculator =
       DefaultPageSizeCalculator(displaySize)
 
-  override fun getImageVersion() = 5
+  override fun getImageVersion() = 6
 
   override fun getImagesBaseUrl() = "$baseUrl/"
 


### PR DESCRIPTION
The basmallah on pages 597 and 598 should have a shaddah. This patch
pulls in quran/quran.com-images#30 and thereby fixes #640.