### PR TITLE
Add a normal DNS provider for fallback

### DIFF
--- a/common/networking/build.gradle
+++ b/common/networking/build.gradle
@@ -5,5 +5,7 @@ dependencies {
   compile deps.kotlin.stdlib
   kapt deps.dagger.apt
   implementation deps.dagger.runtime
+
+  implementation 'dnsjava:dnsjava:2.1.8'
   implementation "com.squareup.okhttp3:okhttp-dnsoverhttps:${okhttpVersion}"
 }

--- a/common/networking/src/main/java/com/quran/common/networking/NetworkModule.java
+++ b/common/networking/src/main/java/com/quran/common/networking/NetworkModule.java
@@ -14,7 +14,7 @@ import okhttp3.OkHttpClient;
 @Module(includes = { DnsModule.class })
 public class NetworkModule {
   private static final int DEFAULT_READ_TIMEOUT_SECONDS = 20;
-  private static final int DEFAULT_CONNECT_TIMEOUT_SECONDS = 15;
+  private static final int DEFAULT_CONNECT_TIMEOUT_SECONDS = 20;
 
   @Provides
   @Singleton

--- a/common/networking/src/main/java/com/quran/common/networking/dns/DnsFallback.kt
+++ b/common/networking/src/main/java/com/quran/common/networking/dns/DnsFallback.kt
@@ -1,0 +1,23 @@
+package com.quran.common.networking.dns
+
+import okhttp3.Dns
+import org.xbill.DNS.Address
+import org.xbill.DNS.ExtendedResolver
+import org.xbill.DNS.Lookup
+import org.xbill.DNS.SimpleResolver
+import java.net.InetAddress
+
+class DnsFallback : Dns {
+  var initialized = false
+
+  override fun lookup(hostname: String): MutableList<InetAddress> {
+    if (!initialized) {
+      val googleResolver = SimpleResolver("8.8.8.8")
+      val cloudflareResolver = SimpleResolver("1.1.1.1")
+      Lookup.setDefaultResolver(ExtendedResolver(arrayOf(googleResolver, cloudflareResolver)))
+      initialized = true
+    }
+
+    return Address.getAllByName(hostname).toMutableList()
+  }
+}

--- a/common/networking/src/main/java/com/quran/common/networking/dns/DnsModule.kt
+++ b/common/networking/src/main/java/com/quran/common/networking/dns/DnsModule.kt
@@ -30,10 +30,13 @@ class DnsModule {
         .cache(dnsCache)
         .build()
 
+    // dns fallback tries the equivalent of Dns.SYSTEM first,
+    // so no need to explicitly add Dns.SYSTEM here.
+    val dnsFallback = DnsFallback()
     val googleDns = provideGoogleDns(bootstrapClient)
     return if (googleDns != null) {
-      listOf(Dns.SYSTEM, googleDns)
-    } else { listOf(Dns.SYSTEM) }
+      listOf(dnsFallback, googleDns)
+    } else { listOf(dnsFallback) }
   }
 
   private fun provideGoogleDns(bootstrapClient: OkHttpClient): Dns? {


### PR DESCRIPTION
Since fallback over https doesn't work for some people, let's try to
fallback to standard dns first (keep Dns over https as a fallback for
now).