### PR TITLE
Fix repeat sometimes stopping at end of file

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/service/AudioService.java
+++ b/app/src/main/java/com/quran/labs/androidquran/service/AudioService.java
@@ -1093,11 +1093,19 @@ public class AudioService extends Service implements OnCompletionListener,
     } else {
       final int beforeSura = audioQueue.getCurrentSura();
       if (audioQueue.playNextAyah(false)) {
-        // we actually switched to a different ayah - so if the
-        // sura changed, then play the basmala if the ayah is
-        // not the first one (or if we're in sura tawba).
-        boolean flag = beforeSura != audioQueue.getCurrentSura();
-        playAudio(flag);
+        if (audioRequest != null &&
+            audioRequest.isGapless() &&
+            beforeSura == audioQueue.getCurrentSura()) {
+          // we're actually repeating, but we reached the end of the file before we could
+          // seek to the proper place. so let's seek anyway.
+          player.seekTo(gaplessSuraData.get(audioQueue.getCurrentAyah()));
+        } else {
+          // we actually switched to a different ayah - so if the
+          // sura changed, then play the basmala if the ayah is
+          // not the first one (or if we're in sura tawba).
+          boolean flag = beforeSura != audioQueue.getCurrentSura();
+          playAudio(flag);
+        }
       } else {
         processStopRequest(true);
       }


### PR DESCRIPTION
Gapless files sometimes have a 999 entry, and sometimes don't. When they
don't, playback continues until the end of the file. If a file doesn't
have a 999 entry, it's possible for the file to end before a seek
happens, and for the seek to happen when we're trying to replay the file
insted of seek. This causes an error and causes the playback to stop.

This patch works around this by properly seeking if the end of file is
reached in a gapless file (instead of trying to re-play).
