### PR TITLE
Stop playback when end reached

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/service/AudioService.java
+++ b/app/src/main/java/com/quran/labs/androidquran/service/AudioService.java
@@ -608,6 +608,8 @@ public class AudioService extends Service implements OnCompletionListener,
             // jump back to the ayah we should repeat and play it
             pos = getSeekPosition(false);
             player.seekTo(pos);
+          } if (!success) {
+            processStopRequest();
           } else {
             playAudio(true);
           }


### PR DESCRIPTION
Certain timing files for suras have an extra "999" entry, after which
audio playback should stop (to remove extra audio at the end of the
file). Unfortunately, instead of stopping once this 999 timestamp was
reached, the audio was restarted. This patch fixes this bug.

Fixes #1482.
