### PR TITLE
Re-add the partial page checker

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/data/Constants.java
+++ b/app/src/main/java/com/quran/labs/androidquran/data/Constants.java
@@ -80,4 +80,5 @@ public class Constants {
   public static final String DEBUG_PAGES_DOWNLOADED_TIME = "debugPagesDownloadedTime";
   public static final String DEBUG_PAGES_DOWNLOADED = "debugPagesDownloaded";
   public static final String PREF_READING_CATEGORY = "readingCategoryKey";
+  public static final String PREF_CHECKED_PARTIAL_IMAGES = "didCheckPartialImages";
 }

--- a/app/src/main/java/com/quran/labs/androidquran/presenter/data/QuranDataPresenter.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/presenter/data/QuranDataPresenter.kt
@@ -12,6 +12,7 @@ import com.quran.labs.androidquran.data.QuranInfo
 import com.quran.labs.androidquran.presenter.Presenter
 import com.quran.labs.androidquran.util.CopyDatabaseUtil
 import com.quran.labs.androidquran.util.QuranFileUtils
+import com.quran.labs.androidquran.util.QuranPartialPageChecker
 import com.quran.labs.androidquran.util.QuranScreenInfo
 import com.quran.labs.androidquran.util.QuranSettings
 import io.reactivex.Completable
