### PR TITLE
1365/ Add ToastCompat with support for dark toasts on pre-R

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/QuranAdvancedPreferenceActivity.java
+++ b/app/src/main/java/com/quran/labs/androidquran/QuranAdvancedPreferenceActivity.java
@@ -16,6 +16,7 @@ import android.widget.Toast;
 import com.quran.labs.androidquran.service.util.PermissionUtil;
 import com.quran.labs.androidquran.ui.QuranActionBarActivity;
 import com.quran.labs.androidquran.ui.fragment.QuranAdvancedSettingsFragment;
+import com.quran.labs.androidquran.ui.util.ToastCompat;
 import com.quran.labs.androidquran.util.AudioManagerUtils;
 import com.quran.labs.androidquran.util.QuranSettings;
 
@@ -82,7 +83,7 @@ public class QuranAdvancedPreferenceActivity extends QuranActionBarActivity {
           REQUEST_WRITE_TO_SDCARD_PERMISSION);
     } else {
       // in the future, we should make this a direct link - perhaps using a Snackbar.
-      Toast.makeText(this, R.string.please_grant_permissions, Toast.LENGTH_SHORT).show();
+      ToastCompat.makeText(this, R.string.please_grant_permissions, Toast.LENGTH_SHORT).show();
     }
   }
 

--- a/app/src/main/java/com/quran/labs/androidquran/QuranDataActivity.java
+++ b/app/src/main/java/com/quran/labs/androidquran/QuranDataActivity.java
@@ -23,6 +23,7 @@ import com.quran.labs.androidquran.service.util.PermissionUtil;
 import com.quran.labs.androidquran.service.util.QuranDownloadNotifier;
 import com.quran.labs.androidquran.service.util.ServiceIntentHelper;
 import com.quran.labs.androidquran.ui.QuranActivity;
+import com.quran.labs.androidquran.ui.util.ToastCompat;
 import com.quran.labs.androidquran.util.QuranFileUtils;
 import com.quran.labs.androidquran.util.QuranScreenInfo;
 import com.quran.labs.androidquran.util.QuranSettings;
@@ -258,7 +259,7 @@ public class QuranDataActivity extends Activity implements
         havePermission = true;
         Answers.getInstance().logCustom(new CustomEvent("storagePermissionGranted"));
         if (!canWriteSdcardAfterPermissions()) {
-          Toast.makeText(this,
+          ToastCompat.makeText(this,
               R.string.storage_permission_please_restart, Toast.LENGTH_LONG).show();
         }
         checkPages();

--- a/app/src/main/java/com/quran/labs/androidquran/QuranImportActivity.java
+++ b/app/src/main/java/com/quran/labs/androidquran/QuranImportActivity.java
@@ -12,6 +12,7 @@ import com.crashlytics.android.answers.Answers;
 import com.crashlytics.android.answers.CustomEvent;
 import com.quran.labs.androidquran.dao.bookmark.BookmarkData;
 import com.quran.labs.androidquran.presenter.QuranImportPresenter;
+import com.quran.labs.androidquran.ui.util.ToastCompat;
 
 import javax.inject.Inject;
 
@@ -69,7 +70,7 @@ public class QuranImportActivity extends AppCompatActivity implements
 
   public void showImportComplete() {
     Answers.getInstance().logCustom(new CustomEvent("importDataSuccessful"));
-    Toast.makeText(QuranImportActivity.this,
+    ToastCompat.makeText(QuranImportActivity.this,
         R.string.import_successful, Toast.LENGTH_LONG).show();
     finish();
   }

--- a/app/src/main/java/com/quran/labs/androidquran/ui/PagerActivity.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/PagerActivity.java
@@ -70,6 +70,7 @@ import com.quran.labs.androidquran.ui.helpers.QuranDisplayHelper;
 import com.quran.labs.androidquran.ui.helpers.QuranPage;
 import com.quran.labs.androidquran.ui.helpers.QuranPageAdapter;
 import com.quran.labs.androidquran.ui.helpers.SlidingPagerAdapter;
+import com.quran.labs.androidquran.ui.util.ToastCompat;
 import com.quran.labs.androidquran.ui.util.TranslationsSpinnerAdapter;
 import com.quran.labs.androidquran.util.AudioUtils;
 import com.quran.labs.androidquran.util.QuranAppUtils;
@@ -800,7 +801,7 @@ public class PagerActivity extends QuranActionBarActivity implements
 
     if (downloadType != QuranDownloadService.DOWNLOAD_TYPE_AUDIO) {
       // if audio is playing, just show a status notification
-      Toast.makeText(this, R.string.downloading_title,
+      ToastCompat.makeText(this, R.string.downloading_title,
           Toast.LENGTH_SHORT).show();
     }
   }

--- a/app/src/main/java/com/quran/labs/androidquran/ui/SheikhAudioManagerActivity.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/SheikhAudioManagerActivity.kt
@@ -34,6 +34,7 @@ import com.quran.labs.androidquran.service.util.DefaultDownloadReceiver
 import com.quran.labs.androidquran.service.util.DefaultDownloadReceiver.SimpleDownloadListener
 import com.quran.labs.androidquran.service.util.QuranDownloadNotifier.ProgressIntent
 import com.quran.labs.androidquran.service.util.ServiceIntentHelper
+import com.quran.labs.androidquran.ui.util.ToastCompat
 import com.quran.labs.androidquran.util.AudioManagerUtils
 import com.quran.labs.androidquran.util.AudioUtils
 import com.quran.labs.androidquran.util.QariDownloadInfo
@@ -292,7 +293,7 @@ class SheikhAudioManagerActivity : QuranActionBarActivity(), SimpleDownloadListe
           R.plurals.audio_manager_delete_surah_success, successCount, successCount
       )
     }
