### PR TITLE
Register MediaSession callbacks on service handler

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/service/AudioService.java
+++ b/app/src/main/java/com/quran/labs/androidquran/service/AudioService.java
@@ -304,7 +304,7 @@ public class AudioService extends Service implements OnCompletionListener,
     mediaSession = new MediaSessionCompat(appContext, "QuranMediaSession", receiver, null);
     mediaSession.setFlags(MediaSessionCompat.FLAG_HANDLES_MEDIA_BUTTONS |
         MediaSessionCompat.FLAG_HANDLES_TRANSPORT_CONTROLS);
-    mediaSession.setCallback(new MediaSessionCallback());
+    mediaSession.setCallback(new MediaSessionCallback(), serviceHandler);
 
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
       setupNotificationChannel();


### PR DESCRIPTION
In order to avoid conflicting calls to the MediaPlayer (nulling out the
MediaPlayer due to a "stop" while the service handler thread is trying
to play, for example), the MediaSession callbacks should happen on the
service handler so as to serialize them.