### PR TITLE
#1407 improvements to audio settings

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -172,6 +172,7 @@ dependencies {
   androidTestImplementation "androidx.test.espresso:espresso-core:${espressoVersion}"
   androidTestImplementation "androidx.test.espresso:espresso-intents:${espressoVersion}"
   implementation 'com.crashlytics.sdk.android:crashlytics:2.10.1'
+  implementation 'com.google.code.gson:gson:2.8.6'
 
   errorprone 'com.google.errorprone:error_prone_core:2.3.3'
   //noinspection GradleDynamicVersion

--- a/app/src/main/java/com/quran/labs/androidquran/dao/audio/AudioPlaybackSettings.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/dao/audio/AudioPlaybackSettings.kt
@@ -1,0 +1,12 @@
+package com.quran.labs.androidquran.dao.audio
+
+import android.os.Parcelable
+import com.quran.data.model.SuraAyah
+import kotlinx.android.parcel.Parcelize
+
+@Parcelize
+data class AudioPlaybackSettings(val start: SuraAyah,
+                                 val end: SuraAyah,
+                                 val verseRepeatCount: Int = 0,
+                                 val rangeRepeatCount: Int = 0,
+                                 val enforceRange: Boolean = false) : Parcelable

--- a/app/src/main/java/com/quran/labs/androidquran/data/Constants.java
+++ b/app/src/main/java/com/quran/labs/androidquran/data/Constants.java
@@ -98,4 +98,5 @@ public class Constants {
   public static final String PREF_CHECKED_PARTIAL_IMAGES = "didCheckPartialImages";
   public static final String PREF_CURRENT_AUDIO_REVISION = "currentAudioRevision";
   public static final String PREF_SURA_TRANSLATED_NAME = "suraTranslatedName";
+  public static final String PREF_AUDIO_PLAYBACK_SETTINGS = "audioPlaybackSettings";
 }

--- a/app/src/main/java/com/quran/labs/androidquran/service/AudioService.java
+++ b/app/src/main/java/com/quran/labs/androidquran/service/AudioService.java
@@ -414,15 +414,8 @@ public class AudioService extends Service implements OnCompletionListener,
         audioQueue = new AudioQueue(quranInfo, audioRequest,
             new AudioPlaybackInfo(start, 1, 1, basmallah));
         Crashlytics.log("audio request has changed...");
-
-        if (player != null) {
-          player.stop();
-        }
-        state = State.Stopped;
-        Crashlytics.log("stop if playing...");
       }
