### PR TITLE
Long press play should play the ayah directly

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/ui/PagerActivity.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/PagerActivity.java
@@ -1901,7 +1901,9 @@ public class PagerActivity extends QuranActionBarActivity implements
           sliderPage = slidingPagerAdapter.getPagePosition(TRANSLATION_PAGE);
           break;
         case R.id.cab_play_from_here:
-          sliderPage = slidingPagerAdapter.getPagePosition(AUDIO_PAGE);
+          playFromAyah(getCurrentPage(), start.sura, start.ayah);
+          toggleActionBarVisibility(true);
+          sliderPage = -1;
           break;
         case R.id.cab_share_ayah_link:
           shareAyahLink(start, end);


### PR DESCRIPTION
Instead of showing the dialog when someone long presses an ayah and
chooses play, start playing right away. The dialog can be reached from
the settings button on the bottom bar when needed.