-    Toast.makeText(this, resultString, Toast.LENGTH_SHORT).show()
+    ToastCompat.makeText(this, resultString, Toast.LENGTH_SHORT).show()
     if (successCount > 0) {
       // refresh, if at least 1 file was deleted
       AudioManagerUtils.clearCacheKeyForSheikh(qari)

--- a/app/src/main/java/com/quran/labs/androidquran/ui/fragment/QuranAdvancedSettingsFragment.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/fragment/QuranAdvancedSettingsFragment.java
@@ -24,6 +24,7 @@ import com.quran.labs.androidquran.data.Constants;
 import com.quran.labs.androidquran.model.bookmark.BookmarkImportExportModel;
 import com.quran.labs.androidquran.service.util.PermissionUtil;
 import com.quran.labs.androidquran.ui.preference.DataListPreference;
+import com.quran.labs.androidquran.ui.util.ToastCompat;
 import com.quran.labs.androidquran.util.QuranFileUtils;
 import com.quran.labs.androidquran.util.QuranScreenInfo;
 import com.quran.labs.androidquran.util.QuranSettings;
@@ -156,7 +157,7 @@ public class QuranAdvancedSettingsFragment extends PreferenceFragmentCompat {
                   File exportedPath = new File(appContext.getExternalFilesDir(null), "backups");
                   String exported = appContext.getString(
                       R.string.exported_data, exportedPath.toString());
-                  Toast.makeText(appContext, exported, Toast.LENGTH_LONG).show();
+                  ToastCompat.makeText(appContext, exported, Toast.LENGTH_LONG).show();
                 }
               }
 
@@ -164,7 +165,7 @@ public class QuranAdvancedSettingsFragment extends PreferenceFragmentCompat {
               public void onError(Throwable e) {
                 exportSubscription = null;
                 if (isAdded()) {
-                  Toast.makeText(context, R.string.export_data_error, Toast.LENGTH_LONG).show();
+                  ToastCompat.makeText(context, R.string.export_data_error, Toast.LENGTH_LONG).show();
                 }
               }
             });
