### PR TITLE
Force re-init of overlayParams on view invalidate

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/widgets/HighlightingImageView.java
+++ b/app/src/main/java/com/quran/labs/androidquran/widgets/HighlightingImageView.java
@@ -266,6 +266,14 @@ public class HighlightingImageView extends AppCompatImageView {
     didDraw = true;
   }
 
+  @Override
+  public void invalidate() {
+    super.invalidate();
+    if (overlayParams != null) {
+      overlayParams.init = false;
+    }
+  }
+
   private Paint getPaintForHighlightType(HighlightType type) {
     int color = type.getColor(getContext());
     Paint paint = SPARSE_PAINT_ARRAY.get(color);

--- a/app/src/main/java/com/quran/labs/androidquran/widgets/HighlightingImageView.java
+++ b/app/src/main/java/com/quran/labs/androidquran/widgets/HighlightingImageView.java
@@ -125,6 +125,8 @@ public class HighlightingImageView extends AppCompatImageView {
       // we need a new color filter now
       isColorFilterOn = false;
     }
+    // Re-init overlay params color based on the new night mode setting
+    initOverlayParamsColor();
     adjustNightMode();
   }
 
@@ -217,12 +219,7 @@ public class HighlightingImageView extends AppCompatImageView {
       return true;
     }
 
-    int overlayColor = overlayTextColor;
-    if (isNightMode) {
-      overlayColor = Color.rgb(nightModeTextBrightness,
-          nightModeTextBrightness, nightModeTextBrightness);
-    }
-    overlayParams.paint.setColor(overlayColor);
+    initOverlayParamsColor();
 
     // Use font metrics to calculate the maximum possible height of the text
     FontMetrics fm = overlayParams.paint.getFontMetrics();
@@ -245,6 +242,18 @@ public class HighlightingImageView extends AppCompatImageView {
     return true;
   }
 
+  private void initOverlayParamsColor() {
+    if (overlayParams == null) {
+      return;
+    }
+    int overlayColor = overlayTextColor;
+    if (isNightMode) {
+      overlayColor = Color.rgb(nightModeTextBrightness,
+          nightModeTextBrightness, nightModeTextBrightness);
+    }
+    overlayParams.paint.setColor(overlayColor);
+  }
+
   private void overlayText(Canvas canvas, Matrix matrix) {
     if (overlayParams == null || !initOverlayParams(matrix)) {
       return;
@@ -264,14 +273,6 @@ public class HighlightingImageView extends AppCompatImageView {
         getWidth() - overlayParams.offsetX, overlayParams.topBaseline,
         overlayParams.paint);
     didDraw = true;
-  }
-
-  @Override
-  public void invalidate() {
-    super.invalidate();
-    if (overlayParams != null) {
-      overlayParams.init = false;
-    }
   }
 
   private Paint getPaintForHighlightType(HighlightType type) {


### PR DESCRIPTION
I noticed a bug where, when toggling night mode, the overlay text at the top of Quran Arabic pages does not change colour for currently active fragments (ie the fragment currently displayed and one either side). In particular, when going from night mode to normal mode, this currently makes the text unreadable.

I'm not sure if this is the best way to fix this, as, from debugging this, there are several calls to `invalidate` where this code gets run but doesn't need to. That said, this felt cleaner to me than adding the equivalent code to the end of this method:

https://github.com/quran/quran_android/blob/44715eaaf2761b5560154f88affe1f57a7bab2f8/app/src/main/java/com/quran/labs/androidquran/widgets/HighlightingImageView.java#L157-L173