### PR TITLE
Minor cleanup of unnecessary code

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/QuranDataActivity.java
+++ b/app/src/main/java/com/quran/labs/androidquran/QuranDataActivity.java
@@ -59,7 +59,6 @@ public class QuranDataActivity extends Activity implements
   private boolean havePermission = false;
   private boolean taskIsRunning;
   private String patchUrl;
-  private int fromVersion;
 
   @Inject QuranInfo quranInfo;
   @Inject QuranFileUtils quranFileUtils;
@@ -76,7 +75,6 @@ public class QuranDataActivity extends Activity implements
     quranApp.getApplicationComponent().inject(this);
 
     quranSettings = QuranSettings.getInstance(this);
-    fromVersion = quranSettings.getVersion();
     quranSettings.upgradePreferences();
 
     // replace null app locations (especially those set to null due to failures
@@ -329,20 +327,6 @@ public class QuranDataActivity extends Activity implements
       if (baseDir == null) {
         storageNotAvailable = true;
         return false;
-      }
-
-      // there was a bug in 2.9.2 through 2.9.2-p2 where an upgraded tafseer could be
-      // downloaded while not retaining the record in the translations database. sync
-      // with the database to fix this in these cases.
-      if (fromVersion > 2920 && fromVersion < 2923) {
-        // subscribe on the current thread which is a background thread
-        translationManagerPresenter.syncTranslationsWithCache()
-            .subscribe();
-      }
-
-      final File pageType = new File(baseDir, "pageType");
-      if (pageType.exists()) {
-        quranFileUtils.deleteFileOrDirectory(pageType);
       }
 
       final int totalPages = quranInfo.getNumberOfPages();

--- a/app/src/main/java/com/quran/labs/androidquran/util/QuranSettings.java
+++ b/app/src/main/java/com/quran/labs/androidquran/util/QuranSettings.java
@@ -378,21 +378,4 @@ public class QuranSettings {
   public boolean getWasShowingTranslation() {
     return perInstallationPrefs.getBoolean(Constants.PREF_WAS_SHOWING_TRANSLATION, false);
   }
-
-  public boolean didCheckPartialImages() {
-    final Set<String> checkedSets =
-        perInstallationPrefs.getStringSet(Constants.PREF_CHECKED_PARTIAL_IMAGES,
-            Collections.emptySet());
-    return checkedSets.contains(getPageType());
-  }
-
-  public void setCheckedPartialImages() {
-    final Set<String> checkedSets =
-        perInstallationPrefs.getStringSet(Constants.PREF_CHECKED_PARTIAL_IMAGES,
-            Collections.emptySet());
-    final Set<String> setToSave = new HashSet<>(checkedSets);
-    setToSave.add(getPageType());
-    perInstallationPrefs.edit()
-        .putStringSet(Constants.PREF_CHECKED_PARTIAL_IMAGES, setToSave).apply();
-  }
 }


### PR DESCRIPTION
This patch just removes some older upgrade logic and some unused checks
related to the page checker (which was removed).