@@ -282,7 +283,7 @@ public class QuranAdvancedSettingsFragment extends PreferenceFragmentCompat {
                 handleMove(newLocation);
               }
             } else {
-              Toast.makeText(context1,
+              ToastCompat.makeText(context1,
                   getString(
                       R.string.prefs_no_enough_space_to_move_files),
                   Toast.LENGTH_LONG).show();
@@ -389,7 +390,7 @@ public class QuranAdvancedSettingsFragment extends PreferenceFragmentCompat {
             listStoragePref.setValue(newLocation);
           }
         } else {
-          Toast.makeText(appContext,
+          ToastCompat.makeText(appContext,
               getString(R.string.prefs_err_moving_app_files),
               Toast.LENGTH_LONG).show();
         }

--- a/app/src/main/java/com/quran/labs/androidquran/ui/helpers/QuranDisplayHelper.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/helpers/QuranDisplayHelper.java
@@ -16,6 +16,7 @@ import android.widget.Toast;
 import com.quran.data.core.QuranInfo;
 import com.quran.labs.androidquran.R;
 import com.quran.labs.androidquran.common.Response;
+import com.quran.labs.androidquran.ui.util.ToastCompat;
 import com.quran.labs.androidquran.util.QuranFileUtils;
 import com.quran.labs.androidquran.util.QuranUtils;
 
@@ -83,7 +84,7 @@ public class QuranDisplayHelper {
     }
 
     String result = sb.toString();
-    Toast.makeText(context, result, Toast.LENGTH_SHORT).show();
+    ToastCompat.makeText(context, result, Toast.LENGTH_SHORT).show();
     return System.currentTimeMillis();
   }
 

--- a/app/src/main/java/com/quran/labs/androidquran/ui/util/ToastCompat.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/util/ToastCompat.java
@@ -46,7 +46,7 @@ public class ToastCompat {
       toastView.setBackgroundDrawable(tintedBackground);
     }
 
-    TextView textView = toastView.findViewById(android.R.id.message);
+    TextView textView = toastView.findViewById(R.id.message);
     textView.setTextColor(getTextColor(context, nightMode));
     textView.setText(message);
     return toastView;

--- a/app/src/main/java/com/quran/labs/androidquran/ui/util/ToastCompat.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/util/ToastCompat.java
@@ -1,0 +1,83 @@
+package com.quran.labs.androidquran.ui.util;
+
+import android.annotation.SuppressLint;
+import android.content.Context;
+import android.graphics.Color;
+import android.graphics.drawable.Drawable;
+import android.os.Build;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.StringRes;
+import androidx.appcompat.content.res.AppCompatResources;
+import androidx.core.content.ContextCompat;
+import androidx.core.graphics.drawable.DrawableCompat;
+
+import com.quran.labs.androidquran.R;
+import com.quran.labs.androidquran.util.QuranSettings;
+
+public class ToastCompat {
+
+  private static final int ANDROID_R = 30;
+
+  public static Toast makeText(@NonNull Context context, @StringRes int messageRes, int duration) {
+    return makeText(context, context.getString(messageRes), duration);
+  }
+
+  public static Toast makeText(@NonNull Context context, CharSequence message, int duration) {
+    @SuppressLint("ShowToast") Toast toast = Toast.makeText(context, message, duration);
+    if (Build.VERSION.SDK_INT < ANDROID_R) {
+      // It's unclear what behavior `Toast.setView()` has on R and above, hence the guard.
+      toast.setView(createToastView(context, message));
+    }
+    return toast;
+  }
+
+  private static View createToastView(Context context, CharSequence message) {
+    View toastView = LayoutInflater.from(context).inflate(R.layout.toast, null, false);
+
+    QuranSettings settings = QuranSettings.getInstance(context);
+    Drawable tintedBackground = createTintedBackground(context, settings.isNightMode());
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
+      toastView.setBackground(tintedBackground);
+    } else {
+      toastView.setBackgroundDrawable(tintedBackground);
+    }
+
+    TextView textView = toastView.findViewById(android.R.id.message);
+    textView.setTextColor(getTextColor(context, settings));
+    textView.setText(message);
+    return toastView;
+  }
+
+  private static Drawable createTintedBackground(Context context, boolean nightMode) {
+    Drawable toastFrame = DrawableCompat.wrap(AppCompatResources.getDrawable(context, R.drawable.toast_frame));
+    DrawableCompat.setTint(toastFrame, getBackgroundColor(context, nightMode));
+    return toastFrame;
+  }
+
+  private static int getTextColor(Context context, QuranSettings settings) {
+    if (settings.isNightMode()) {
+      int textColorNight = ContextCompat.getColor(context, R.color.toast_text_color_night);
+      return Color.argb(
+          settings.getNightModeTextBrightness(),
+          Color.red(textColorNight),
+          Color.green(textColorNight),
+          Color.blue(textColorNight)
+      );
+    } else {
+      return ContextCompat.getColor(context, R.color.toast_text_color);
+    }
+  }
+
+  private static int getBackgroundColor(Context context, boolean nightMode) {
+    if (nightMode) {
+      return ContextCompat.getColor(context, R.color.toast_background_color_night);
+    } else {
+      return ContextCompat.getColor(context, R.color.toast_background_color);
+    }
+  }
+}

