### PR TITLE
Fix switching reading/translations on Android 11

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/widgets/AudioStatusBar.java
+++ b/app/src/main/java/com/quran/labs/androidquran/widgets/AudioStatusBar.java
@@ -179,7 +179,7 @@ public class AudioStatusBar extends LeftToRightLinearLayout {
 
   public void updateSelectedItem() {
     if (spinner != null) {
-      spinner.setSelection(currentQari);
+      spinner.setSelection(currentQari, false);
     }
   }
 


### PR DESCRIPTION
On Android 11, after full screen is enabled (i.e after the actionbar is
hidden), tapping the screen and tapping the translation icon doesn't
render translations on Android 11. Similarly, starting on translation
view and attempting to transition back to the ayah view after full
screen is enabled doesn't render the ayah view.

Not sure why this specific line fixes the issue on Android 11.