### PR TITLE
Downloading image should take a width parameter

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/ui/helpers/QuranDisplayHelper.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/helpers/QuranDisplayHelper.java
@@ -44,7 +44,7 @@ public class QuranDisplayHelper {
           noNetworkResponse.setPageData(page);
           response = noNetworkResponse;
         } else {
-          response = quranFileUtils.getImageFromWeb(okHttpClient, context, filename);
+          response = quranFileUtils.getImageFromWeb(okHttpClient, context, widthParam, filename);
         }
       }
     }

--- a/app/src/main/java/com/quran/labs/androidquran/util/QuranFileUtils.java
+++ b/app/src/main/java/com/quran/labs/androidquran/util/QuranFileUtils.java
@@ -231,14 +231,13 @@ public class QuranFileUtils {
   }
 
   public Response getImageFromWeb(OkHttpClient okHttpClient,
-      Context context, String filename) {
-    return getImageFromWeb(okHttpClient, context, filename, false);
+      Context context, String widthParam, String filename) {
+    return getImageFromWeb(okHttpClient, context, widthParam, filename, false);
   }
 
   @NonNull
   private Response getImageFromWeb(OkHttpClient okHttpClient,
-      Context context, String filename, boolean isRetry) {
-    final String widthParam = quranScreenInfo.getWidthParam();
+      Context context, String widthParam, String filename, boolean isRetry) {
     String urlString = IMG_BASE_URL + "width"
         + widthParam + File.separator
         + filename;
@@ -285,7 +284,7 @@ public class QuranFileUtils {
     }
 
     return isRetry ? new Response(Response.ERROR_DOWNLOADING_ERROR) :
-        getImageFromWeb(okHttpClient, context, filename, true);
+        getImageFromWeb(okHttpClient, context, filename, widthParam, true);
   }
 
   private Bitmap decodeBitmapStream(InputStream is) {


### PR DESCRIPTION
The per page downloader attempts to download a page. If it fails due to
out of memory, for example, it attempts to fallback to the tablet page
width (if the device is in dual page mode). Because the downloader
always tries to use the current width, this parameter is unfortunately
ignored, and the app tries to redownload the same page width again.