### PR TITLE
Show spinner while pages load in page selection

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/pageselect/PageSelectAdapter.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/pageselect/PageSelectAdapter.kt
@@ -6,7 +6,10 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
+import android.widget.ProgressBar
 import android.widget.TextView
+import androidx.viewpager.widget.PagerAdapter
+import androidx.viewpager.widget.ViewPager
 import com.google.android.material.floatingactionbutton.FloatingActionButton
 import com.quran.labs.androidquran.R
 import io.reactivex.Maybe
@@ -17,7 +20,7 @@ import java.lang.ref.WeakReference
 
 class PageSelectAdapter(val inflater: LayoutInflater,
                         val width: Int,
-                        private val selectionHandler: (String) -> Unit) : androidx.viewpager.widget.PagerAdapter() {
+                        private val selectionHandler: (String) -> Unit) : PagerAdapter() {
   private val items : MutableList<PageTypeItem> = mutableListOf()
   private val compositeDisposable = CompositeDisposable()
 
@@ -28,7 +31,7 @@ class PageSelectAdapter(val inflater: LayoutInflater,
     }
   }
 
-  fun replaceItems(updates: List<PageTypeItem>, pager: androidx.viewpager.widget.ViewPager) {
+  fun replaceItems(updates: List<PageTypeItem>, pager: ViewPager) {
     items.clear()
     items.addAll(updates)
     items.forEach {
@@ -52,9 +55,12 @@ class PageSelectAdapter(val inflater: LayoutInflater,
     view.findViewById<FloatingActionButton>(R.id.fab).setOnClickListener(listener)
 
     val image = view.findViewById<ImageView>(R.id.preview)
+    val progressBar = view.findViewById<ProgressBar>(R.id.progress_bar)
     if (data.previewImage != null) {
+      progressBar.visibility = View.GONE
       readImage(data.previewImage.path, WeakReference(image))
     } else {
+      progressBar.visibility = View.VISIBLE
       image.setImageBitmap(null)
     }
   }

--- a/app/src/main/res/layout/page_select_page.xml
+++ b/app/src/main/res/layout/page_select_page.xml
@@ -13,6 +13,14 @@
       android:scaleType="centerCrop"
       />
 
+  <ProgressBar
+      android:id="@+id/progress_bar"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:layout_gravity="center"
+      android:visibility="gone"
+      />
+
   <com.google.android.material.floatingactionbutton.FloatingActionButton
       android:id="@+id/fab"
       android:layout_width="wrap_content"


### PR DESCRIPTION
This patch shows a spinner while the page is loaded, since otherwise, it
would just be blank until it could download the image. This should make
things a bit clearer. Fixes #1432.