### PR TITLE
Fix bundled page upgrade and clean up old files

### DIFF
--- a/app/src/madani/java/com/quran/labs/androidquran/data/QuranFileConstants.java
+++ b/app/src/madani/java/com/quran/labs/androidquran/data/QuranFileConstants.java
@@ -21,4 +21,5 @@ public class QuranFileConstants {
 
   // data
   public static final boolean ARE_PAGES_BUNDLED = false;
+  public static final int[] FORCE_DELETE_PAGES = new int[] { };
 }

--- a/app/src/main/java/com/quran/labs/androidquran/presenter/data/QuranDataPresenter.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/presenter/data/QuranDataPresenter.kt
@@ -101,6 +101,9 @@ class QuranDataPresenter @Inject internal constructor(
   private fun copyLocalDataIfNecessary(status: QuranDataStatus): Single<QuranDataStatus> {
     return Single.fromCallable {
       if (!status.havePages() && QuranFileConstants.ARE_PAGES_BUNDLED) {
+        for (widthToDelete in QuranFileConstants.FORCE_DELETE_PAGES) {
+          quranFileUtils.removeFilesForWidth(appContext, widthToDelete)
+        }
         quranFileUtils.copyQuranDataFromAssets(appContext, status.portraitWidth)
         status.copy(havePortrait = true, haveLandscape = true)
       } else {
@@ -245,7 +248,7 @@ class QuranDataPresenter @Inject internal constructor(
   }
 
   private fun actuallyCheckPages(totalPages: Int): Single<QuranDataStatus> {
-    return Single.fromCallable<QuranDataStatus> {
+    return Single.fromCallable {
       val width = quranScreenInfo.widthParam
       val havePortrait = quranFileUtils.haveAllImages(appContext, width, totalPages, true)
 

--- a/app/src/main/java/com/quran/labs/androidquran/util/QuranFileUtils.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/util/QuranFileUtils.kt
@@ -18,14 +18,12 @@ import okhttp3.Request.Builder
 import okhttp3.ResponseBody
 import okio.Buffer
 import okio.ForwardingSource
-import okio.Okio
 import okio.Source
 import okio.buffer
 import okio.sink
 import okio.source
 import timber.log.Timber
 import java.io.File
-import java.io.FileInputStream
 import java.io.FileOutputStream
 import java.io.IOException
 import java.io.InputStream
@@ -94,6 +92,19 @@ class QuranFileUtils @Inject constructor(
       }
     }
     return null
+  }
+
+  fun removeFilesForWidth(context: Context, width: Int) {
+    val widthParam = "_$width"
+    val quranDirectory = getQuranImagesDirectory(context, widthParam) ?: return
+    val file = File(quranDirectory)
+    if (file.exists()) {
+      deleteFileOrDirectory(file)
+      val ayahinfoFile = File(getQuranAyahDatabaseDirectory(context), "ayahinfo_$width.db")
+      if (ayahinfoFile.exists()) {
+        ayahinfoFile.delete()
+      }
+    }
   }
 
   fun copyQuranDataFromAssets(context: Context, widthParam: String) {

--- a/app/src/naskh/java/com/quran/labs/androidquran/data/QuranFileConstants.java
+++ b/app/src/naskh/java/com/quran/labs/androidquran/data/QuranFileConstants.java
@@ -17,4 +17,5 @@ public class QuranFileConstants {
 
   public static final boolean ARABIC_SHARE_TEXT_HAS_BASMALLAH = false;
   public static final boolean ARE_PAGES_BUNDLED = false;
+  public static final int[] FORCE_DELETE_PAGES = new int[] { };
 }

--- a/app/src/qaloon/java/com/quran/labs/androidquran/data/QuranFileConstants.java
+++ b/app/src/qaloon/java/com/quran/labs/androidquran/data/QuranFileConstants.java
@@ -14,4 +14,5 @@ public class QuranFileConstants {
 
   // data
   public static final boolean ARE_PAGES_BUNDLED = false;
+  public static final int[] FORCE_DELETE_PAGES = new int[] { };
 }

--- a/app/src/shemerly/java/com/quran/labs/androidquran/data/QuranFileConstants.java
+++ b/app/src/shemerly/java/com/quran/labs/androidquran/data/QuranFileConstants.java
@@ -20,4 +20,5 @@ public class QuranFileConstants {
 
   // data
   public static final boolean ARE_PAGES_BUNDLED = false;
+  public static final int[] FORCE_DELETE_PAGES = new int[] { };
 }

--- a/app/src/warsh/java/com/quran/labs/androidquran/data/QuranFileConstants.java
+++ b/app/src/warsh/java/com/quran/labs/androidquran/data/QuranFileConstants.java
@@ -14,4 +14,5 @@ public class QuranFileConstants {
 
   // data
   public static final boolean ARE_PAGES_BUNDLED = true;
+  public static final int[] FORCE_DELETE_PAGES = new int[] { 1260 };
 }


### PR DESCRIPTION
For page types that need to be bundled, prpoerly handle the upgrade
(assuming the width parameter is different) and allow for removing the
old set of pages.
