### PR TITLE
Don't log IOExceptions for page by page loads

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/pageselect/PageSelectPresenter.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/pageselect/PageSelectPresenter.kt
@@ -46,7 +46,7 @@ class PageSelectPresenter @Inject
               imageUtil.downloadImage(url, previewImage)
                   .subscribeOn(Schedulers.io())
                   .observeOn(mainThreadScheduler)
-                  .subscribe({ generateData() }, { Crashlytics.logException(it) })
+                  .subscribe({ generateData() }, { e -> Crashlytics.logException(e) })
           )
           null
         } else {

--- a/app/src/main/java/com/quran/labs/androidquran/util/ImageUtil.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/util/ImageUtil.kt
@@ -7,6 +7,7 @@ import okhttp3.Request
 import okio.Okio
 import okio.Source
 import java.io.File
+import java.io.IOException
 import javax.inject.Inject
 
 class ImageUtil @Inject constructor(private val okHttpClient: OkHttpClient) {
@@ -32,6 +33,8 @@ class ImageUtil @Inject constructor(private val okHttpClient: OkHttpClient) {
             destination.copyTo(outputPath)
             destination.delete()
           }
+        } catch (exception: IOException) {
+          // ignore - socket was likely closed, etc.
         } finally {
           sink.closeQuietly()
           source.closeQuietly()


### PR DESCRIPTION
For the time being, stop logging these IOExceptions - many of them are
expected (ex the Rx chain is unsubscribed to due to changing the page).
It also adds a lot of noise, making it tough to figure out the real
underlying issues.