### PR TITLE
Fix bugs with the partial page checker and tablet

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/util/QuranScreenInfo.java
+++ b/app/src/main/java/com/quran/labs/androidquran/util/QuranScreenInfo.java
@@ -28,7 +28,7 @@ public class QuranScreenInfo {
 
     height = point.y;
     altDimension = point.x;
-    maxWidth = (point.x > point.y) ? point.x : point.y;
+    maxWidth = Math.max(point.x, point.y);
     orientation = appContext.getResources().getConfiguration().orientation;
 
     this.context = appContext;

--- a/app/src/main/java/com/quran/labs/androidquran/worker/PartialPageCheckingWorker.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/worker/PartialPageCheckingWorker.kt
@@ -43,7 +43,7 @@ class PartialPageCheckingWorker(private val context: Context,
       val width = quranScreenInfo.widthParam
       val pagesDirectory = quranFileUtils.getQuranImagesDirectory(context, width)
       val tabletWidth = quranScreenInfo.tabletWidthParam
-      val tabletPagesDirectory = quranFileUtils.getQuranImagesDirectory(context, width)
+      val tabletPagesDirectory = quranFileUtils.getQuranImagesDirectory(context, tabletWidth)
 
       // compute the partial page sets
       val partialPages =
@@ -57,7 +57,7 @@ class PartialPageCheckingWorker(private val context: Context,
         quranPartialPageChecker.checkPages(tabletPagesDirectory, numberOfPages, tabletWidth)
             .map { PartialPage(tabletWidth, it) }
       }
-      Timber.d("Found %d partial images for tablet width %s", tabletPartialPages.size, width)
+      Timber.d("Found %d partial images for tablet width %s", tabletPartialPages.size, tabletWidth)
 
       val allPartialPages = partialPages + tabletPartialPages
       if (allPartialPages.size > PARTIAL_PAGE_LIMIT) {
@@ -77,7 +77,7 @@ class PartialPageCheckingWorker(private val context: Context,
 
       val deletionSucceeded = try {
         // iterate through each one and delete the partial pages
-        partialPages.firstOrNull {
+        allPartialPages.firstOrNull {
           val path = if (it.width == width) pagesDirectory else tabletPagesDirectory
           !deletePage(path, it.page)
         } == null

--- a/common/data/src/main/java/com/quran/data/pageinfo/common/size/DefaultPageSizeCalculator.kt
+++ b/common/data/src/main/java/com/quran/data/pageinfo/common/size/DefaultPageSizeCalculator.kt
@@ -29,10 +29,10 @@ open class DefaultPageSizeCalculator(displaySize: DisplaySize) : PageSizeCalcula
   }
 
   override fun setOverrideParameter(parameter: String) {
-    if (parameter.isNotBlank()) {
-      overrideParam = parameter
+    overrideParam = if (parameter.isNotBlank()) {
+      parameter
     } else {
-      overrideParam = null
+      null
     }
   }
 }


### PR DESCRIPTION
Al7amdulillah, got really lucky here! The parital page checker had a
number of bugs - namely it used the width where it should have used the
tablet width. Consequently, it marks a massive number of pages as "to be
deleted." Due to another bug though (looping over only the pages to
delete instead of all pages to delete), al7amdulillah the pages didn't
actually get deleted in this case. This fixes these bugs.