### PR TITLE
Fix Arabic search

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -107,6 +107,7 @@ dependencies {
   implementation project(path: ':common:data')
   implementation project(path: ':common:networking')
   implementation project(path: ':common:pages')
+  implementation project(path: ':common:search')
 
   implementation deps.kotlin.stdlib
   implementation "androidx.appcompat:appcompat:${androidxAppcompatVersion}"

--- a/app/src/main/java/com/quran/labs/androidquran/data/QuranDataProvider.java
+++ b/app/src/main/java/com/quran/labs/androidquran/data/QuranDataProvider.java
@@ -226,7 +226,7 @@ public class QuranDataProvider extends ContentProvider {
   private Cursor search(String query, String databaseName, boolean wantSnippets) {
     final DatabaseHandler handler =
         DatabaseHandler.getDatabaseHandler(getContext(), databaseName, quranFileUtils);
-    return handler.search(query, wantSnippets);
+    return handler.search(query, wantSnippets, QURAN_ARABIC_DATABASE.equals(databaseName));
   }
 
   @Override

--- a/common/search/build.gradle
+++ b/common/search/build.gradle
@@ -1,0 +1,15 @@
+apply plugin: 'com.android.library'
+apply plugin: 'kotlin-android'
+apply plugin: 'kotlin-kapt'
+
+android {
+  compileSdkVersion deps.android.build.compileSdkVersion
+  defaultConfig {
+    minSdkVersion deps.android.build.minSdkVersion
+    targetSdkVersion deps.android.build.targetSdkVersion
+  }
+}
+
+dependencies {
+  implementation deps.kotlin.stdlib
+}

--- a/common/search/src/main/AndroidManifest.xml
+++ b/common/search/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest package="com.quran.labs.androidquran.common.search"/>

--- a/common/search/src/main/java/com/quran/common/search/ArabicSearcher.kt
+++ b/common/search/src/main/java/com/quran/common/search/ArabicSearcher.kt
@@ -1,0 +1,64 @@
+package com.quran.common.search
+
+import android.database.Cursor
+import android.database.MatrixCursor
+import android.database.sqlite.SQLiteDatabase
+import com.quran.common.search.arabic.ArabicCharacterHelper
+import java.util.regex.Pattern
+
+class ArabicSearcher(private val defaultSearcher: Searcher,
+                     private val matchStart: String,
+                     private val matchEnd: String) : Searcher {
+  override fun getQuery(withSnippets: Boolean,
+                        hasFTS: Boolean,
+                        table: String,
+                        columns: String,
+                        searchColumn: String): String {
+    return defaultSearcher.getQuery(false, hasFTS, table, columns, searchColumn)
+  }
+
+  override fun getLimit(withSnippets: Boolean): String {
+    return if (withSnippets) { "" } else { "LIMIT 250" }
+  }
+
+  override fun processSearchText(searchText: String, hasFTS: Boolean): String {
+    return defaultSearcher.processSearchText(searchText.replace(arabicRegex, "_"), false)
+  }
+
+  override fun runQuery(database: SQLiteDatabase,
+                        query: String,
+                        searchText: String,
+                        originalSearchText: String,
+                        withSnippets: Boolean,
+                        columns: Array<String>): Cursor {
+    val matrixCursor = MatrixCursor(columns)
+
+    val regexp = ArabicCharacterHelper.generateRegex(originalSearchText)
+    val pattern = Pattern.compile(regexp)
+    database.rawQuery(query, arrayOf(searchText))?.use { cursor ->
+      while (cursor.moveToNext()) {
+        val text = cursor.getString(3)
+
+        val matcher = pattern.matcher(text)
+        if (matcher.find()) {
+          val matchText: String = if (withSnippets) {
+            text.replace("($regexp)".toRegex(), "$matchStart$1$matchEnd")
+          } else {
+            text
+          }
+
+          matrixCursor.addRow(arrayOf(cursor.getInt(0),
+              cursor.getInt(1),
+              cursor.getInt(2),
+              matchText))
+        }
+      }
+    }
+
+    return matrixCursor
+  }
+
+  companion object {
+    private val arabicRegex =  "[\u0627\u0623\u0621\u062a\u0629\u0647\u0649]".toRegex()
+  }
+}

--- a/common/search/src/main/java/com/quran/common/search/DefaultSearcher.kt
+++ b/common/search/src/main/java/com/quran/common/search/DefaultSearcher.kt
@@ -1,0 +1,55 @@
+package com.quran.common.search
+
+import android.database.Cursor
+import android.database.sqlite.SQLiteDatabase
+
+class DefaultSearcher(private val matchStart: String,
+                      private val matchEnd: String,
+                      private val ellipses: String) : Searcher {
+
+  override fun getQuery(withSnippets: Boolean,
+                        hasFTS: Boolean,
+                        table: String,
+                        columns: String,
+                        searchColumn: String): String {
+
+    val operator = if (hasFTS) {
+      " MATCH "
+    } else {
+      " LIKE "
+    }
+
+    val whatToSelect = if (hasFTS && withSnippets) {
+      "snippet(" + table + ", '" +
+          matchStart + "', '" + matchEnd +
+          "', '" + ellipses + "', -1, 64)"
+    } else {
+      searchColumn
+    }
+
+    return "select $columns, $whatToSelect FROM $table WHERE $searchColumn $operator ?"
+  }
+
+  override fun getLimit(withSnippets: Boolean): String {
+    return if (withSnippets) { "" } else { "LIMIT 25" }
+  }
+
+  override fun processSearchText(searchText: String, hasFTS: Boolean): String {
+    return if (hasFTS) {
+      // MATCH query
+      "$searchText*"
+    } else {
+      // LIKE query
+      "%$searchText%"
+    }
+  }
+
+  override fun runQuery(database: SQLiteDatabase,
+                        query: String,
+                        searchText: String,
+                        originalSearchText: String,
+                        withSnippets: Boolean,
+                        columns: Array<String>): Cursor {
+    return database.rawQuery(query, arrayOf(searchText))
+  }
+}

--- a/common/search/src/main/java/com/quran/common/search/Searcher.kt
+++ b/common/search/src/main/java/com/quran/common/search/Searcher.kt
@@ -1,0 +1,23 @@
+package com.quran.common.search
+
+import android.database.Cursor
+import android.database.sqlite.SQLiteDatabase
+
+interface Searcher {
+  fun getQuery(withSnippets: Boolean,
+               hasFTS: Boolean,
+               table: String,
+               columns: String,
+               searchColumn: String): String
+
+  fun getLimit(withSnippets: Boolean): String
+
+  fun processSearchText(searchText: String, hasFTS: Boolean): String
+
+  fun runQuery(database: SQLiteDatabase,
+               query: String,
+               searchText: String,
+               originalSearchText: String,
+               withSnippets: Boolean,
+               columns: Array<String>): Cursor
+}

--- a/common/search/src/main/java/com/quran/common/search/arabic/ArabicCharacterHelper.kt
+++ b/common/search/src/main/java/com/quran/common/search/arabic/ArabicCharacterHelper.kt
@@ -1,0 +1,48 @@
+package com.quran.common.search.arabic
+
+object ArabicCharacterHelper {
+  private val lookupTable = hashMapOf(
+      // given: ا
+      // match: آأإاﻯ
+      "\u0627" to "\u0622\u0623\u0625\u0627\u0649",
+
+      // given: ﺃ
+      // match: ﺃﺀﺆﺋ
+      "\u0623" to "\u0621\u0623\u0624\u0626",
+
+      // given: ﺀ
+      // match: ﺀﺃﺆ
+      "\u0621" to "\u0621\u0623\u0624\u0626",
+
+      // given: ﺕ
+      // match: ﺕﺓ
+      "\u062a" to "\u062a\u0629",
+
+      // given: ﺓ
+      // match: ﺓتﻫ
+      "\u0629" to "\u0629\u062a\u0647",
+
+      // given: ه
+      // match: ةه
+      "\u0647" to "\u0647\u0629",
+
+      // given: ﻯ
+      // match: ﻯي
+      "\u0649" to "\u0649\u064a"
+  )
+
+  fun generateRegex(query: String): String {
+    val characters = query.toCharArray()
+    val regexBuilder = StringBuilder()
+    characters.forEach {
+      if (lookupTable.containsKey(it.toString())) {
+        regexBuilder.append("[")
+        regexBuilder.append(lookupTable[it.toString()])
+        regexBuilder.append("]")
+      } else {
+        regexBuilder.append(it)
+      }
+    }
+    return regexBuilder.toString()
+  }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,6 +2,7 @@ include ':app'
 include ':common:data'
 include ':common:networking'
 include ':common:pages'
+include ':common:search'
 include ':pages:madani'
 
 if (new File(rootDir, 'extras/settings-extra.gradle').exists()) {


### PR DESCRIPTION
Al7amdulillah, this patch completely rewrites (and fixes) Arabic search.
It now supports searching with approximate matches for characters that
could have multiple variants in Arabic (i.e. an alif now matches an alif
with a hamza, etc), among other things. It doesn't support tashkeel
search yet, but in practice, this isn't a problem since Arabic search is
only used for searching the Quran text without taskeel.

Fixes #427, #453, #953, and #960.