### PR TITLE
Fix for a case where start is larger than end

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/presenter/audio/AudioPresenter.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/presenter/audio/AudioPresenter.kt
@@ -2,6 +2,7 @@ package com.quran.labs.androidquran.presenter.audio
 
 import android.content.Context
 import android.content.Intent
+import com.crashlytics.android.Crashlytics
 import com.quran.labs.androidquran.R
 import com.quran.labs.androidquran.common.audio.QariItem
 import com.quran.labs.androidquran.dao.audio.AudioPathInfo
@@ -15,6 +16,7 @@ import com.quran.labs.androidquran.ui.PagerActivity
 import com.quran.labs.androidquran.util.AudioUtils
 import com.quran.labs.androidquran.util.QuranFileUtils
 import java.io.File
+import java.lang.IllegalArgumentException
 import javax.inject.Inject
 
 class AudioPresenter @Inject
@@ -48,8 +50,13 @@ constructor(private val quranInfo: QuranInfo,
         audioPathInfo
       }
 
+      val (checkedStart, checkedEnd) = if (start < end) start to end else end to start
+      if (checkedStart != start) {
+        Crashlytics.logException(IllegalArgumentException("expected $start > $end, but wasn't."))
+      }
+
       val audioRequest = AudioRequest(
-          start, end, qari, verseRepeat, rangeRepeat, enforceRange, stream, audioPath)
+          checkedStart, checkedEnd, qari, verseRepeat, rangeRepeat, enforceRange, stream, audioPath)
       play(audioRequest)
     }
   }

--- a/app/src/main/java/com/quran/labs/androidquran/ui/PagerActivity.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/PagerActivity.java
@@ -1480,7 +1480,8 @@ public class PagerActivity extends QuranActionBarActivity implements
             quranSettings.getPreferredDownloadAmount(), isDualPages);
 
     if (ending != null) {
-      Crashlytics.log("playFromAyah - " + ending + " - original: " + end + " -- " +
+      Crashlytics.log("playFromAyah - " + start + ", ending: " +
+          ending + " - original: " + end + " -- " +
           quranSettings.getPreferredDownloadAmount());
       final QariItem item = audioStatusBar.getAudioInfo();
       final boolean shouldStream = quranSettings.shouldStream();


### PR DESCRIPTION
We have a check to make sure we are not trying to play "backwards" - for
some reason, in some rare cases, the end ayah is less than the start
ayah. This checks and silently handles the case, while logging it as a
checked exception so that the root cause can be fixed.