### PR TITLE
Update dependency versions

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -167,7 +167,7 @@ dependencies {
   debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.2'
   testImplementation 'junit:junit:4.13'
   testImplementation 'com.google.truth:truth:1.0.1'
-  testImplementation "org.mockito:mockito-core:3.2.0"
+  testImplementation "org.mockito:mockito-core:3.3.3"
   testImplementation "com.squareup.okhttp3:mockwebserver:${okhttpVersion}"
   androidTestImplementation "androidx.test.espresso:espresso-core:${espressoVersion}"
   androidTestImplementation "androidx.test.espresso:espresso-intents:${espressoVersion}"

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
   ext {
-    kotlinVersion = '1.3.71'
+    kotlinVersion = '1.3.72'
     coroutinesVersion = '1.3.5'
     daggerVersion = '2.27'
     androidxMediaVersion = '1.1.0'
@@ -14,11 +14,11 @@ buildscript {
     espressoVersion = '3.2.0'
     moshiVersion = '1.9.2'
     // note - 3.13.x and above require minSdk 21
-    okhttpVersion = '3.12.10'
+    okhttpVersion = '3.12.+'
     okioVersion = '2.5.0'
     workManagerVersion = '2.3.4'
     // note - 2.7.x and above require minSdk 21
-    retrofitVersion = '2.6.4'
+    retrofitVersion = '2.6.+'
 
     deps = [
         android: [
@@ -46,7 +46,7 @@ buildscript {
   }
 
   dependencies {
-    classpath 'com.android.tools.build:gradle:3.6.2'
+    classpath 'com.android.tools.build:gradle:3.6.3'
     classpath "io.fabric.tools:gradle:1.31.2"
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
     classpath "net.ltgt.gradle:gradle-errorprone-plugin:1.1.1"


### PR DESCRIPTION
This sets OkHttp and Retrofit minor versions to dynamic, so that we keep receiving (possible future) security updates.