### PR TITLE
Remove unnecessary page size fallback logic

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/QuranDataActivity.java
+++ b/app/src/main/java/com/quran/labs/androidquran/QuranDataActivity.java
@@ -330,8 +330,11 @@ public class QuranDataActivity extends Activity implements
       }
 
       final int totalPages = quranInfo.getNumberOfPages();
-      if (!quranSettings.haveDefaultImagesDirectory()) {
-           /* previously, we would send any screen widths greater than 1280
+      if (!quranSettings.haveDefaultImagesDirectory() &&
+          "madani".equals(quranSettings.getPageType())) {
+           /* this code is only valid for the legacy madani pages.
+            *
+            * previously, we would send any screen widths greater than 1280
             * to get 1920 images. this was problematic for various reasons,
             * including:
             * a. a texture limit for the maximum size of a bitmap that could
@@ -346,15 +349,20 @@ public class QuranDataActivity extends Activity implements
             * minor loss in quality.
             *
             * this code checks and sees, if the user already has a complete
-            * folder of images - 1920, then 1280, then 1024 - and in any of
-            * those cases, sets that in the pref so we load those instead of
-            * the new 1260 images.
+            * folder of 1920 images, in which case it sets that in the pref
+            * so we load those instead of 1260s.
             */
         final String fallback =
             quranFileUtils.getPotentialFallbackDirectory(appContext, totalPages);
         if (fallback != null) {
           Timber.d("setting fallback pages to %s", fallback);
           quranSettings.setDefaultImagesDirectory(fallback);
+        } else {
+          // stop doing this check every launch if the images don't exist.
+          // since the method checks for the key being missing (and since
+          // override parameter ignores the empty string), empty string is
+          // fine here.
+          quranSettings.setDefaultImagesDirectory("");
         }
       }
 

--- a/app/src/main/java/com/quran/labs/androidquran/util/QuranFileUtils.java
+++ b/app/src/main/java/com/quran/labs/androidquran/util/QuranFileUtils.java
@@ -85,7 +85,7 @@ public class QuranFileUtils {
     return hasVersionFile(context, widthParam, version);
   }
 
-  public boolean hasVersionFile(Context context, String widthParam, int version) {
+  private boolean hasVersionFile(Context context, String widthParam, int version) {
     String quranDirectory = getQuranImagesDirectory(context, widthParam);
     Timber.d("isVersion: checking if version %d exists for width %s at %s",
         version, widthParam, quranDirectory);
@@ -109,10 +109,6 @@ public class QuranFileUtils {
     if (state.equals(Environment.MEDIA_MOUNTED)) {
       if (haveAllImages(context, "_1920", totalPages, false)) {
         return "1920";
-      } else if (haveAllImages(context, "_1280", totalPages, false)) {
-        return "1280";
-      } else if (haveAllImages(context, "_1024", totalPages, false)) {
-        return "1024";
       }
     }
     return null;

--- a/app/src/main/java/com/quran/labs/androidquran/util/QuranSettings.java
+++ b/app/src/main/java/com/quran/labs/androidquran/util/QuranSettings.java
@@ -354,7 +354,7 @@ public class QuranSettings {
         .apply();
   }
 
-  public void clearDefaultImagesDirectory() {
+  private void clearDefaultImagesDirectory() {
     perInstallationPrefs.edit().remove(Constants.PREF_DEFAULT_IMAGES_DIR).apply();
   }
 

--- a/common/data/src/main/java/com/quran/data/pageinfo/common/size/DefaultPageSizeCalculator.kt
+++ b/common/data/src/main/java/com/quran/data/pageinfo/common/size/DefaultPageSizeCalculator.kt
@@ -5,6 +5,9 @@ import com.quran.data.source.PageSizeCalculator
 
 open class DefaultPageSizeCalculator(displaySize: DisplaySize) : PageSizeCalculator {
   private val maxWidth: Int = if (displaySize.x > displaySize.y) displaySize.x else displaySize.y
+
+  // override parameter can be null or 1920
+  // (a few upgrade scenarios may also see this set at 1024)
   private var overrideParam: String? = null
 
   override fun getWidthParameter(): String {


### PR DESCRIPTION
Previously, the app would always check for 1920, 1280, or 1024 images,
setting them as an override if they existed (to support older versions
of the app). This had a set of problems:
1. These checks were run on all page types and flavors, even though they
   were only necessary for the legacy madani pages.
2. The 1280 images were never served for the legacy madani pages, so
   checking for them was not necessary.
3. The 1024 images were a fallback for old devices that couldn't use
   1920 images when their devices couldn't load a 1920 images. This is
   supposed to be rare, so the override isn't strictly necessary here.
4. If no override is necessary, the app always repeated this set of
   checks every time it checked the pages.

This patch attempts to fix many of these problems.