### PR TITLE
Target api 29 and migrate for scoped storage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ android:
       - platform-tools
       - build-tools-29.0.2
       - build-tools-28.0.3
-      - android-28
+      - android-29
       - android-22 # required for emulator below
       - extra-android-m2repository
       - sys-img-armeabi-v7a-android-22

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -27,11 +27,10 @@
       android:fullBackupContent="@xml/backup"
       android:networkSecurityConfig="@xml/network_security_config"
       android:supportsRtl="true"
-      android:theme="@style/Quran">
-    <activity
-        android:name=".ui.SheikhAudioManagerActivity"
-        android:theme="@style/Quran"
-        ></activity>
+      android:theme="@style/Quran"
+      android:requestLegacyExternalStorage="true"
+      tools:targetApi="n">
+
     <activity
         android:name=".QuranDataActivity"
         android:label="@string/app_name"
@@ -193,6 +192,8 @@
         android:launchMode="singleInstance"
         android:excludeFromRecents="true"
         android:theme="@style/Theme.AppCompat.Dialog" />
+
+    <activity android:name=".ui.SheikhAudioManagerActivity" />
 
     <!-- override WorkManager initialization -->
     <provider

--- a/app/src/main/java/com/quran/labs/androidquran/util/QuranSettings.java
+++ b/app/src/main/java/com/quran/labs/androidquran/util/QuranSettings.java
@@ -12,6 +12,7 @@ import com.quran.labs.androidquran.R;
 import com.quran.labs.androidquran.data.Constants;
 import com.quran.labs.androidquran.service.QuranDownloadService;
 
+import java.io.File;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
@@ -26,9 +27,9 @@ public class QuranSettings {
 
   private static QuranSettings instance;
 
-  private Context appContext;
-  private SharedPreferences prefs;
-  private SharedPreferences perInstallationPrefs;
+  private final Context appContext;
+  private final SharedPreferences prefs;
+  private final SharedPreferences perInstallationPrefs;
 
   public static synchronized QuranSettings getInstance(@NonNull Context context) {
     if (instance == null) {
@@ -285,7 +286,9 @@ public class QuranSettings {
   }
 
   public String getDefaultLocation() {
-    return Environment.getExternalStorageDirectory().getAbsolutePath();
+    final File externalFilesDir = appContext.getExternalFilesDir(null);
+    return externalFilesDir != null ?
+        externalFilesDir.getAbsolutePath() : null;
   }
 
   public void setAppCustomLocation(String newLocation) {

--- a/app/src/main/res/layout/migration_upgrade.xml
+++ b/app/src/main/res/layout/migration_upgrade.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="150dp"
+    android:orientation="horizontal"
+    android:layout_margin="16dp"
+    >
+
+  <ProgressBar
+      android:id="@+id/progress_bar"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:padding="16dp"
+      android:layout_gravity="center_vertical"
+      />
+
+  <TextView
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:layout_gravity="center_vertical"
+      android:text="@string/please_wait" />
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -39,6 +39,7 @@
   <string name="menu_jump">Jump</string>
   <string name="gotoPage">Go to page</string>
   <string name="cancel">Cancel</string>
+  <string name="please_wait">Please wait…</string>
 
   <!-- about -->
   <string name="about_description">Quran for Android is a free Quran application. Please do not forget the contributors in your prayers.</string>
@@ -411,13 +412,15 @@
   <!-- format strings -->
   <string name="sura_ayah" translatable="false">%1$d:%2$d</string>
 
-  <!-- notification channel names [CHAR LIMIT=40] -->
+  <!-- dual screen prefs -->
   <string name="prefs_category_dual_screen">Dual Page Preferences</string>
-  <string name="notification_channel_download">Quran Downloads</string>
-  <string name="notification_channel_audio">Quran Recitation</string>
   <string name="prefs_quran_on_right_title">Show Quran on right in dual mode</string>
   <string name="prefs_quran_on_right_summary_on">In dual page mode with translations, Quran is shown on the right</string>
   <string name="prefs_quran_on_right_summary_off">In dual page mode with translations, translation is shown on the right</string>
   <string name="prefs_split_page_and_translation_title">Quran and translation in dual mode</string>
   <string name="prefs_split_page_and_translation_summary">In dual page mode with translations, Quran page and translation is shown</string>
+
+  <!-- notification channel names [CHAR LIMIT=40] -->
+  <string name="notification_channel_download">Quran Downloads</string>
+  <string name="notification_channel_audio">Quran Recitation</string>
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -25,8 +25,8 @@ buildscript {
         android: [
             build: [
                 minSdkVersion    : 14,
-                targetSdkVersion : 28,
-                compileSdkVersion: 28
+                targetSdkVersion : 29,
+                compileSdkVersion: 29
             ]
         ],
         dagger: [


### PR DESCRIPTION
In order to target api 29 (which is required for apps to update as of
November 2020), prepare to support scoped storage. This patch changes
the default directory to the application storage directory for the
application. It also attempts to migrate people on apis 29 and above who
are still using the sdcard to the application storage directory. This
should make it easy to target api 30 when necessary. Fixes #1246.
