### PR TITLE
Suppress many non-actionable warnings

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/common/Response.java
+++ b/app/src/main/java/com/quran/labs/androidquran/common/Response.java
@@ -6,8 +6,9 @@ public class Response {
   public static final int ERROR_SD_CARD_NOT_FOUND = 1;
   public static final int ERROR_FILE_NOT_FOUND = 2;
   public static final int ERROR_DOWNLOADING_ERROR = 3;
-  public static final int WARN_SD_CARD_NOT_FOUND = 4;
-  public static final int WARN_COULD_NOT_SAVE_FILE = 5;
+  public static final int ERROR_NO_INTERNET = 4;
+  public static final int WARN_SD_CARD_NOT_FOUND = 5;
+  public static final int WARN_COULD_NOT_SAVE_FILE = 6;
 
   private Bitmap bitmap;
   private int errorCode;

--- a/app/src/main/java/com/quran/labs/androidquran/presenter/quran/QuranPagePresenter.java
+++ b/app/src/main/java/com/quran/labs/androidquran/presenter/quran/QuranPagePresenter.java
@@ -153,6 +153,7 @@ public class QuranPagePresenter implements Presenter<QuranPageScreen> {
                   case Response.ERROR_SD_CARD_NOT_FOUND:
                     errorRes = R.string.sdcard_error;
                     break;
+                  case Response.ERROR_NO_INTERNET:
                   case Response.ERROR_DOWNLOADING_ERROR:
                     errorRes = R.string.download_error_network;
                     break;

--- a/app/src/main/java/com/quran/labs/androidquran/presenter/translation/TranslationManagerPresenter.java
+++ b/app/src/main/java/com/quran/labs/androidquran/presenter/translation/TranslationManagerPresenter.java
@@ -20,6 +20,9 @@ import com.squareup.moshi.JsonAdapter;
 import com.squareup.moshi.Moshi;
 
 import java.io.File;
+import java.io.IOException;
+import java.net.SocketException;
+import java.net.SocketTimeoutException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -115,7 +118,10 @@ public class TranslationManagerPresenter implements Presenter<TranslationManager
 
           @Override
           public void onError(Throwable e) {
-            Timber.e(e, "error updating translations list");
+            if (!(e instanceof IOException)) {
+              Timber.e(e, "error updating translations list");
+            }
+
             if (currentActivity != null) {
               currentActivity.onErrorDownloadTranslations();
             }

--- a/app/src/main/java/com/quran/labs/androidquran/service/AudioService.java
+++ b/app/src/main/java/com/quran/labs/androidquran/service/AudioService.java
@@ -437,7 +437,7 @@ public class AudioService extends Service implements OnCompletionListener,
       processRewindRequest();
     } else if (ACTION_UPDATE_REPEAT.equals(action)) {
       final AudioRequest playInfo = intent.getParcelableExtra(EXTRA_PLAY_INFO);
-      if (playInfo != null) {
+      if (playInfo != null && audioQueue != null) {
         audioQueue = audioQueue.withUpdatedAudioRequest(playInfo);
         audioRequest = playInfo;
       }

--- a/app/src/main/java/com/quran/labs/androidquran/service/QuranDownloadService.java
+++ b/app/src/main/java/com/quran/labs/androidquran/service/QuranDownloadService.java
@@ -29,6 +29,8 @@ import com.quran.labs.androidquran.util.ZipUtils;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.SocketException;
+import java.net.SocketTimeoutException;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
@@ -615,7 +617,7 @@ public class QuranDownloadService extends Service implements
         Timber.e(new Exception("Unable to download file - code: " + response.code()));
       }
     } catch (IOException exception) {
-      Timber.e(exception, "Failed to download file");
+      Timber.d(exception, "Failed to download file");
     } catch (SecurityException se) {
       Timber.e(se, "Security exception while downloading file");
     } finally {

--- a/app/src/main/java/com/quran/labs/androidquran/ui/helpers/QuranPageWorker.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/helpers/QuranPageWorker.java
@@ -1,6 +1,8 @@
 package com.quran.labs.androidquran.ui.helpers;
 
 import android.content.Context;
+import android.net.ConnectivityManager;
+import android.net.NetworkInfo;
 import android.util.Log;
 
 import com.crashlytics.android.Crashlytics;
@@ -42,6 +44,12 @@ public class QuranPageWorker {
     Response response = null;
     OutOfMemoryError oom = null;
 
+    if (!isNetworkAvailable()) {
+      final Response noNetworkResponse = new Response(Response.ERROR_NO_INTERNET);
+      noNetworkResponse.setPageData(pageNumber);
+      return noNetworkResponse;
+    }
+
     try {
       response = QuranDisplayHelper.getQuranPage(
           okHttpClient, appContext, imageWidth, pageNumber, quranFileUtils);
@@ -77,6 +85,13 @@ public class QuranPageWorker {
 
     response.setPageData(pageNumber);
     return response;
+  }
+
+  private boolean isNetworkAvailable() {
+    final ConnectivityManager connectivityManager =
+        (ConnectivityManager) appContext.getSystemService(Context.CONNECTIVITY_SERVICE);
+    final NetworkInfo networkInfo = connectivityManager.getActiveNetworkInfo();
+    return networkInfo != null && networkInfo.isConnected();
   }
 
   public Observable<Response> loadPages(Integer... pages) {


### PR DESCRIPTION
This also checks for connectivity before trying to download pages, since
many silently reported crashes come from this. This should also be
checked in other places in the future.