### PR TITLE
Put page in its place in split translation view

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/data/Constants.java
+++ b/app/src/main/java/com/quran/labs/androidquran/data/Constants.java
@@ -67,8 +67,6 @@ public class Constants {
       "ayahBeforeTranslation";
   public static final String PREF_SPLIT_PAGE_AND_TRANSLATION =
       "splitPageAndTranslation";
-  public static final String PREF_QURAN_ON_RIGHT =
-      "quranOnRight";
   public static final String PREF_PREFER_STREAMING = "preferStreaming";
   public static final String PREF_DOWNLOAD_AMOUNT = "preferredDownloadAmount";
   public static final String PREF_LAST_UPDATED_TRANSLATIONS =

--- a/app/src/main/java/com/quran/labs/androidquran/ui/fragment/TabletFragment.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/fragment/TabletFragment.java
@@ -145,7 +145,7 @@ public class TabletFragment extends Fragment
   }
 
   private void initSplitMode() {
-    isQuranOnRight = quranSettings.isQuranOnRight();
+    isQuranOnRight = pageNumber % 2 == 1;
 
     final int leftPageType = isQuranOnRight ? TabletView.TRANSLATION_PAGE : TabletView.QURAN_PAGE;
     final int rightPageType = isQuranOnRight ? TabletView.QURAN_PAGE : TabletView.TRANSLATION_PAGE;

--- a/app/src/main/java/com/quran/labs/androidquran/util/QuranSettings.java
+++ b/app/src/main/java/com/quran/labs/androidquran/util/QuranSettings.java
@@ -169,10 +169,6 @@ public class QuranSettings {
     return prefs.getBoolean(Constants.PREF_SPLIT_PAGE_AND_TRANSLATION, false);
   }
 
-  public boolean isQuranOnRight() {
-    return prefs.getBoolean(Constants.PREF_QURAN_ON_RIGHT, true);
-  }
-
   public boolean isShowSuraTranslatedName() {
     return prefs.getBoolean(Constants.PREF_SURA_TRANSLATED_NAME,
         appContext.getResources().getBoolean(R.bool.show_sura_names_translation));

--- a/app/src/main/res/values/preferences_keys.xml
+++ b/app/src/main/res/values/preferences_keys.xml
@@ -21,7 +21,6 @@
   <string translatable="false" name="prefs_translation_text_size">translationTextSize</string>
   <string translatable="false" name="prefs_ayah_before_translation">ayahBeforeTranslation</string>
   <string translatable="false" name="prefs_split_page_and_translation">splitPageAndTranslation</string>
-  <string translatable="false" name="prefs_quran_on_right">quranOnRight</string>
   <string translatable="false" name="prefs_prefer_streaming">preferStreaming</string>
   <string translatable="false" name="prefs_download_amount">preferredDownloadAmount</string>
   <string translatable="false" name="prefs_volume_key_navigation">volumeKeyNavigation</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -414,9 +414,6 @@
 
   <!-- dual screen prefs -->
   <string name="prefs_category_dual_screen">Dual Page Preferences</string>
-  <string name="prefs_quran_on_right_title">Show Quran on right in dual mode</string>
-  <string name="prefs_quran_on_right_summary_on">In dual page mode with translations, Quran is shown on the right</string>
-  <string name="prefs_quran_on_right_summary_off">In dual page mode with translations, translation is shown on the right</string>
   <string name="prefs_split_page_and_translation_title">Quran and translation in dual mode</string>
   <string name="prefs_split_page_and_translation_summary">In dual page mode with translations, Quran page and translation is shown</string>
 

--- a/app/src/main/res/xml/quran_preferences.xml
+++ b/app/src/main/res/xml/quran_preferences.xml
@@ -113,6 +113,30 @@
   </PreferenceCategory>
 
   <PreferenceCategory
+      android:key="@string/prefs_category_dual_screen_key"
+      android:title="@string/prefs_category_dual_screen"
+      app:iconSpaceReserved="false">
+
+    <CheckBoxPreference
+        android:defaultValue="@bool/use_tablet_interface_by_default"
+        android:key="@string/prefs_dual_page_enabled"
+        android:persistent="true"
+        android:summaryOff="@string/prefs_dual_page_mode_disabled"
+        android:summaryOn="@string/prefs_dual_page_mode_enabled"
+        android:title="@string/prefs_dual_page_mode_title"
+        app:iconSpaceReserved="false"/>
+
+    <CheckBoxPreference
+        android:defaultValue="false"
+        android:key="@string/prefs_split_page_and_translation"
+        android:persistent="true"
+        android:summary="@string/prefs_split_page_and_translation_summary"
+        android:title="@string/prefs_split_page_and_translation_title"
+        app:iconSpaceReserved="false" />
+
+  </PreferenceCategory>
+
+  <PreferenceCategory
       android:title="@string/prefs_category_translation"
       app:iconSpaceReserved="false">
 
@@ -136,40 +160,6 @@
         android:max="40"
         android:persistent="true"
         android:title="@string/prefs_translation_text_title"/>
-  </PreferenceCategory>
-
-  <PreferenceCategory
-      android:key="@string/prefs_category_dual_screen_key"
-      android:title="@string/prefs_category_dual_screen"
-      app:iconSpaceReserved="false">
-
-    <CheckBoxPreference
-        android:defaultValue="@bool/use_tablet_interface_by_default"
-        android:key="@string/prefs_dual_page_enabled"
-        android:persistent="true"
-        android:summaryOff="@string/prefs_dual_page_mode_disabled"
-        android:summaryOn="@string/prefs_dual_page_mode_enabled"
-        android:title="@string/prefs_dual_page_mode_title"
-        app:iconSpaceReserved="false"/>
-
-    <CheckBoxPreference
-        android:defaultValue="false"
-        android:key="@string/prefs_split_page_and_translation"
-        android:persistent="true"
-        android:summary="@string/prefs_split_page_and_translation_summary"
-        android:title="@string/prefs_split_page_and_translation_title"
-        app:iconSpaceReserved="false" />
-
-    <CheckBoxPreference
-        android:defaultValue="true"
-        android:dependency="@string/prefs_split_page_and_translation"
-        android:key="@string/prefs_quran_on_right"
-        android:persistent="true"
-        android:summaryOff="@string/prefs_quran_on_right_summary_off"
-        android:summaryOn="@string/prefs_quran_on_right_summary_on"
-        android:title="@string/prefs_quran_on_right_title"
-        app:iconSpaceReserved="false" />
-
   </PreferenceCategory>
 
   <PreferenceCategory


### PR DESCRIPTION
In split screen between Quran and translation, leave the Quran page
where it is in the normal mushaf instead of having a preference to pin
it to the left or right. This way, pages match their expected place in
the mushaf instead of being pinned to one side or the other.
