### PR TITLE
Improvements to scoped storage

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/QuranDataActivity.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/QuranDataActivity.kt
@@ -194,8 +194,8 @@ class QuranDataActivity : Activity(), SimpleDownloadListener, OnRequestPermissio
           runListView()
         }
       }
-   } else if (needsPermission && Build.VERSION.SDK_INT > Build.VERSION_CODES.P) {
-      // we need permission (i.e. are writing to the sdcard) on Android 10 (Q) and above
+   } else if (needsPermission && Build.VERSION.SDK_INT > Build.VERSION_CODES.Q) {
+      // we need permission (i.e. are writing to the sdcard) on Android 11 and above
       // we should migrate because when we are required to target Android 11 next year
       // in sha' Allah, we may lose legacy permissions.
       //

--- a/app/src/main/java/com/quran/labs/androidquran/util/StorageUtils.java
+++ b/app/src/main/java/com/quran/labs/androidquran/util/StorageUtils.java
@@ -70,9 +70,12 @@ public class StorageUtils {
         }
 
         int number = 1;
-        result.add(new Storage(context.getString(typeId, number),
-            Environment.getExternalStorageDirectory().getAbsolutePath(),
-            Build.VERSION.SDK_INT >= Build.VERSION_CODES.M));
+        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.Q) {
+          // don't show the /sdcard option for people on Android 11
+          result.add(new Storage(context.getString(typeId, number),
+              Environment.getExternalStorageDirectory().getAbsolutePath(),
+              Build.VERSION.SDK_INT >= Build.VERSION_CODES.M));
+        }
         for (File mountPoint : mountPoints) {
           result.add(new Storage(context.getString(typeId, number++),
               mountPoint.getAbsolutePath()));

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -332,7 +332,7 @@
   <string name="about_quran_enc_summary">الترجمات لعدد من اللغات</string>
   <string name="about_tanzil" translatable="false">تنزيل</string>
   <string name="about_tanzil_summary">ترجمات لبعض اللغات</string>
-  <string name="please_wait">الرجاء الانتظار...</string>
+  <string name="please_wait">الرجاء الانتظار…</string>
   <string name="exported_data">صدرت البيانات إلى %1$s</string>
   <string name="audio_manager_remove_audio_title">حذف الملف الصوتي؟</string>
   <string name="audio_manager_remove_audio_msg">سيتم حذف الملف الصوتي ل%1$s. متأكد؟</string>
@@ -345,5 +345,9 @@
   <string name="please_grant_permissions">رجاء امنح الإذن في الإعدادات</string>
   <string name="about_noorhidayat" translatable="false">نور وهداية (Noorhidayat)</string>
   <string name="kitkat_external_message">بسبب قيود الأندرويد، إذا اخترت تخزين ملفات قرآن على الذاكرة الخارجية ثم مسحت التطبيق أو بيانات قرآن أندرويد، ستحذف جميع صفحات المصحف والصوت ولابد من تحميلها مجددا. هل ترغب في استعمال الذاكرة الخارجية؟</string>
+  <string name="scoped_storage_message">بسبب القيود الجديدة في أندرويد 11، تخزين بيانات التطبيق في
+    مكان غير مجلد التطبيق الافتراضي قد يؤدي إلى عدم تمكن التطبيق من الوصول لملفاته في إصدارات أندرويد
+    القادمة، هل ترغب في نقل البيانات على أية حال؟
+  </string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -247,6 +247,9 @@
         data on your external SD card and later uninstall or clear data for Quran Android, all Quran
         Android pages and audio will be deleted and you will have to download them again. Are you
         sure you want to use the external SD card?</string>
+  <string name="scoped_storage_message">Due to Android changes to increase user privacy, copying
+    files outside of the app directories might stop Quran from accessing its data in future versions
+    of Android. Are you sure you\'d like to use this path?</string>
   <string name="please_grant_permissions">Please grant permission in application settings</string>
   <!-- Preferences End -->
 


### PR DESCRIPTION
This patch updates scoped storage, making the following changes:
1. only force copying on Android 11 (sdk 30) and above. Before, this was
   also enabled for Android 10 (sdk 29).
2. disable the advanced settings move option to copy to /sdcard on
   Android 30 and above (since it doesn't make sense anymore).
3. warn people on Android 29 when they try to explicitly use /sdcard
   that data might not remain accessible on future Android versions.
4. show warning before asking for external sdcard permissions if
   required.

Fixes #1478.
