### PR TITLE
Add an all results search suggestion

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/SearchActivity.java
+++ b/app/src/main/java/com/quran/labs/androidquran/SearchActivity.java
@@ -272,6 +272,10 @@ public class SearchActivity extends QuranActionBarActivity
       }
 
       if (id != null) {
+        if (id == -1) {
+          showResults(query);
+          return;
+        }
         int sura = 1;
         int total = id;
         for (int j = 1; j <= 114; j++) {

--- a/app/src/main/java/com/quran/labs/androidquran/data/QuranDataProvider.java
+++ b/app/src/main/java/com/quran/labs/androidquran/data/QuranDataProvider.java
@@ -133,6 +133,7 @@ public class QuranDataProvider extends ContentProvider {
 
     Context context = getContext();
     boolean gotResults = false;
+    boolean likelyHaveMoreResults = false;
     for (int i = start; i < total; i++) {
       if (gotResults) {
         continue;
@@ -160,7 +161,15 @@ public class QuranDataProvider extends ContentProvider {
       try {
         suggestions = search(query, database, false);
         if (context != null && suggestions != null && suggestions.moveToFirst()) {
+          if (suggestions.getCount() > 5) {
+            likelyHaveMoreResults = true;
+          }
+
+          int results = 0;
           do {
+            if (results == 5) {
+              break;
+            }
             int sura = suggestions.getInt(1);
             int ayah = suggestions.getInt(2);
             String text = suggestions.getString(3);
@@ -175,6 +184,7 @@ public class QuranDataProvider extends ContentProvider {
             row.add(text);
             row.add(foundText);
             row.add(id);
+            results++;
           } while (suggestions.moveToNext());
         }
       } finally {
@@ -182,6 +192,12 @@ public class QuranDataProvider extends ContentProvider {
       }
     }
 
+    if (context != null && (queryIsArabic || likelyHaveMoreResults)) {
+      mc.addRow(new Object[] {
+          -1, context.getString(R.string.search_full_results),
+          context.getString(R.string.search_entire_mushaf), -1
+      });
+    }
     return mc;
   }
 

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -50,6 +50,8 @@
 
   <string name="search_hint">بحث في القران</string>
   <string name="quranSearchType">آيات القران</string>
+  <string name="search_full_results">نتائج كاملة</string>
+  <string name="search_entire_mushaf">ابحث في المصحف بأكمله</string>
 
   <plurals name="files_downloaded">
     <item quantity="zero">لم يتم تحميل سور بعد‎</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -132,6 +132,8 @@
     </string>
   <string name="search_hint">Search the Quran</string>
   <string name="quranSearchType">Verses of the Quran</string>
+  <string name="search_full_results">Full Results</string>
+  <string name="search_entire_mushaf">Search the entire mushaf</string>
 
   <plurals name="files_downloaded">
     <item quantity="one">1 surah downloaded</item>

--- a/common/search/src/main/java/com/quran/common/search/DefaultSearcher.kt
+++ b/common/search/src/main/java/com/quran/common/search/DefaultSearcher.kt
@@ -31,7 +31,7 @@ class DefaultSearcher(private val matchStart: String,
   }
 
   override fun getLimit(withSnippets: Boolean): String {
-    return if (withSnippets) { "" } else { "LIMIT 25" }
+    return if (withSnippets) { "" } else { "LIMIT 10" }
   }
 
   override fun processSearchText(searchText: String, hasFTS: Boolean): String {


### PR DESCRIPTION
Improve search suggestions by adding an "all results" search suggestion
result. Because of the way Arabic search works, the search has to be
very broad, and more specific results have to be filtered in code.
Consequently, there's a limit of the first set of results found from the
database (before filtering). Consequently, queries that match many
things in the middle will only return some results instead of all. This
patch updates search suggestions to include an "all results" item to do
a full, unrestricted search.

Fixes #1404.
