### PR TITLE
Fix popup not showing up in translations

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/ui/PagerActivity.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/PagerActivity.java
@@ -1051,6 +1051,9 @@ public class PagerActivity extends QuranActionBarActivity implements
   }
 
   private void switchToQuran() {
+    if (isInAyahMode) {
+      endAyahMode();
+    }
     final int page = getCurrentPage();
     pagerAdapter.setQuranMode();
     showingTranslation = false;

--- a/app/src/main/java/com/quran/labs/androidquran/ui/helpers/QuranPageAdapter.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/helpers/QuranPageAdapter.java
@@ -16,7 +16,7 @@ import timber.log.Timber;
 public class QuranPageAdapter extends FragmentStatePagerAdapter {
 
   private boolean isShowingTranslation;
-  private boolean isDualPages;
+  private final boolean isDualPages;
   private final boolean isSplitScreen;
   private final QuranInfo quranInfo;
   private final int totalPages;

--- a/app/src/main/java/com/quran/labs/androidquran/ui/translation/TranslationView.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/translation/TranslationView.java
@@ -232,7 +232,12 @@ public class TranslationView extends FrameLayout implements View.OnClickListener
   public AyahToolBar.AyahToolBarPosition getToolbarPosition() {
     int[] versePopupPosition = translationAdapter.getSelectedVersePopupPosition();
     if (versePopupPosition != null) {
-      final int xOffset = ((View) getParent()).getLeft();
+      // for dual screen tablet mode, we need to add the view's x (so clicks on the
+      // right page properly show on the right page and not on the left one).
+      final int[] positionOnScreen = new int[2];
+      getLocationOnScreen(positionOnScreen);
+      final int xOffset = positionOnScreen[0];
+
       AyahToolBar.AyahToolBarPosition position = new AyahToolBar.AyahToolBarPosition();
       position.x = xOffset + versePopupPosition[0];
       position.y = versePopupPosition[1];
@@ -266,6 +271,10 @@ public class TranslationView extends FrameLayout implements View.OnClickListener
       if (isUnselectingSelectedVerse) {
         return;
       }
+    } else {
+      // hide the menu because the previous page might have had
+      // something selected here (which would break selection).
+      hideMenu();
     }
 
     pageController.handleLongPress(suraAyah);


### PR DESCRIPTION
The ayah popup was often rendered off the screen, and thus not visible.
This occurred due to the offset being added to handle two pages side by
side being incorrect when there was only a single page.

Fixes #1053.