-
-      processTogglePlaybackRequest();
+       processTogglePlaybackRequest();
     } else if (ACTION_PLAY.equals(action)) {
       processPlayRequest();
     } else if (ACTION_PAUSE.equals(action)) {

--- a/app/src/main/java/com/quran/labs/androidquran/ui/fragment/AyahPlaybackFragment.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/fragment/AyahPlaybackFragment.java
@@ -14,10 +14,12 @@ import android.widget.CheckBox;
 import com.quran.data.core.QuranInfo;
 import com.quran.labs.androidquran.QuranApplication;
 import com.quran.labs.androidquran.R;
+import com.quran.labs.androidquran.dao.audio.AudioPlaybackSettings;
 import com.quran.labs.androidquran.dao.audio.AudioRequest;
 import com.quran.data.model.SuraAyah;
 import com.quran.labs.androidquran.ui.PagerActivity;
 import com.quran.labs.androidquran.ui.helpers.HighlightType;
+import com.quran.labs.androidquran.util.QuranSettings;
 import com.quran.labs.androidquran.util.QuranUtils;
 import com.quran.labs.androidquran.widgets.QuranSpinner;
 
@@ -45,7 +47,10 @@ public class AyahPlaybackFragment extends AyahActionFragment {
   private ArrayAdapter<CharSequence> startAyahAdapter;
   private ArrayAdapter<CharSequence> endingAyahAdapter;
 
-  @Inject QuranInfo quranInfo;
+  @Inject
+  QuranInfo quranInfo;
+  @Inject
+  QuranSettings quranSettings;
 
   @Override
   public View onCreateView(LayoutInflater inflater,
@@ -78,15 +83,15 @@ public class AyahPlaybackFragment extends AyahActionFragment {
     repeatRangeSpinner.setAdapter(rangeAdapter);
     repeatRangeSpinner.setOnItemSelectedListener(
         new AdapterView.OnItemSelectedListener() {
-      @Override
-      public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
-        updateEnforceBounds(position);
-      }
+          @Override
+          public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
+            updateEnforceBounds(position);
+          }
 
-      @Override
-      public void onNothingSelected(AdapterView<?> parent) {
-      }
-    });
+          @Override
+          public void onNothingSelected(AdapterView<?> parent) {
+          }
+        });
     final ArrayAdapter<CharSequence> verseAdapter =
         new ArrayAdapter<>(context, ITEM_LAYOUT, repeatOptions);
     verseAdapter.setDropDownViewResource(
@@ -169,7 +174,12 @@ public class AyahPlaybackFragment extends AyahActionFragment {
       if (updatedRange) {
         pagerActivity.toggleActionBarVisibility(true);
       }
+      AudioPlaybackSettings lastAudioSettings =
+          new AudioPlaybackSettings(currentStart, currentEnding, verseRepeat, rangeRepeat,
+              enforceRange);
+      quranSettings.setLastAudioSettings(lastAudioSettings);
     }
+
   }
 
   private void initializeSuraSpinner(final Context context,
@@ -177,7 +187,7 @@ public class AyahPlaybackFragment extends AyahActionFragment {
                                      final ArrayAdapter<CharSequence> ayahAdapter) {
     String[] suras = context.getResources().
         getStringArray(R.array.sura_names);
-    for (int i=0; i<suras.length; i++){
+    for (int i = 0; i < suras.length; i++) {
       suras[i] = QuranUtils.getLocalizedNumber(context, (i + 1)) +
           ". " + suras[i];
     }
@@ -192,12 +202,12 @@ public class AyahPlaybackFragment extends AyahActionFragment {
             int sura = position + 1;
             int ayahCount = quranInfo.getNumberOfAyahs(sura);
             CharSequence[] ayahs = new String[ayahCount];
-            for (int i = 0; i < ayahCount; i++){
+            for (int i = 0; i < ayahCount; i++) {
               ayahs[i] = QuranUtils.getLocalizedNumber(context, (i + 1));
             }
             ayahAdapter.clear();
 
-            for (int i=0; i<ayahCount; i++){
+            for (int i = 0; i < ayahCount; i++) {
               ayahAdapter.add(ayahs[i]);
             }
           }
@@ -264,16 +274,15 @@ public class AyahPlaybackFragment extends AyahActionFragment {
   protected void refreshView() {
     final Context context = getActivity();
     if (context instanceof PagerActivity && start != null && end != null) {
-      final AudioRequest lastRequest =
-          ((PagerActivity) context).getLastAudioRequest();
+      final AudioPlaybackSettings lastAudioSettings = quranSettings.getLastAudioSettings();
       final SuraAyah start;
       final SuraAyah ending;
-      if (lastRequest != null) {
-        start = lastRequest.getStart();
-        ending = lastRequest.getEnd();
-        verseRepeatCount = lastRequest.getRepeatInfo();
-        rangeRepeatCount = lastRequest.getRangeRepeatInfo();
-        shouldEnforce = lastRequest.getEnforceBounds();
+      if (lastAudioSettings != null) {
+        start = lastAudioSettings.getStart();
+        ending = lastAudioSettings.getEnd();
+        verseRepeatCount = lastAudioSettings.getVerseRepeatCount();
+        rangeRepeatCount = lastAudioSettings.getRangeRepeatCount();
+        shouldEnforce = lastAudioSettings.getEnforceRange();
         decidedStart = start;
         decidedEnd = ending;
         applyButton.setText(R.string.play_apply);

--- a/app/src/main/java/com/quran/labs/androidquran/util/QuranSettings.java
+++ b/app/src/main/java/com/quran/labs/androidquran/util/QuranSettings.java
@@ -7,8 +7,11 @@ import android.os.Build;
 import android.os.Environment;
 import android.preference.PreferenceManager;
 
+import com.google.gson.Gson;
 import com.quran.labs.androidquran.BuildConfig;
 import com.quran.labs.androidquran.R;
+import com.quran.labs.androidquran.dao.audio.AudioPlaybackSettings;
+import com.quran.labs.androidquran.dao.audio.AudioRequest;
 import com.quran.labs.androidquran.data.Constants;
 import com.quran.labs.androidquran.service.QuranDownloadService;
 
@@ -21,6 +24,7 @@ import androidx.annotation.RequiresApi;
 import androidx.annotation.VisibleForTesting;
 
 
+
 public class QuranSettings {
   private static final String PREFS_FILE = "com.quran.labs.androidquran.per_installation";
 
@@ -29,6 +33,7 @@ public class QuranSettings {
   private Context appContext;
   private SharedPreferences prefs;
   private SharedPreferences perInstallationPrefs;
+  Gson gson = new Gson();
 
   public static synchronized QuranSettings getInstance(@NonNull Context context) {
     if (instance == null) {
@@ -156,7 +161,9 @@ public class QuranSettings {
     prefs.edit().putBoolean(Constants.PREF_SHOW_RECENTS, minimizeRecents).apply();
   }
 
-  public boolean getShowDate() { return prefs.getBoolean(Constants.PREF_SHOW_DATE, false);  }
+  public boolean getShowDate() {
+    return prefs.getBoolean(Constants.PREF_SHOW_DATE, false);
+  }
 
   public void setShowDate(boolean isDateShown) {
     prefs.edit().putBoolean(Constants.PREF_SHOW_DATE, isDateShown).apply();
@@ -165,6 +172,7 @@ public class QuranSettings {
   public boolean isShowSuraTranslatedName() {
     return prefs.getBoolean(Constants.PREF_SURA_TRANSLATED_NAME, appContext.getResources().getBoolean(R.bool.show_sura_names_translation));
   }
+
   // probably should eventually move this to Application.onCreate..
   public void upgradePreferences() {
     int version = getVersion();
@@ -195,7 +203,7 @@ public class QuranSettings {
               .remove(QuranDownloadService.PREF_LAST_DOWNLOAD_ERROR)
               .remove(QuranDownloadService.PREF_LAST_DOWNLOAD_ITEM)
               .remove(Constants.PREF_ACTIVE_TRANSLATION)
-                  // these aren't migrated since they can be derived pretty easily
+              // these aren't migrated since they can be derived pretty easily
               .remove("didPresentPermissionsRationale") // was renamed, removing old one
               .remove(Constants.PREF_DEFAULT_IMAGES_DIR)
               .remove(Constants.PREF_HAVE_UPDATED_TRANSLATIONS)
@@ -435,5 +443,13 @@ public class QuranSettings {
     setToSave.add(pageType);
     perInstallationPrefs.edit()
         .putStringSet(Constants.PREF_CHECKED_PARTIAL_IMAGES, setToSave).apply();
+  }
+
+  public void setLastAudioSettings(AudioPlaybackSettings audioSettings) {
+    prefs.edit().putString(Constants.PREF_AUDIO_PLAYBACK_SETTINGS, gson.toJson(audioSettings)).apply();
+  }
+
+  public AudioPlaybackSettings getLastAudioSettings() {
+    return gson.fromJson(prefs.getString(Constants.PREF_AUDIO_PLAYBACK_SETTINGS, ""), AudioPlaybackSettings.class);
   }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ buildscript {
   }
 
   dependencies {
-    classpath 'com.android.tools.build:gradle:4.0.0'
+    classpath 'com.android.tools.build:gradle:4.0.1'
     classpath "io.fabric.tools:gradle:1.31.2"
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
     classpath "net.ltgt.gradle:gradle-errorprone-plugin:1.2.1"


### PR DESCRIPTION
1.When I play a Surat then I go into settings to chose to play from what Surat to what Surat and I click play only above verses, the audio of the Surat will restart. It really shouldn't have to restart and should just apply the settings and keep playing. It makes it harder for the kids to focus because it repeats when I apply the settings.

A. removed the part where audio playback is stopped if playing now it pauses and continues on pressing play if in selected range restarts to new start ayah if not in selected range

2.There should be an option to remember the last selected setting being "play only above verses". I'm always having to manually select it.

A.modified 'refreshview()' to read from former used settings which where stored in sharedprefferences on pressing apply button