### PR TITLE
Fix the settings button during audio playback

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/pageselect/PageSelectAdapter.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/pageselect/PageSelectAdapter.kt
@@ -67,7 +67,7 @@ class PageSelectAdapter(val inflater: LayoutInflater,
         }
         .subscribeOn(Schedulers.io())
         .observeOn(AndroidSchedulers.mainThread())
-        .subscribe( { imageRef.get()?.setImageBitmap(it) })
+        .subscribe { imageRef.get()?.setImageBitmap(it) }
     )
   }
 

--- a/app/src/main/java/com/quran/labs/androidquran/ui/PagerActivity.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/PagerActivity.java
@@ -1546,7 +1546,7 @@ public class PagerActivity extends QuranActionBarActivity implements
       start = new SuraAyah(bounds[0], bounds[1]);
       end = start;
     }
-    showSlider(AUDIO_PAGE);
+    showSlider(slidingPagerAdapter.getPagePosition(AUDIO_PAGE));
   }
 
   public boolean updatePlayOptions(int rangeRepeat,


### PR DESCRIPTION
In Arabic mode, the settings button that appears during audio playback
goes to the tags screen instead of the audio screen. This patch fixes
this bug.