### PR TITLE
Fix audio not refreshing for the last ayah

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/service/AudioService.java
+++ b/app/src/main/java/com/quran/labs/androidquran/service/AudioService.java
@@ -628,6 +628,8 @@ public class AudioService extends Service implements OnCompletionListener,
           t = 10000;
         }
         serviceHandler.sendEmptyMessageDelayed(MSG_UPDATE_AUDIO_POS, t);
+      } else if (maxAyahs == updatedAyah) {
+        serviceHandler.sendEmptyMessageDelayed(MSG_UPDATE_AUDIO_POS, 150);
       }
       // if we're on the last ayah, don't do anything - let the file
       // complete on its own to avoid getCurrentPosition() bugs.


### PR DESCRIPTION
In certain cases, the audio stopped refreshing for the last ayah. This
isn't right, since in some cases, we have a 999 stopping marker that
should be stopped at (instead of the end of the file). This just checks
the position periodically, even when we're at the last ayah.