### PR TITLE
Support verse by verse mode without translations

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/presenter/translation/BaseTranslationPresenter.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/presenter/translation/BaseTranslationPresenter.kt
@@ -38,16 +38,8 @@ internal open class BaseTranslationPresenter<T> internal constructor(
                 translations: List<String>,
                 verseRange: VerseRange
   ): Single<ResultHolder> {
-    // get all the translations for these verses, using a source of either the list
-    // of active translations, or a set of all translations if there are no active
-    // translations selected.
-    val source = if (!translations.isEmpty())
-      Observable.fromIterable(translations)
-    else
-      getTranslationMapSingle()
-          .toObservable()
-          .map<List<String>> { map -> map.map { it.value.filename }.toList() }
-          .flatMap<String> { Observable.fromIterable(it) }
+    // get all the translations for these verses, using a source of the list of active translations
+    val source = Observable.fromIterable(translations)
 
     val translationsObservable =
         source.concatMapEager { db ->

--- a/app/src/main/java/com/quran/labs/androidquran/ui/util/TranslationsSpinnerAdapter.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/util/TranslationsSpinnerAdapter.java
@@ -53,19 +53,13 @@ public class TranslationsSpinnerAdapter extends ArrayAdapter<String> {
     CheckBoxHolder holder = (CheckBoxHolder) ((View) buttonView.getParent()).getTag();
     LocalTranslation localTranslation = translations.get(holder.position);
 
-    boolean updated = true;
     if (selectedItems.contains(localTranslation.getFilename())) {
-      if (selectedItems.size() > 1) {
         selectedItems.remove(localTranslation.getFilename());
-      } else {
-        updated = false;
-        holder.checkBox.setChecked(true);
-      }
     } else {
       selectedItems.add(localTranslation.getFilename());
     }
 
-    if (updated && listener != null) {
+    if (listener != null) {
       listener.onSelectionChanged(selectedItems);
     }
 


### PR DESCRIPTION
This PR fixes #1327. 

It allows readers to uncheck all the check-boxes in the translations spinner and changes translations retrieval logic to not default to all available translations if the set of active translations is empty. 