### PR TITLE
Replace jump with go to

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -36,7 +36,7 @@
   <string name="menu_help">Help</string>
   <string name="menu_search">Search</string>
   <string name="menu_get_translations">Get Translations</string>
-  <string name="menu_jump">Jump</string>
+  <string name="menu_jump">@string/gotoPage</string>
   <string name="gotoPage">Go to page</string>
   <string name="cancel">Cancel</string>
   <string name="please_wait">Please wait…</string>


### PR DESCRIPTION
Some people suggested that jump is disrespectful - the intention was not
disrespect, but using go to is probably clearer.
