### PR TITLE
Fix sura playback range

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/util/AudioUtils.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/util/AudioUtils.kt
@@ -128,16 +128,10 @@ constructor(private val quranInfo: QuranInfo, private val quranFileUtils: QuranF
 
 
     if (mode == LookAheadAmount.SURA) {
-      var sura = startAyah.sura
-      var lastAyah = quranInfo.getNumberOfAyahs(sura)
+      val sura = startAyah.sura
+      val lastAyah = quranInfo.getNumberOfAyahs(sura)
       if (lastAyah == -1) {
         return null
-      }
-
-      // if we start playback between two suras, download both suras
-      if (pageLastSura > sura) {
-        sura = pageLastSura
-        lastAyah = quranInfo.getNumberOfAyahs(sura)
       }
       return SuraAyah(sura, lastAyah)
     } else if (mode == LookAheadAmount.JUZ) {

--- a/app/src/test/java/com/quran/labs/androidquran/util/AudioUtilsTest.kt
+++ b/app/src/test/java/com/quran/labs/androidquran/util/AudioUtilsTest.kt
@@ -19,10 +19,25 @@ class AudioUtilsTest {
         .thenReturn(MadaniDataSource())
     val quranInfo = QuranInfo(MadaniDataSource())
     val audioUtils = AudioUtils(quranInfo, Mockito.mock(QuranFileUtils::class.java))
+    // mode 1 is PAGE
     val lastAyah = audioUtils.getLastAyahToPlay(SuraAyah(109, 1), 603, 1, false)
     Assert.assertNotNull(lastAyah)
     Assert.assertEquals(5, lastAyah!!.ayah.toLong())
     Assert.assertEquals(111, lastAyah.sura.toLong())
+  }
+
+  @Test
+  fun testGetLastAyahWhenPlayingWithSuraBounds() {
+     val pageProviderMock = Mockito.mock(PageProvider::class.java)
+    whenever(pageProviderMock.getDataSource())
+        .thenReturn(MadaniDataSource())
+    val quranInfo = QuranInfo(MadaniDataSource())
+    val audioUtils = AudioUtils(quranInfo, Mockito.mock(QuranFileUtils::class.java))
+    // mode 2 is SURA
+    val lastAyah = audioUtils.getLastAyahToPlay(SuraAyah(2, 6), 3, 2, false)
+    Assert.assertNotNull(lastAyah)
+    Assert.assertEquals(286, lastAyah!!.ayah.toLong())
+    Assert.assertEquals(2, lastAyah.sura.toLong())
   }
 
   @Test


### PR DESCRIPTION
This patch fixes playback when the download amount is set to sura. It
also relaxes the constraint to only download to the end of the currently
selected sura (instead of the end of the sura on the next page). This
fixes #1376.