### PR TITLE
Decrease unique images required for tablet mode

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/util/QuranScreenInfo.java
+++ b/app/src/main/java/com/quran/labs/androidquran/util/QuranScreenInfo.java
@@ -57,6 +57,6 @@ public class QuranScreenInfo {
   }
 
   public boolean isDualPageMode() {
-    return maxWidth > 800;
+    return maxWidth > 960;
   }
 }

--- a/common/data/src/main/java/com/quran/data/pageinfo/common/size/DefaultPageSizeCalculator.kt
+++ b/common/data/src/main/java/com/quran/data/pageinfo/common/size/DefaultPageSizeCalculator.kt
@@ -18,12 +18,10 @@ open class DefaultPageSizeCalculator(displaySize: DisplaySize) : PageSizeCalcula
   }
 
   override fun getTabletWidthParameter(): String {
-    return if ("1260" == getWidthParameter()) {
-      // for tablet, if the width is more than 1280, use 1260
-      // images for both dimens (only applies to new installs)
-      "1260"
+    return if ("1920" == overrideParam) {
+      "1024"
     } else {
-      getBestTabletLandscapeSizeMatch(maxWidth / 2)
+      getWidthParameter()
     }
   }
 
@@ -32,14 +30,6 @@ open class DefaultPageSizeCalculator(displaySize: DisplaySize) : PageSizeCalcula
       overrideParam = parameter
     } else {
       overrideParam = null
-    }
-  }
-
-  private fun getBestTabletLandscapeSizeMatch(width: Int): String {
-    return if (width <= 640) {
-      "512"
-    } else {
-      "1024"
     }
   }
 }


### PR DESCRIPTION
This patch tries to avoid downloading extra pages for tablet. Whereas
before, any screen with its largest dimension being greater than 800
would download either 1024 or 512 tablet images, this patch prefers to
use the normal images as the tablet images in most cases. The exception
is when the person had 1920 images installed, use 1024 images for
tablet (1920 images were downloadable in older versions of the app).