### PR TITLE
Only apply tafseer font to Arabic tafaseer

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/ui/translation/TranslationAdapter.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/translation/TranslationAdapter.kt
@@ -13,6 +13,7 @@ import android.view.ViewGroup
 import android.widget.TextView
 import androidx.annotation.LayoutRes
 import androidx.core.content.ContextCompat
+import androidx.core.text.TextDirectionHeuristicsCompat
 import androidx.recyclerview.widget.RecyclerView
 import com.quran.labs.androidquran.R
 import com.quran.labs.androidquran.common.QuranAyahInfo
@@ -262,20 +263,31 @@ internal class TranslationAdapter(private val context: Context,
               }
             }
 
-            if (text != null && QuranUtils.doesStringContainArabic(text.toString())) {
-              // arabic tafseer, style it
+            // determine text directionality
+            val isRtl = when {
+              row.isArabic -> true
+              text != null -> QuranUtils.isRtl(text.toString())
+              else -> false
+            }
+
+            // reset the typeface
+            holder.text.typeface = null
+
+            if (isRtl) {
+              // rtl tafseer, style it
               if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
                 holder.text.layoutDirection = View.LAYOUT_DIRECTION_RTL
 
                 // allow the tafseer font for api 19 because it's fine there and
                 // is much better than the stock font (this is more lenient than
-                // the api 21 restriction on the hafs font).
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+                // the api 21 restriction on the hafs font). only allow this for
+                // Arabic though since the Arabic font isn't compatible with other
+                // RTL languages that share some Arabic characters.
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT && row.isArabic) {
                   holder.text.typeface = TypefaceManager.getTafseerTypeface(context)
                 }
               }
             } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
-              holder.text.typeface = null
               holder.text.layoutDirection = View.LAYOUT_DIRECTION_INHERIT
             }
 

--- a/app/src/main/java/com/quran/labs/androidquran/ui/translation/TranslationView.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/translation/TranslationView.java
@@ -121,7 +121,8 @@ public class TranslationView extends FrameLayout implements View.OnClickListener
           }
           rows.add(new TranslationViewRow(
               TranslationViewRow.Type.TRANSLATION_TEXT, verse, text, j,
-              metadata == null ? null : metadata.getLink()));
+              metadata == null ? null : metadata.getLink(),
+              "ar".equals(translations[j].getLanguageCode())));
         }
       }
 

--- a/app/src/main/java/com/quran/labs/androidquran/ui/translation/TranslationViewRow.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/translation/TranslationViewRow.java
@@ -26,24 +26,27 @@ class TranslationViewRow {
   @Nullable final CharSequence data;
   final int translationIndex;
   @Nullable final SuraAyah link;
+  final boolean isArabic;
 
   TranslationViewRow(int type, @NonNull QuranAyahInfo ayahInfo) {
     this(type, ayahInfo, null);
   }
 
   TranslationViewRow(int type, @NonNull QuranAyahInfo ayahInfo, @Nullable CharSequence data) {
-    this(type, ayahInfo, data, -1, null);
+    this(type, ayahInfo, data, -1, null, false);
   }
 
   TranslationViewRow(int type,
                      @NonNull QuranAyahInfo ayahInfo,
                      @Nullable CharSequence data,
                      int translationIndex,
-                     @Nullable SuraAyah link) {
+                     @Nullable SuraAyah link,
+                     boolean isArabic) {
     this.type = type;
     this.ayahInfo = ayahInfo;
     this.data = data;
     this.translationIndex = translationIndex;
     this.link = link;
+    this.isArabic = isArabic;
   }
 }

--- a/app/src/main/java/com/quran/labs/androidquran/util/QuranUtils.java
+++ b/app/src/main/java/com/quran/labs/androidquran/util/QuranUtils.java
@@ -29,6 +29,28 @@ public class QuranUtils {
   private static NumberFormat numberFormat;
   private static Locale lastLocale;
 
+  public static boolean isRtl(@NonNull String s) {
+    final char[] characters = s.toCharArray();
+    for (char character : characters) {
+      final int directionality = Character.getDirectionality(character);
+      if (directionality == Character.DIRECTIONALITY_RIGHT_TO_LEFT ||
+          directionality == Character.DIRECTIONALITY_RIGHT_TO_LEFT_ARABIC) {
+        return true;
+      } else if (directionality == Character.DIRECTIONALITY_LEFT_TO_RIGHT) {
+        return false;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Returns a boolean indicating if this string contains Arabic
+   * Note that this returns true for non-Arabic languages that share
+   * Arabic characters (ex Urdu).
+   *
+   * @param s the string to check
+   * @return a boolean
+   */
   public static boolean doesStringContainArabic(String s) {
     if (s == null) {
       return false;


### PR DESCRIPTION
Previously, due to QuranUtils.doesStringContainArabic method returning
true for languages like Urdu and others that share some of the Arabic
characters in the ranges that were checked, an Arabic font was set for
any such language. This consequently broke many non-Arabic RTL languages
on versions above 21.

This patch fixes it by only applying the font to Arabic tafaseer, while
still gracefully handling RTL otherwise. Fixes #1255.