### PR TITLE
Implement worker for partial page cleanup

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -138,6 +138,9 @@ dependencies {
   kapt deps.dagger.apt
   implementation deps.dagger.runtime
 
+  // workmanager
+  implementation "androidx.work:work-runtime-ktx:${workManagerVersion}"
+
   implementation "com.squareup.okio:okio:2.4.3"
   implementation "com.squareup.okhttp3:okhttp:${okhttpVersion}"
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -159,5 +159,11 @@
         <action android:name="android.intent.action.MEDIA_BUTTON"/>
       </intent-filter>
     </service>
+
+    <!-- override WorkManager initialization -->
+    <provider
+        android:name="androidx.work.impl.WorkManagerInitializer"
+        android:authorities="${applicationId}.workmanager-init"
+        tools:node="remove" />
   </application>
 </manifest> 

--- a/app/src/main/java/com/quran/labs/androidquran/QuranApplication.java
+++ b/app/src/main/java/com/quran/labs/androidquran/QuranApplication.java
@@ -6,6 +6,7 @@ import android.content.res.Resources;
 import android.os.Build;
 import androidx.annotation.NonNull;
 import androidx.multidex.MultiDexApplication;
+import androidx.work.WorkManager;
 import com.crashlytics.android.Crashlytics;
 import com.crashlytics.android.core.CrashlyticsCore;
 import com.quran.labs.androidquran.component.application.ApplicationComponent;
@@ -13,12 +14,17 @@ import com.quran.labs.androidquran.component.application.DaggerApplicationCompon
 import com.quran.labs.androidquran.module.application.ApplicationModule;
 import com.quran.labs.androidquran.util.QuranSettings;
 import com.quran.labs.androidquran.util.RecordingLogTree;
+import com.quran.labs.androidquran.core.worker.QuranWorkerFactory;
 import io.fabric.sdk.android.Fabric;
 import java.util.Locale;
+import javax.inject.Inject;
 import timber.log.Timber;
 
 public class QuranApplication extends MultiDexApplication {
   private ApplicationComponent applicationComponent;
+
+  @Inject
+  QuranWorkerFactory quranWorkerFactory;
 
   @Override
   public void onCreate() {
@@ -30,6 +36,13 @@ public class QuranApplication extends MultiDexApplication {
         .build());
     Timber.plant(new RecordingLogTree());
     this.applicationComponent = initializeInjector();
+    this.applicationComponent.inject(this);
+
+    WorkManager.initialize(this,
+        new androidx.work.Configuration.Builder()
+          .setWorkerFactory(quranWorkerFactory)
+          .build()
+    );
   }
 
   protected ApplicationComponent initializeInjector() {

--- a/app/src/main/java/com/quran/labs/androidquran/component/application/ApplicationComponent.java
+++ b/app/src/main/java/com/quran/labs/androidquran/component/application/ApplicationComponent.java
@@ -1,6 +1,7 @@
 package com.quran.labs.androidquran.component.application;
 
 import com.quran.data.page.provider.QuranPageModule;
+import com.quran.labs.androidquran.QuranApplication;
 import com.quran.labs.androidquran.QuranDataActivity;
 import com.quran.labs.androidquran.QuranForwarderActivity;
 import com.quran.labs.androidquran.QuranImportActivity;
@@ -27,6 +28,7 @@ import com.quran.labs.androidquran.ui.fragment.QuranSettingsFragment;
 import com.quran.labs.androidquran.ui.fragment.SuraListFragment;
 import com.quran.labs.androidquran.ui.fragment.TagBookmarkDialog;
 
+import com.quran.labs.androidquran.core.worker.di.WorkerModule;
 import javax.inject.Singleton;
 
 import dagger.Component;
@@ -37,10 +39,15 @@ import dagger.Component;
     DatabaseModule.class,
     NetworkModule.class,
     QuranDataModule.class,
-    QuranPageModule.class } )
+    QuranPageModule.class,
+    WorkerModule.class
+} )
 public interface ApplicationComponent {
   // subcomponents
   PagerActivityComponent.Builder pagerActivityComponentBuilder();
+
+  // application
+  void inject(QuranApplication quranApplication);
 
   // content provider
   void inject(QuranDataProvider quranDataProvider);

--- a/app/src/main/java/com/quran/labs/androidquran/core/worker/QuranWorkerFactory.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/core/worker/QuranWorkerFactory.kt
@@ -1,0 +1,23 @@
+package com.quran.labs.androidquran.core.worker
+
+import android.content.Context
+import androidx.work.ListenableWorker
+import androidx.work.WorkerFactory
+import androidx.work.WorkerParameters
+import javax.inject.Inject
+import javax.inject.Provider
+
+class QuranWorkerFactory @Inject constructor(
+  private val workerTaskFactories: Map<Class<out ListenableWorker>,
+      @JvmSuppressWildcards Provider<WorkerTaskFactory>>
+): WorkerFactory() {
+  override fun createWorker(
+    appContext: Context,
+    workerClassName: String,
+    workerParameters: WorkerParameters
+  ): ListenableWorker? {
+    val workerClass = Class.forName(workerClassName)
+    val factory = workerTaskFactories.entries.find { workerClass.isAssignableFrom(it.key) }?.value
+    return factory?.get()?.makeWorker(appContext, workerParameters)
+  }
+}

--- a/app/src/main/java/com/quran/labs/androidquran/core/worker/WorkerKey.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/core/worker/WorkerKey.kt
@@ -1,0 +1,9 @@
+package com.quran.labs.androidquran.core.worker
+
+import androidx.work.ListenableWorker
+import dagger.MapKey
+import kotlin.reflect.KClass
+
+@Retention(AnnotationRetention.RUNTIME)
+@MapKey
+annotation class WorkerKey(val value: KClass<out ListenableWorker>)

--- a/app/src/main/java/com/quran/labs/androidquran/core/worker/WorkerTaskFactory.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/core/worker/WorkerTaskFactory.kt
@@ -1,0 +1,9 @@
+package com.quran.labs.androidquran.core.worker
+
+import android.content.Context
+import androidx.work.ListenableWorker
+import androidx.work.WorkerParameters
+
+interface WorkerTaskFactory {
+  fun makeWorker(appContext: Context, workerParameters: WorkerParameters): ListenableWorker
+}

--- a/app/src/main/java/com/quran/labs/androidquran/core/worker/di/WorkerModule.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/core/worker/di/WorkerModule.kt
@@ -1,0 +1,28 @@
+package com.quran.labs.androidquran.core.worker.di
+
+import com.quran.labs.androidquran.core.worker.WorkerKey
+import com.quran.labs.androidquran.core.worker.WorkerTaskFactory
+import com.quran.labs.androidquran.worker.MissingPageDownloadWorker
+import com.quran.labs.androidquran.worker.PartialPageCheckingWorker
+import com.quran.labs.androidquran.worker.PartialPageCheckingWorker.Factory
+import dagger.Binds
+import dagger.Module
+import dagger.multibindings.IntoMap
+
+@Module
+abstract class WorkerModule {
+
+  @Binds
+  @IntoMap
+  @WorkerKey(PartialPageCheckingWorker::class)
+  abstract fun bindPartialPageCheckingWorkerFactory(
+    workerFactory: Factory
+  ): WorkerTaskFactory
+
+  @Binds
+  @IntoMap
+  @WorkerKey(MissingPageDownloadWorker::class)
+  abstract fun bindMissingPageDownloadWorkerFactory(
+    workerFactory: MissingPageDownloadWorker.Factory
+  ): WorkerTaskFactory
+}

--- a/app/src/main/java/com/quran/labs/androidquran/util/QuranSettings.java
+++ b/app/src/main/java/com/quran/labs/androidquran/util/QuranSettings.java
@@ -224,6 +224,12 @@ public class QuranSettings {
         if (version < 2943) {
           prefs.edit().remove("didDownloadPages").apply();
         }
+
+        if (version < 2961) {
+          // on 2.9.6 and below, remove the partial checked flag so we can
+          // check them again.
+          perInstallationPrefs.edit().remove(Constants.PREF_CHECKED_PARTIAL_IMAGES).apply();
+        }
       }
 
       // no matter which version we're upgrading from, make sure the app location is set
@@ -407,19 +413,19 @@ public class QuranSettings {
     return perInstallationPrefs.getBoolean(Constants.PREF_WAS_SHOWING_TRANSLATION, false);
   }
 
-  public boolean didCheckPartialImages() {
+  public boolean didCheckPartialImages(String pageType) {
     final Set<String> checkedSets =
         perInstallationPrefs.getStringSet(Constants.PREF_CHECKED_PARTIAL_IMAGES,
             Collections.emptySet());
-    return checkedSets != null && checkedSets.contains(getPageType());
+    return checkedSets != null && checkedSets.contains(pageType);
   }
 
-  public void setCheckedPartialImages() {
+  public void setCheckedPartialImages(String pageType) {
     final Set<String> checkedSets =
         perInstallationPrefs.getStringSet(Constants.PREF_CHECKED_PARTIAL_IMAGES,
             Collections.emptySet());
     final Set<String> setToSave = new HashSet<>(checkedSets);
-    setToSave.add(getPageType());
+    setToSave.add(pageType);
     perInstallationPrefs.edit()
         .putStringSet(Constants.PREF_CHECKED_PARTIAL_IMAGES, setToSave).apply();
   }

--- a/app/src/main/java/com/quran/labs/androidquran/worker/MissingPageDownloadWorker.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/worker/MissingPageDownloadWorker.kt
@@ -1,0 +1,126 @@
+package com.quran.labs.androidquran.worker
+
+import android.content.Context
+import androidx.work.CoroutineWorker
+import androidx.work.ListenableWorker
+import androidx.work.WorkerParameters
+import com.crashlytics.android.answers.Answers
+import com.crashlytics.android.answers.CustomEvent
+import com.quran.labs.androidquran.core.worker.WorkerTaskFactory
+import com.quran.labs.androidquran.data.QuranInfo
+import com.quran.labs.androidquran.util.QuranFileUtils
+import com.quran.labs.androidquran.util.QuranScreenInfo
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.toList
+import okhttp3.OkHttpClient
+import timber.log.Timber
+import java.io.File
+import javax.inject.Inject
+
+class MissingPageDownloadWorker(private val context: Context,
+                                params: WorkerParameters,
+                                private val okHttpClient: OkHttpClient,
+                                private val quranInfo: QuranInfo,
+                                private val quranScreenInfo: QuranScreenInfo,
+                                private val quranFileUtils: QuranFileUtils
+) : CoroutineWorker(context, params) {
+
+  @ExperimentalCoroutinesApi
+  override suspend fun doWork(): Result = coroutineScope {
+    Timber.d("MissingPageDownloadWorker")
+    val pagesToDownload = findMissingPagesToDownload()
+    Timber.d("MissingPageDownloadWorker found $pagesToDownload missing pages")
+    if (pagesToDownload.size < MISSING_PAGE_LIMIT) {
+      // attempt to download missing pages
+      val results = pagesToDownload.asFlow()
+          .map { downloadPage(it) }
+          .flowOn(Dispatchers.IO)
+          .toList()
+
+      val failures = results.count { !it }
+      if (failures > 0) {
+        Timber.d("MissingPageWorker failed with $failures from ${pagesToDownload.size}")
+        Answers.getInstance()
+            .logCustom(
+                CustomEvent("missingPageWorkerFailure")
+                    .putCustomAttribute("failed", failures)
+                    .putCustomAttribute("percentageSuccess",
+                        1.0 * (pagesToDownload.size - failures) / pagesToDownload.size * 1.0)
+                    .putCustomAttribute("missingImages", pagesToDownload.size)
+            )
+      } else {
+        Timber.d("MissingPageWorker success with ${pagesToDownload.size}")
+        Answers.getInstance()
+          .logCustom(
+              CustomEvent("missingPageWorkerSuccess")
+                  .putCustomAttribute("missingImages", pagesToDownload.size)
+          )
+      }
+    }
+    Result.success()
+  }
+
+  private fun findMissingPagesToDownload(): List<PageToDownload> {
+    val width = quranScreenInfo.widthParam
+    val result = findMissingPagesForWidth(width)
+
+    val tabletWidth = quranScreenInfo.tabletWidthParam
+    return if (width == tabletWidth) {
+      result
+    } else {
+      result + findMissingPagesForWidth(tabletWidth)
+    }
+  }
+
+  private fun findMissingPagesForWidth(width: String): List<PageToDownload> {
+    val result = mutableListOf<PageToDownload>()
+    val pagesDirectory = File(quranFileUtils.getQuranImagesDirectory(context, width))
+    for (page in 1..quranInfo.numberOfPages) {
+      val pageFile = QuranFileUtils.getPageFileName(page)
+      if (!File(pagesDirectory, pageFile).exists()) {
+        result.add(PageToDownload(width, page))
+      }
+    }
+    return result
+  }
+
+  data class PageToDownload(val width: String, val page: Int)
+
+  private fun downloadPage(pageToDownload: PageToDownload): Boolean {
+    Timber.d("downloading ${pageToDownload.page} for ${pageToDownload.width} - thread: %s",
+        Thread.currentThread().name)
+    val pageName = QuranFileUtils.getPageFileName(pageToDownload.page)
+
+    return try {
+      quranFileUtils.getImageFromWeb(okHttpClient, context, pageToDownload.width, pageName)
+          .isSuccessful
+    } catch (throwable: Throwable) {
+      false
+    }
+  }
+
+  class Factory @Inject constructor(
+    private val quranInfo: QuranInfo,
+    private val quranFileUtils: QuranFileUtils,
+    private val quranScreenInfo: QuranScreenInfo,
+    private val okHttpClient: OkHttpClient
+  ) : WorkerTaskFactory {
+    override fun makeWorker(
+      appContext: Context,
+      workerParameters: WorkerParameters
+    ): ListenableWorker {
+      return MissingPageDownloadWorker(
+          appContext, workerParameters, okHttpClient, quranInfo, quranScreenInfo, quranFileUtils
+      )
+    }
+  }
+
+  companion object {
+    private const val MISSING_PAGE_LIMIT = 50
+  }
+}

--- a/app/src/main/java/com/quran/labs/androidquran/worker/PartialPageCheckingWorker.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/worker/PartialPageCheckingWorker.kt
@@ -1,0 +1,162 @@
+package com.quran.labs.androidquran.worker
+
+import android.content.Context
+import androidx.work.CoroutineWorker
+import androidx.work.ListenableWorker
+import androidx.work.WorkerParameters
+import com.crashlytics.android.answers.Answers
+import com.crashlytics.android.answers.CustomEvent
+import com.quran.labs.androidquran.core.worker.WorkerTaskFactory
+import com.quran.labs.androidquran.data.QuranInfo
+import com.quran.labs.androidquran.util.QuranFileUtils
+import com.quran.labs.androidquran.util.QuranPartialPageChecker
+import com.quran.labs.androidquran.util.QuranScreenInfo
+import com.quran.labs.androidquran.util.QuranSettings
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.coroutineScope
+import timber.log.Timber
+import java.io.File
+import java.io.IOException
+import javax.inject.Inject
+
+class PartialPageCheckingWorker(private val context: Context,
+                                private val params: WorkerParameters,
+                                private val quranInfo: QuranInfo,
+                                private val quranFileUtils: QuranFileUtils,
+                                private val quranScreenInfo: QuranScreenInfo,
+                                private val quranSettings: QuranSettings,
+                                private val quranPartialPageChecker: QuranPartialPageChecker
+) : CoroutineWorker(context, params) {
+
+  @ExperimentalCoroutinesApi
+  override suspend fun doWork(): Result = coroutineScope {
+    Timber.d("PartialPageCheckingWorker")
+    val requestedPageType = params.inputData.getString(WorkerConstants.PAGE_TYPE)
+    if (requestedPageType != quranSettings.pageType) {
+      Timber.e(IllegalStateException(
+          "PageType different than expected: $requestedPageType, found ${quranSettings.pageType}"))
+      Result.success()
+    } else if (!quranSettings.didCheckPartialImages(requestedPageType)) {
+      val numberOfPages = quranInfo.numberOfPages
+
+      // prepare page widths and paths
+      val width = quranScreenInfo.widthParam
+      val pagesDirectory = quranFileUtils.getQuranImagesDirectory(context, width)
+      val tabletWidth = quranScreenInfo.tabletWidthParam
+      val tabletPagesDirectory = quranFileUtils.getQuranImagesDirectory(context, width)
+
+      // compute the partial page sets
+      val partialPages =
+        quranPartialPageChecker.checkPages(pagesDirectory, numberOfPages, width)
+          .map { PartialPage(width, it) }
+      Timber.d("Found %d partial images for width %s", partialPages.size, width)
+
+      val tabletPartialPages = if (width == tabletWidth) {
+        emptyList()
+      } else {
+        quranPartialPageChecker.checkPages(tabletPagesDirectory, numberOfPages, tabletWidth)
+            .map { PartialPage(tabletWidth, it) }
+      }
+      Timber.d("Found %d partial images for tablet width %s", tabletPartialPages.size, width)
+
+      val allPartialPages = partialPages + tabletPartialPages
+      if (allPartialPages.size > PARTIAL_PAGE_LIMIT) {
+        Timber.e(IllegalStateException("Too many partial pages found"),
+            "found ${allPartialPages.size} partial images")
+        Answers.getInstance()
+            .logCustom(
+                CustomEvent("tooManyPartialPagesFound")
+                    .putCustomAttribute("pageType", requestedPageType)
+                    .putCustomAttribute("partialPages", allPartialPages.size)
+                    .putCustomAttribute("tabletImages", if (width == tabletWidth) "no" else "yes")
+                    .putCustomAttribute("width", width)
+                    .putCustomAttribute("tabletWidth", tabletWidth)
+            )
+        // still delete the partial images just because ¯\_(ツ)_/¯
+      }
+
+      val deletionSucceeded = try {
+        // iterate through each one and delete the partial pages
+        partialPages.firstOrNull {
+          val path = if (it.width == width) pagesDirectory else tabletPagesDirectory
+          !deletePage(path, it.page)
+        } == null
+      } catch (ioException: IOException) {
+        Timber.e(ioException)
+        false
+      }
+
+      if (!deletionSucceeded) {
+        Answers.getInstance()
+            .logCustom(
+                CustomEvent("partialPagesWorkerFailedToDelete")
+                    .putCustomAttribute("pageType", requestedPageType)
+                    .putCustomAttribute("width", width)
+                    .putCustomAttribute("tabletWidth", tabletWidth)
+                    .putCustomAttribute("partialPages", allPartialPages.size)
+            )
+        Timber.d("PartialPageCheckingWorker - partial deletion failure, retrying..")
+        Result.retry()
+      } else {
+        if (allPartialPages.isNotEmpty()) {
+          Answers.getInstance()
+              .logCustom(
+                  CustomEvent("partialPagesWorkerSuccess")
+                      .putCustomAttribute("pageType", requestedPageType)
+                      .putCustomAttribute("width", width)
+                      .putCustomAttribute("tabletWidth", tabletWidth)
+                      .putCustomAttribute("partialPages", allPartialPages.size)
+              )
+        } else {
+          Answers.getInstance()
+              .logCustom(
+                  CustomEvent("partialPagesWorkerNoOpSuccess")
+                      .putCustomAttribute("pageType", requestedPageType)
+                      .putCustomAttribute("width", width)
+                      .putCustomAttribute("tabletWidth", tabletWidth)
+              )
+        }
+        Timber.d("PartialPageCheckingWorker - partial success!")
+        quranSettings.setCheckedPartialImages(requestedPageType)
+        Result.success()
+      }
+    } else {
+      Result.success()
+    }
+  }
+
+  data class PartialPage(val width: String, val page: Int)
+
+  private fun deletePage(directory: String, page: Int): Boolean {
+    val pageName = QuranFileUtils.getPageFileName(page)
+    return File(directory, pageName).let { file ->
+      if (file.exists()) {
+        file.delete()
+      } else {
+        true
+      }
+    }
+  }
+
+  class Factory @Inject constructor(
+    private val quranInfo: QuranInfo,
+    private val quranFileUtils: QuranFileUtils,
+    private val quranScreenInfo: QuranScreenInfo,
+    private val quranSettings: QuranSettings,
+    private val quranPartialPageChecker: QuranPartialPageChecker
+  ) : WorkerTaskFactory {
+    override fun makeWorker(
+      appContext: Context,
+      workerParameters: WorkerParameters
+    ): ListenableWorker {
+      return PartialPageCheckingWorker(
+          appContext, workerParameters, quranInfo, quranFileUtils, quranScreenInfo, quranSettings,
+          quranPartialPageChecker
+      )
+    }
+  }
+
+  companion object {
+    private const val PARTIAL_PAGE_LIMIT = 50
+  }
+}

--- a/app/src/main/java/com/quran/labs/androidquran/worker/WorkerConstants.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/worker/WorkerConstants.kt
@@ -1,0 +1,6 @@
+package com.quran.labs.androidquran.worker
+
+object WorkerConstants {
+  const val CLEANUP_PREFIX = "cleanup_"
+  const val PAGE_TYPE = "pageType"
+}

--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,7 @@ buildscript {
     espressoVersion = '3.2.0'
     // note - 3.13.x and above require minSdk 21
     okhttpVersion = '3.12.6'
+    workManagerVersion = '2.3.1'
 
     deps = [
         android: [


### PR DESCRIPTION
This patch adds 2 WorkManager workers - one to look for partial pages
and remove them, and a follow up one to try to download missing pages.