### PR TITLE
Fix translation list not loading with R8/Proguard

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -131,6 +131,8 @@ dependencies {
 
   implementation "com.squareup.okio:okio:2.4.3"
   implementation "com.squareup.okhttp3:okhttp:${okhttpVersion}"
+
+  // remove metadata line from proguard.cfg upon updating to 1.9.3
   implementation 'com.squareup.moshi:moshi:1.9.2'
   kapt("com.squareup.moshi:moshi-kotlin-codegen:1.9.2")
 

--- a/app/proguard.cfg
+++ b/app/proguard.cfg
@@ -50,3 +50,6 @@
 -keep interface com.squareup.moshi.** { *; }
 -dontwarn com.squareup.moshi.**
 -keep public class com.quran.labs.androidquran.dao.** { *; }
+
+# temporary until Moshi 1.9.3 due to square/moshi#1049
+-keep class kotlin.Metadata { *; }


### PR DESCRIPTION
This patch maintains Kotlin metadata for now to work around a crash when
using R8/Proguard.