### PR TITLE
Log some additional events

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/QuranDataActivity.java
+++ b/app/src/main/java/com/quran/labs/androidquran/QuranDataActivity.java
@@ -5,6 +5,7 @@ import android.app.Activity;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.pm.PackageManager;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Environment;
 import android.text.TextUtils;
@@ -369,6 +370,13 @@ public class QuranDataActivity extends Activity implements
         new File(baseDirectory, QURAN_DIRECTORY_MARKER_FILE).createNewFile();
         //noinspection ResultOfMethodCallIgnored
         new File(baseDirectory, QURAN_HIDDEN_DIRECTORY_MARKER_FILE).createNewFile();
+
+        // try writing a file to the app's internal no_backup directory
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+          //noinspection ResultOfMethodCallIgnored
+          new File(getNoBackupFilesDir(), QURAN_HIDDEN_DIRECTORY_MARKER_FILE).createNewFile();
+        }
+
         quranSettings.setDownloadedPages(System.currentTimeMillis(), appLocation,
             quranDataStatus.getPortraitWidth() + "_" + quranDataStatus.getLandscapeWidth());
       } catch (IOException ioe) {
@@ -430,6 +438,17 @@ public class QuranDataActivity extends Activity implements
       }
     }
 
+    // check for the existence of a .q4a file in the internal no_backup directory.
+    boolean didInternalFileSurvive = false;
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+      try {
+        didInternalFileSurvive =
+            new File(getNoBackupFilesDir(), QURAN_HIDDEN_DIRECTORY_MARKER_FILE).exists();
+      } catch (Exception e) {
+        Crashlytics.logException(e);
+      }
+    }
+
 
     // how recently did the files disappear?
     final long downloadTime = quranSettings.getPreviouslyDownloadedTime();
@@ -461,6 +480,7 @@ public class QuranDataActivity extends Activity implements
             .putCustomAttribute("isPagePathTheSame", isPagePathTheSame ? "yes" : "no")
             .putCustomAttribute("didNormalFileSurvive", didNormalFileSurvive ? "yes" : "no")
             .putCustomAttribute("didHiddenFileSurvive", didHiddenFileSurvive ? "yes" : "no")
+            .putCustomAttribute("didInternalFileSurvive", didInternalFileSurvive ? "yes" : "no")
             .putCustomAttribute("recencyOfRemoval", recencyOfRemoval)
             .putCustomAttribute("arePagesToDownloadTheSame",
                 arePageSetsEquivalent ? "yes" : "no"));
@@ -471,6 +491,7 @@ public class QuranDataActivity extends Activity implements
     Timber.w("appLocation: %s", appLocation);
     Timber.w("sdcard: %s, app dir: %s", sdcard, appDir);
     Timber.w("didNormalFileSurvive: %s", didNormalFileSurvive);
+    Timber.w("didInternalFileSurvive: %s", didInternalFileSurvive);
     Timber.w("didHiddenFileSurvive: %s", didHiddenFileSurvive);
     Timber.w("seconds passed: %d, recency: %s",
         (System.currentTimeMillis() - downloadTime) / 1000, recencyOfRemoval);

--- a/app/src/main/java/com/quran/labs/androidquran/presenter/data/QuranDataPresenter.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/presenter/data/QuranDataPresenter.kt
@@ -32,7 +32,7 @@ class QuranDataPresenter @Inject internal constructor(
     private val quranPageProvider: PageProvider,
     private val copyDatabaseUtil: CopyDatabaseUtil,
     val quranFileUtils: QuranFileUtils,
-    val quranPartialPageChecker: QuranPartialPageChecker) : Presenter<QuranDataActivity> {
+    private val quranPartialPageChecker: QuranPartialPageChecker) : Presenter<QuranDataActivity> {
 
   private var activity: QuranDataActivity? = null
   private var checkPagesDisposable: Disposable? = null

--- a/app/src/main/java/com/quran/labs/androidquran/ui/helpers/QuranPageWorker.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/helpers/QuranPageWorker.java
@@ -91,7 +91,7 @@ public class QuranPageWorker {
     final ConnectivityManager connectivityManager =
         (ConnectivityManager) appContext.getSystemService(Context.CONNECTIVITY_SERVICE);
     final NetworkInfo networkInfo = connectivityManager.getActiveNetworkInfo();
-    return networkInfo != null && networkInfo.isConnected();
+    return networkInfo != null && networkInfo.isConnectedOrConnecting();
   }
 
   public Observable<Response> loadPages(Integer... pages) {


### PR DESCRIPTION
Log when the partial page checker removes images. Also, write a file in
the internal storage directory to try to figure out if internal files
are also being deleted when images are lost (if the theory is correct,
the times when images are lost and this file is lost should be few,
representing only the times when the app had its data cleared, was
uninstalled and reinstalled, etc. If there are cases in which the
internal file survives but the sdcard files don't, this is good proof of
an sdcard cleaning up removing this data.