### PR TITLE
Use red color for downloaded surah in Audio Manager

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/ui/SheikhAudioManagerActivity.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/SheikhAudioManagerActivity.kt
@@ -374,15 +374,19 @@ class SheikhAudioManagerActivity : QuranActionBarActivity(), SimpleDownloadListe
       holder.name.text = quranDisplayData.getSuraName(context, position + 1, true)
       val surahStatus: Int
       val surahStatusImage: Int
+      val surahStatusBackground: Int
       if (isItemFullyDownloaded(position)) {
         surahStatus = R.string.audio_manager_surah_delete
         surahStatusImage = R.drawable.ic_cancel
+        surahStatusBackground = R.drawable.cancel_button_circle
       } else {
         surahStatus = R.string.audio_manager_surah_download
         surahStatusImage = R.drawable.ic_download
+        surahStatusBackground = R.drawable.download_button_circle
       }
       holder.status.text = getString(surahStatus)
       holder.image.setImageResource(surahStatusImage)
+      holder.image.setBackgroundResource(surahStatusBackground)
       holder.setChecked(isItemChecked(position))
     }
 

--- a/app/src/main/res/drawable/cancel_button_circle.xml
+++ b/app/src/main/res/drawable/cancel_button_circle.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+    <solid android:color="@color/cancel_button_background" />
+</shape>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -40,6 +40,7 @@
   <color name="audio_notification_background_color">#ffd8d8d8</color>
   <color name="ayah_bookmark_color">#ff81c784</color>
   <color name="download_button_background">#ff556f79</color>
+  <color name="cancel_button_background">#ffa50800</color>
   <color name="snackbar_background_color">@color/download_button_background</color>
   <color name="overlay_panel">#bb000000</color>
   <color name="navbar_night_color">#ff000000</color>


### PR DESCRIPTION
Suggestion to change the color of the downloaded Surah in Audio Manager.
I feel this is very useful to quickly locate the downloaded Surah's in the list.

![redDeleteColor](https://user-images.githubusercontent.com/69304392/92967872-a9ce0b00-f482-11ea-8b16-a52b3f18ea3b.png)