--- a/app/src/main/java/com/quran/labs/androidquran/ui/util/ToastCompat.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/util/ToastCompat.java
@@ -2,7 +2,6 @@ package com.quran.labs.androidquran.ui.util;
 
 import android.annotation.SuppressLint;
 import android.content.Context;
-import android.graphics.Color;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
 import android.view.LayoutInflater;
@@ -39,8 +38,8 @@ public class ToastCompat {
   private static View createToastView(Context context, CharSequence message) {
     View toastView = LayoutInflater.from(context).inflate(R.layout.toast, null, false);
 
-    QuranSettings settings = QuranSettings.getInstance(context);
-    Drawable tintedBackground = createTintedBackground(context, settings.isNightMode());
+    boolean nightMode = QuranSettings.getInstance(context).isNightMode();
+    Drawable tintedBackground = createTintedBackground(context, nightMode);
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
       toastView.setBackground(tintedBackground);
     } else {
@@ -48,7 +47,7 @@ public class ToastCompat {
     }
 
     TextView textView = toastView.findViewById(android.R.id.message);
-    textView.setTextColor(getTextColor(context, settings));
+    textView.setTextColor(getTextColor(context, nightMode));
     textView.setText(message);
     return toastView;
   }
@@ -59,15 +58,9 @@ public class ToastCompat {
     return toastFrame;
   }
 
-  private static int getTextColor(Context context, QuranSettings settings) {
-    if (settings.isNightMode()) {
-      int textColorNight = ContextCompat.getColor(context, R.color.toast_text_color_night);
-      return Color.argb(
-          settings.getNightModeTextBrightness(),
-          Color.red(textColorNight),
-          Color.green(textColorNight),
-          Color.blue(textColorNight)
-      );
+  private static int getTextColor(Context context, boolean nightMode) {
+    if (nightMode) {
+      return ContextCompat.getColor(context, R.color.toast_text_color_night);
     } else {
       return ContextCompat.getColor(context, R.color.toast_text_color);
     }

--- a/app/src/main/java/com/quran/labs/androidquran/util/ShareUtil.java
+++ b/app/src/main/java/com/quran/labs/androidquran/util/ShareUtil.java
@@ -12,6 +12,7 @@ import com.quran.labs.androidquran.common.LocalTranslation;
 import com.quran.labs.androidquran.common.QuranAyahInfo;
 import com.quran.labs.androidquran.common.QuranText;
 import com.quran.labs.androidquran.data.QuranDisplayData;
+import com.quran.labs.androidquran.ui.util.ToastCompat;
 
 import java.util.List;
 
@@ -38,7 +39,7 @@ public class ShareUtil {
     ClipboardManager cm = (ClipboardManager) activity.getSystemService(Context.CLIPBOARD_SERVICE);
     ClipData clip = ClipData.newPlainText(activity.getString(R.string.app_name), text);
     cm.setPrimaryClip(clip);
-    Toast.makeText(activity, activity.getString(R.string.ayah_copied_popup),
+    ToastCompat.makeText(activity, activity.getString(R.string.ayah_copied_popup),
         Toast.LENGTH_SHORT).show();
   }
 

--- a/app/src/main/java/com/quran/labs/androidquran/widgets/AyahToolBar.java
+++ b/app/src/main/java/com/quran/labs/androidquran/widgets/AyahToolBar.java
@@ -16,6 +16,7 @@ import android.widget.Toast;
 
 import com.quran.labs.androidquran.BuildConfig;
 import com.quran.labs.androidquran.R;
+import com.quran.labs.androidquran.ui.util.ToastCompat;
 
 import androidx.annotation.MenuRes;
 import androidx.appcompat.widget.PopupMenu;
@@ -246,7 +247,7 @@ public class AyahToolBar extends ViewGroup implements
   public boolean onLongClick(View v) {
     MenuItem item = menu.findItem(v.getId());
     if (item != null && item.getTitle() != null) {
-      Toast.makeText(context, item.getTitle(), Toast.LENGTH_SHORT).show();
+      ToastCompat.makeText(context, item.getTitle(), Toast.LENGTH_SHORT).show();
       return true;
     }
     return false;

--- a/app/src/main/res/drawable/toast_frame.xml
+++ b/app/src/main/res/drawable/toast_frame.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+  <!-- background is tinted programmatically -->
+  <solid android:color="@android:color/holo_red_light" />
+  <corners android:radius="22dp" />
+</shape>

--- a/app/src/main/res/layout/toast.xml
+++ b/app/src/main/res/layout/toast.xml
@@ -5,7 +5,7 @@
     android:orientation="vertical">
 
   <TextView
-      android:id="@android:id/message"
+      android:id="@+id/message"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
       android:layout_gravity="center_horizontal"

--- a/app/src/main/res/layout/toast.xml
+++ b/app/src/main/res/layout/toast.xml
@@ -1,0 +1,16 @@
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@drawable/toast_frame"
+    android:orientation="vertical">
+
+  <TextView
+      android:id="@android:id/message"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:layout_gravity="center_horizontal"
+      android:layout_marginHorizontal="24dp"
+      android:layout_marginVertical="15dp"
+      android:textAppearance="@style/ToastText" />
+
+</LinearLayout>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -43,4 +43,8 @@
   <color name="snackbar_background_color">@color/download_button_background</color>
   <color name="overlay_panel">#bb000000</color>
   <color name="navbar_night_color">#ff000000</color>
+  <color name="toast_background_color">#e6eeeeee</color>
+  <color name="toast_text_color">#ff000000</color>
+  <color name="toast_background_color_night">#ff2d2d2d</color>
+  <color name="toast_text_color_night">#ffffffff</color>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -84,4 +84,10 @@
         <item name="android:textSize">16sp</item>
         <item name="android:textStyle">normal</item>
     </style>
+
+    <style name="ToastText">
+      <item name="android:textSize">14sp</item>
+      <item name="android:textStyle">normal</item>
+      <item name="fontFamily">sans-serif</item>
+    </style>
 </resources>


### PR DESCRIPTION
I started implementing this using theme attributes, but then I noticed there was an in-app night mode. I tried to follow this approach which means that the system "Night mode" will have no effect on the color of the toast.

Before / Default | Night mode (in-app) enabled
---|---
![lightmode](https://user-images.githubusercontent.com/2678555/83358800-eeb7b100-a36d-11ea-8584-6487491731cf.png) | ![nightmode](https://user-images.githubusercontent.com/2678555/83358802-f1b2a180-a36d-11ea-8a35-b82af96c3894.png)