### PR TITLE
Improve highlighting behavior in translation view

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/presenter/audio/AudioPresenter.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/presenter/audio/AudioPresenter.kt
@@ -49,7 +49,7 @@ constructor(private val quranDisplayData: QuranDisplayData,
         audioPathInfo
       }
 
-      val (actualStart, actualEnd) = if (start < end) {
+      val (actualStart, actualEnd) = if (start <= end) {
         start to end
       } else {
         Timber.e(

--- a/app/src/main/java/com/quran/labs/androidquran/presenter/quran/ayahtracker/AyahTranslationTrackerItem.java
+++ b/app/src/main/java/com/quran/labs/androidquran/presenter/quran/ayahtracker/AyahTranslationTrackerItem.java
@@ -26,17 +26,17 @@ public class AyahTranslationTrackerItem extends AyahTrackerItem {
   @Override
   boolean onHighlightAyah(int page, int sura, int ayah, HighlightType type, boolean scrollToAyah) {
     if (this.page == page) {
-      ayahView.highlightAyah(new SuraAyah(sura, ayah), quranInfo.getAyahId(sura, ayah));
+      ayahView.highlightAyah(new SuraAyah(sura, ayah), quranInfo.getAyahId(sura, ayah), type);
       return true;
     }
-    ayahView.unhighlightAyat();
+    ayahView.unhighlightAyah(type);
     return false;
   }
 
   @Override
   void onUnHighlightAyah(int page, int sura, int ayah, HighlightType type) {
     if (this.page == page) {
-      ayahView.unhighlightAyat();
+      ayahView.unhighlightAyah(type);
     }
   }
 

--- a/app/src/main/java/com/quran/labs/androidquran/service/AudioService.java
+++ b/app/src/main/java/com/quran/labs/androidquran/service/AudioService.java
@@ -1318,7 +1318,11 @@ public class AudioService extends Service implements OnCompletionListener,
     compositeDisposable.clear();
     // Service is being killed, so make sure we release our resources
     serviceHandler.removeCallbacksAndMessages(null);
-    serviceLooper.quit();
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
+      serviceLooper.quitSafely();
+    } else {
+      serviceLooper.quit();
+    }
     unregisterReceiver(noisyAudioStreamReceiver);
     state = State.Stopped;
     relaxResources(true, true);

--- a/app/src/main/java/com/quran/labs/androidquran/ui/fragment/TranslationFragment.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/fragment/TranslationFragment.java
@@ -39,12 +39,9 @@ public class TranslationFragment extends Fragment implements
     TranslationPresenter.TranslationScreen, PageController {
   private static final String PAGE_NUMBER_EXTRA = "pageNumber";
 
-  private static final String SI_PAGE_NUMBER = "SI_PAGE_NUMBER";
-  private static final String SI_HIGHLIGHTED_AYAH = "SI_HIGHLIGHTED_AYAH";
   private static final String SI_SCROLL_POSITION = "SI_SCROLL_POSITION";
 
   private int pageNumber;
-  private int highlightedAyah;
   private int scrollPosition;
 
   private TranslationView translationView;
@@ -71,14 +68,6 @@ public class TranslationFragment extends Fragment implements
     super.onCreate(savedInstanceState);
 
     if (savedInstanceState != null) {
-      int page = savedInstanceState.getInt(SI_PAGE_NUMBER, -1);
-      if (page == pageNumber) {
-        int highlightedAyah =
-            savedInstanceState.getInt(SI_HIGHLIGHTED_AYAH, -1);
-        if (highlightedAyah > 0) {
-          this.highlightedAyah = highlightedAyah;
-        }
-      }
       scrollPosition = savedInstanceState.getInt(SI_SCROLL_POSITION);
     }
     setHasOptionsMenu(true);
@@ -156,10 +145,6 @@ public class TranslationFragment extends Fragment implements
                         @NonNull LocalTranslation[] translations,
                         @NonNull List<QuranAyahInfo> verses) {
     translationView.setVerses(quranDisplayData, translations, verses);
-    if (highlightedAyah > 0) {
-      translationView.highlightAyah(quranInfo.getSuraAyahFromAyahId(highlightedAyah),
-          highlightedAyah);
-    }
   }
 
   @Override
@@ -173,9 +158,6 @@ public class TranslationFragment extends Fragment implements
 
   @Override
   public void onSaveInstanceState(@NonNull Bundle outState) {
-    if (highlightedAyah > 0) {
-      outState.putInt(SI_HIGHLIGHTED_AYAH, highlightedAyah);
-    }
     scrollPosition = translationView.findFirstCompletelyVisibleItemPosition();
     outState.putInt(SI_SCROLL_POSITION, scrollPosition);
     super.onSaveInstanceState(outState);

--- a/app/src/main/java/com/quran/labs/androidquran/ui/translation/TranslationAdapter.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/translation/TranslationAdapter.kt
@@ -60,13 +60,14 @@ internal class TranslationAdapter(private val context: Context,
       val highlightedEndPosition = highlightedStartPosition + highlightedRowCount
 
       // find the row with the verse number
-      val versePosition = (highlightedStartPosition until highlightedEndPosition)
-          .firstOrNull { data[it].type == TranslationViewRow.Type.VERSE_NUMBER }
+      val versePosition = data.withIndex().firstOrNull {
+        it.index in highlightedStartPosition until highlightedEndPosition &&
+            it.value.type == TranslationViewRow.Type.VERSE_NUMBER }
 
       // find out where to position the popup based on the center of the box
       versePosition?.let {
         val viewHolder =
-            recyclerView.findViewHolderForAdapterPosition(versePosition) as RowViewHolder?
+            recyclerView.findViewHolderForAdapterPosition(versePosition.index) as RowViewHolder?
         viewHolder?.ayahNumber?.let { ayahNumberView ->
           val x = (ayahNumberView.left + ayahNumberView.boxCenterX)
           val y = (ayahNumberView.top + ayahNumberView.boxBottomY)

--- a/app/src/main/java/com/quran/labs/androidquran/ui/translation/TranslationView.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/translation/TranslationView.java
@@ -15,6 +15,7 @@ import com.quran.labs.androidquran.common.LocalTranslation;
 import com.quran.labs.androidquran.common.QuranAyahInfo;
 import com.quran.labs.androidquran.common.TranslationMetadata;
 import com.quran.labs.androidquran.data.QuranDisplayData;
+import com.quran.labs.androidquran.ui.helpers.HighlightType;
 import com.quran.labs.androidquran.ui.util.PageController;
 import com.quran.labs.androidquran.util.QuranSettings;
 
@@ -165,13 +166,24 @@ public class TranslationView extends FrameLayout implements View.OnClickListener
     onClickListener = listener;
   }
 
-  public void highlightAyah(SuraAyah suraAyah, int ayahId) {
-    selectedAyah = suraAyah;
-    translationAdapter.setHighlightedAyah(ayahId);
+  public void highlightAyah(SuraAyah suraAyah, int ayahId, HighlightType highlightType) {
+    if (highlightType == HighlightType.SELECTION) {
+      selectedAyah = suraAyah;
+    } else if (selectedAyah != null) {
+      hideMenu();
+    }
+    translationAdapter.setHighlightedAyah(ayahId, highlightType);
   }
 
   private void hideMenu() {
     pageController.endAyahMode();
+  }
+
+  public void unhighlightAyah(HighlightType highlightType) {
+    if (highlightType == HighlightType.SELECTION) {
+      selectedAyah = null;
+    }
+    translationAdapter.unhighlight();
   }
 
   public void unhighlightAyat() {
@@ -248,9 +260,14 @@ public class TranslationView extends FrameLayout implements View.OnClickListener
   @Override
   public void onVerseSelected(@NonNull QuranAyahInfo ayahInfo) {
     final SuraAyah suraAyah = new SuraAyah(ayahInfo.sura, ayahInfo.ayah);
-    if (selectedAyah != null && !selectedAyah.equals(suraAyah)) {
+    if (selectedAyah != null) {
+      final boolean isUnselectingSelectedVerse = selectedAyah.equals(suraAyah);
       hideMenu();
+      if (isUnselectingSelectedVerse) {
+        return;
+      }
     }
+
     pageController.handleLongPress(suraAyah);
     pageController.requestMenuPositionUpdate();
   }

--- a/app/src/main/java/com/quran/labs/androidquran/util/ImageUtil.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/util/ImageUtil.kt
@@ -7,11 +7,15 @@ import okio.buffer
 import okio.sink
 import okio.source
 import java.io.File
+import java.io.InterruptedIOException
 import javax.inject.Inject
 
 class ImageUtil @Inject constructor(private val okHttpClient: OkHttpClient) {
 
-  fun downloadImage(url: String, outputPath: File): Maybe<File> {
+  fun downloadImage(
+    url: String,
+    outputPath: File
+  ): Maybe<File> {
     return Maybe.fromCallable {
       if (!outputPath.exists()) {
         val destination = File(outputPath.path + ".tmp")
@@ -19,25 +23,42 @@ class ImageUtil @Inject constructor(private val okHttpClient: OkHttpClient) {
             .url(url)
             .build()
         val call = okHttpClient.newCall(request)
+
         val response = call.execute()
 
         if (response.isSuccessful) {
-          // save the png from the download to a temporary file
-          response.body()?.source()?.use { source ->
-            destination.sink().buffer().use { destination ->
-              destination.writeAll(source)
-            }
-          }
+          try {
+            // save the png from the download to a temporary file
+            response.body()
+                ?.source()
+                ?.use { source ->
+                  destination.sink()
+                      .buffer()
+                      .use { destination ->
+                        destination.writeAll(source)
+                      }
+                }
 
-          // and write it to the normal file
-          destination.source().use { source ->
-            outputPath.sink().buffer().use { destination ->
-              destination.writeAll(source)
-            }
-          }
+            // and write it to the normal file
+            destination.source()
+                .use { source ->
+                  outputPath.sink()
+                      .buffer()
+                      .use { destination ->
+                        destination.writeAll(source)
+                      }
+                }
 
-          // and delete the old one
-          destination.delete()
+            // and delete the old one
+            destination.delete()
+          } catch (interruptedIoException: InterruptedIOException) {
+            // if we're interrupted, pretend nothing happened. This happened
+            // due to a dispose / cancellation. Maybe's fromCallable will not
+            // actually emit in this case.
+            //
+            // a more proper fix would probably be to use Maybe.create and
+            // set a cancellation handler to stop the network call.
+          }
         }
       }
       outputPath

--- a/app/src/main/java/com/quran/labs/androidquran/view/HighlightingImageView.java
+++ b/app/src/main/java/com/quran/labs/androidquran/view/HighlightingImageView.java
@@ -241,7 +241,12 @@ public class HighlightingImageView extends AppCompatImageView {
 
     // yes we make copies, because normalizing the bounds will change them
     List<AyahBounds> sourceBounds = new ArrayList<>(startingBounds);
-    List<AyahBounds> destinationBounds = new ArrayList<>(highlightCoordinates.get(destinationHighlight));
+
+    List<AyahBounds> destinationBounds = new ArrayList<>();
+    final List<AyahBounds> source = highlightCoordinates.get(destinationHighlight);
+    if (source != null) {
+      destinationBounds.addAll(source);
+    }
 
     highlights.clear();
     highlights.add(transitionHighlight);


### PR DESCRIPTION
This patch:
- treats audio highlights differently than selection highlights (though
both aren't enabled at the same time yet). This allows audio
highlighting to not show a menu, and clicking an ayah to not highlight
that ayah unless we're already in selection mode.
- clear selection mode when audio highlight overwrites selection
highlight, and when long pressing an already selected ayah.