### PR TITLE
Properly handle MediaButtonReceiver

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/service/AudioService.java
+++ b/app/src/main/java/com/quran/labs/androidquran/service/AudioService.java
@@ -364,7 +364,7 @@ public class AudioService extends Service implements OnCompletionListener,
       }
     } else {
       final String action = intent.getAction();
-      if (ACTION_PLAYBACK.equals(action)) {
+      if (ACTION_PLAYBACK.equals(action) || Intent.ACTION_MEDIA_BUTTON.equals(action)) {
         // go to the foreground as quickly as possible.
         setUpAsForeground();
       }


### PR DESCRIPTION
Previously, the AudioService only went to the foreground when the action
was a playback action. Since the MediaButtonReceiver attempts to start a
foreground service, the service should also go into the foreground for
media buttons.