### PR TITLE
Fix override parameter conflict

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/QuranDataActivity.java
+++ b/app/src/main/java/com/quran/labs/androidquran/QuranDataActivity.java
@@ -371,7 +371,6 @@ public class QuranDataActivity extends Activity implements
         if (fallback != null) {
           Timber.d("setting fallback pages to %s", fallback);
           quranSettings.setDefaultImagesDirectory(fallback);
-          quranScreenInfo.setOverrideParam(fallback);
         }
       }
 

--- a/app/src/main/java/com/quran/labs/androidquran/util/QuranScreenInfo.java
+++ b/app/src/main/java/com/quran/labs/androidquran/util/QuranScreenInfo.java
@@ -2,13 +2,13 @@ package com.quran.labs.androidquran.util;
 
 import android.content.Context;
 import android.graphics.Point;
-import androidx.annotation.NonNull;
 import android.view.Display;
 
 import com.quran.data.source.PageSizeCalculator;
 
 import javax.inject.Inject;
 
+import androidx.annotation.NonNull;
 import timber.log.Timber;
 
 public class QuranScreenInfo {
@@ -34,14 +34,6 @@ public class QuranScreenInfo {
     this.context = appContext;
     this.pageSizeCalculator = pageSizeCalculator;
     Timber.d("initializing with %d and %d", point.y, point.x);
-
-    setOverrideParam(QuranSettings.getInstance(context).getDefaultImagesDirectory());
-  }
-
-  public void setOverrideParam(String overrideParam) {
-    if (!overrideParam.isEmpty()) {
-      pageSizeCalculator.setOverrideParameter(overrideParam);
-    }
   }
 
   public int getHeight() {
@@ -53,10 +45,14 @@ public class QuranScreenInfo {
   }
 
   public String getWidthParam() {
+    pageSizeCalculator.setOverrideParameter(
+        QuranSettings.getInstance(context).getDefaultImagesDirectory());
     return "_" + pageSizeCalculator.getWidthParameter();
   }
 
   public String getTabletWidthParam() {
+    pageSizeCalculator.setOverrideParameter(
+        QuranSettings.getInstance(context).getDefaultImagesDirectory());
     return "_" + pageSizeCalculator.getTabletWidthParameter();
   }
 

--- a/common/data/src/main/java/com/quran/data/pageinfo/common/size/DefaultPageSizeCalculator.kt
+++ b/common/data/src/main/java/com/quran/data/pageinfo/common/size/DefaultPageSizeCalculator.kt
@@ -30,6 +30,8 @@ open class DefaultPageSizeCalculator(displaySize: DisplaySize) : PageSizeCalcula
   override fun setOverrideParameter(parameter: String) {
     if (parameter.isNotBlank()) {
       overrideParam = parameter
+    } else {
+      overrideParam = null
     }
   }
 


### PR DESCRIPTION
Because QuranScreenInfo is no longer a singleton (intentionally due to
the fact that the page size calculator changes between page types), it
is possible to have 2 QuranScreenInfo instances around at the same time,
one pointing to an override parameter and the other not pointing to one.

This particular solution isn't efficient (requiring a SharedPrefs lookup
before either of the get width methods are called), but it's the
quickest and safest solution for the time being.