### PR TITLE
Fix images not loading when in airplane mode

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/ui/helpers/QuranDisplayHelper.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/helpers/QuranDisplayHelper.java
@@ -38,7 +38,14 @@ public class QuranDisplayHelper {
       // the user to mount their sdcard and try again.
       if (response.getErrorCode() != Response.ERROR_SD_CARD_NOT_FOUND) {
         Timber.d("failed to get %d with name %s from sd...", page, filename);
-        response = quranFileUtils.getImageFromWeb(okHttpClient, context, filename);
+
+        if (!QuranUtils.haveInternet(context)) {
+          final Response noNetworkResponse = new Response(Response.ERROR_NO_INTERNET);
+          noNetworkResponse.setPageData(page);
+          response = noNetworkResponse;
+        } else {
+          response = quranFileUtils.getImageFromWeb(okHttpClient, context, filename);
+        }
       }
     }
     return response;

--- a/app/src/main/java/com/quran/labs/androidquran/ui/helpers/QuranPageWorker.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/helpers/QuranPageWorker.java
@@ -1,8 +1,6 @@
 package com.quran.labs.androidquran.ui.helpers;
 
 import android.content.Context;
-import android.net.ConnectivityManager;
-import android.net.NetworkInfo;
 import android.util.Log;
 
 import com.crashlytics.android.Crashlytics;
@@ -11,7 +9,6 @@ import com.quran.labs.androidquran.di.ActivityScope;
 import com.quran.labs.androidquran.util.QuranFileUtils;
 import com.quran.labs.androidquran.util.QuranScreenInfo;
 
-import com.quran.labs.androidquran.util.QuranUtils;
 import javax.inject.Inject;
 
 import io.reactivex.Observable;
@@ -41,15 +38,9 @@ public class QuranPageWorker {
     this.quranFileUtils = quranFileUtils;
   }
 
-  private Response downloadImage(int pageNumber) {
+  private Response loadImage(int pageNumber) {
     Response response = null;
     OutOfMemoryError oom = null;
-
-    if (!QuranUtils.haveInternet(appContext)) {
-      final Response noNetworkResponse = new Response(Response.ERROR_NO_INTERNET);
-      noNetworkResponse.setPageData(pageNumber);
-      return noNetworkResponse;
-    }
 
     try {
       response = QuranDisplayHelper.getQuranPage(
@@ -90,7 +81,7 @@ public class QuranPageWorker {
 
   public Observable<Response> loadPages(Integer... pages) {
     return Observable.fromArray(pages)
-        .flatMap(page -> Observable.fromCallable(() -> downloadImage(page)))
+        .flatMap(page -> Observable.fromCallable(() -> loadImage(page)))
         .subscribeOn(Schedulers.io());
   }
 }


### PR DESCRIPTION
This fixes a bad bug introduced in #1247. The code added a check for
internet before attempting to load the image (thinking it was checking
before attempting to download the image). This moves the internet
checking code to the right place and renames the method to avoid
confusion in the future.