@@ -30,7 +31,8 @@ class QuranDataPresenter @Inject internal constructor(
     val quranScreenInfo: QuranScreenInfo,
     private val quranPageProvider: PageProvider,
     private val copyDatabaseUtil: CopyDatabaseUtil,
-    val quranFileUtils: QuranFileUtils) : Presenter<QuranDataActivity> {
+    val quranFileUtils: QuranFileUtils,
+    val quranPartialPageChecker: QuranPartialPageChecker) : Presenter<QuranDataActivity> {
 
   private var activity: QuranDataActivity? = null
   private var checkPagesDisposable: Disposable? = null
@@ -176,9 +178,10 @@ class QuranDataPresenter @Inject internal constructor(
   private fun actuallyCheckPages(totalPages: Int): Single<QuranDataStatus> {
     return Single.fromCallable<QuranDataStatus> {
       val width = quranScreenInfo.widthParam
-      val havePortrait = quranFileUtils.haveAllImages(appContext, width, totalPages, true)
-
       val tabletWidth = quranScreenInfo.tabletWidthParam
+      quranPartialPageChecker.checkPages(totalPages, width = width, secondWidth = tabletWidth)
+
+      val havePortrait = quranFileUtils.haveAllImages(appContext, width, totalPages, true)
       val needLandscapeImages = if (quranScreenInfo.isDualPageMode && width != tabletWidth) {
         val haveLandscape = quranFileUtils.haveAllImages(appContext, tabletWidth, totalPages, true)
         Timber.d("checkPages: have portrait images: %s, have landscape images: %s",

--- a/app/src/main/java/com/quran/labs/androidquran/util/QuranFileUtils.java
+++ b/app/src/main/java/com/quran/labs/androidquran/util/QuranFileUtils.java
@@ -408,7 +408,7 @@ public class QuranFileUtils {
     return getQuranImagesDirectory(context, quranScreenInfo.getWidthParam());
   }
 
-  private String getQuranImagesDirectory(Context context, String widthParam) {
+  public String getQuranImagesDirectory(Context context, String widthParam) {
     String base = getQuranBaseDirectory(context);
     return (base == null) ? null : base +
         (IMAGES_DIRECTORY.isEmpty() ? "" : IMAGES_DIRECTORY + File.separator) + "width" + widthParam;

--- a/app/src/main/java/com/quran/labs/androidquran/util/QuranPartialPageChecker.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/util/QuranPartialPageChecker.kt
@@ -1,0 +1,108 @@
+package com.quran.labs.androidquran.util
+
+import android.content.Context
+import android.graphics.BitmapFactory
+import timber.log.Timber
+import java.io.File
+import javax.inject.Inject
+
+class QuranPartialPageChecker @Inject constructor(val appContext: Context,
+                                                  val quranSettings: QuranSettings,
+                                                  val quranFileUtils: QuranFileUtils) {
+
+  /**
+   * Checks all the pages to find and delete partially downloaded images.
+   */
+  fun checkPages(numberOfPages: Int, width: String, secondWidth: String) {
+    // internally, this is a set of page types to ensure running this
+    // once per page type (even if there are multiple switches).
+    if (!quranSettings.didCheckPartialImages()) {
+      // past versions of the partial page checker didn't run the checker
+      // whenever any .vX file exists. this was noted as a "works sometimes"
+      // solution because not all zip files contain .vX files (ex naskh and
+      // warsh). removed this now because it is actually invalid for madani
+      // in some cases as well due to the fact that someone could have manually
+      // downloaded images, have broken images, and then get a patch zip which
+      // contains the .vX file.
+      try {
+        // check the partial images for the width
+        checkPartialImages(width, numberOfPages)
+        if (width != secondWidth) {
+          // and only check for the tablet dimension width if it's different
+          checkPartialImages(secondWidth, numberOfPages)
+        }
+        quranSettings.setCheckedPartialImages()
+      } catch (throwable: Throwable) {
+        Timber.e(throwable, "Error while checking partial pages: $width and $secondWidth")
+      }
+    }
+  }
+
+  /**
+   * Check for partial images and delete them.
+   * This opens every downloaded image and looks at the last set of pixels.
+   * If the last few rows are blank, the image is assumed to be partial and
+   * the image is deleted.
+   */
+  private fun checkPartialImages(width: String, numberOfPages: Int) {
+    quranFileUtils.getQuranImagesDirectory(appContext, width)?.let { directoryName ->
+      // scale images down to 1/16th of size
+      val options = BitmapFactory.Options().apply {
+        inSampleSize = 16
+      }
+
+      val directory = File(directoryName)
+      // optimization to avoid re-generating the pixel array every time
+      var pixelArray: IntArray? = null
+
+      // skip pages 1 and 2 since they're "special" (not full pages)
+      for (page in 3..numberOfPages) {
+        val filename = quranFileUtils.getPageFileName(page)
+        if (File(directory, filename).exists()) {
+          val bitmap = BitmapFactory.decodeFile(
+              directoryName + File.separator + filename, options)
+
+          // this is an optimization to avoid allocating 8 * width of memory
+          // for everything.
+          val rowsToCheck =
+              // madani, 8 for 1920, 6 for 1280, 4 or less for smaller
+              //   a handful of pages in 1260 are slightly shorter, so 6
+              //   is a safer default.
+              // for naskh, 1 for everything
+              // for qaloon, 2 for largest size, 1 for smallest
+              // for warsh, 2 for everything
+              when (width) {
+                "_1920" -> 8
+                else -> 6
+              }
+
+          val bitmapWidth = bitmap.width
+          // these should all be the same size, so we can just allocate once
+          val pixels = if (pixelArray?.size == (bitmapWidth * rowsToCheck)) {
+            pixelArray
+          } else {
+            pixelArray = IntArray(bitmapWidth * rowsToCheck)
+            pixelArray
+          }
+
+          // get the set of pixels
+          bitmap.getPixels(pixels,
+              0,
+              bitmapWidth,
+              0,
+              bitmap.height - rowsToCheck,
+              bitmapWidth,
+              rowsToCheck)
+
+          // see if there's any non-0 pixel
+          val foundPixel = pixels.any { it != 0 }
+
+          // if all are non-zero, assume the image is partially blank
+          if (!foundPixel) {
+            File(directory, filename).delete()
+          }
+        }
+      }
+    }
+  }
+}

--- a/app/src/main/java/com/quran/labs/androidquran/util/QuranSettings.java
+++ b/app/src/main/java/com/quran/labs/androidquran/util/QuranSettings.java
@@ -406,4 +406,21 @@ public class QuranSettings {
   public boolean getWasShowingTranslation() {
     return perInstallationPrefs.getBoolean(Constants.PREF_WAS_SHOWING_TRANSLATION, false);
   }
+
+  public boolean didCheckPartialImages() {
+    final Set<String> checkedSets =
+        perInstallationPrefs.getStringSet(Constants.PREF_CHECKED_PARTIAL_IMAGES,
+            Collections.emptySet());
+    return checkedSets != null && checkedSets.contains(getPageType());
+  }
+
+  public void setCheckedPartialImages() {
+    final Set<String> checkedSets =
+        perInstallationPrefs.getStringSet(Constants.PREF_CHECKED_PARTIAL_IMAGES,
+            Collections.emptySet());
+    final Set<String> setToSave = new HashSet<>(checkedSets);
+    setToSave.add(getPageType());
+    perInstallationPrefs.edit()
+        .putStringSet(Constants.PREF_CHECKED_PARTIAL_IMAGES, setToSave).apply();
+  }
 }


### PR DESCRIPTION
This patch re-adds the partial page checker. It also fixes some bugs in
the previous code for it (such as the 1260 images always getting a
handful of pages deleted by the checker whenever it runs, thus forcing
the download twice). This fixes #1252, though at some point, this code
should really be removed completely.