### PR TITLE
Reset Expanded Translated Ayat. Fixes #1256

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/ui/translation/TranslationAdapter.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/translation/TranslationAdapter.kt
@@ -80,6 +80,7 @@ internal class TranslationAdapter(private val context: Context,
 
   fun setData(data: List<TranslationViewRow>) {
     this.data.clear()
+    expandedTafaseerAyahs.clear();
     this.data.addAll(data)
     if (highlightedAyah > 0) {
       highlightAyah(highlightedAyah, false)


### PR DESCRIPTION
Related to issue #1256

Expansion of truncated translations persists based on position and unexpected things happen when translation selections change.  Fixing that by resetting (removing) expansion whenever view refreshes due to translation change, navigation, etc.

Tested on Samsung Galaxy S8, Android 9.

![ezgif-4-263046375883](https://user-images.githubusercontent.com/3638363/79784980-1ba98a80-8311-11ea-978e-793d4fe9b01b.gif)
