### PR TITLE
Make internal storage the default directory

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/ui/fragment/QuranAdvancedSettingsFragment.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/fragment/QuranAdvancedSettingsFragment.java
@@ -187,7 +187,7 @@ public class QuranAdvancedSettingsFragment extends PreferenceFragmentCompat {
 
     // Hide app location pref if there is no storage option
     // except for the normal Environment.getExternalStorageDirectory
-    if (storageList == null || storageList.size() <= 1) {
+    if (storageList.size() <= 1) {
       Timber.d("removing advanced settings from preferences");
       hideStorageListPref();
     } else {
@@ -256,7 +256,7 @@ public class QuranAdvancedSettingsFragment extends PreferenceFragmentCompat {
 
       listStoragePref
           .setOnPreferenceChangeListener((preference, newValue) -> {
-            final Context context1 = getActivity();
+            final Context context1 = requireActivity();
             final QuranSettings settings = QuranSettings.getInstance(context1);
 
             if (TextUtils.isEmpty(settings.getAppCustomLocation()) &&

--- a/app/src/main/java/com/quran/labs/androidquran/util/QuranSettings.java
+++ b/app/src/main/java/com/quran/labs/androidquran/util/QuranSettings.java
@@ -285,9 +285,7 @@ public class QuranSettings {
   }
 
   public String getDefaultLocation() {
-    final File externalFilesDir = appContext.getExternalFilesDir(null);
-    return externalFilesDir != null ?
-        externalFilesDir.getAbsolutePath() : null;
+    return appContext.getFilesDir().getAbsolutePath();
   }
 
   public void setAppCustomLocation(String newLocation) {

--- a/app/src/main/java/com/quran/labs/androidquran/util/StorageUtils.java
+++ b/app/src/main/java/com/quran/labs/androidquran/util/StorageUtils.java
@@ -62,24 +62,27 @@ public class StorageUtils {
       int limit = Build.VERSION.SDK_INT >= Build.VERSION_CODES.M ? 1 : 2;
       final File[] mountPoints = ContextCompat.getExternalFilesDirs(context, null);
       if (mountPoints.length >= limit) {
-        int typeId;
-        if (!Environment.isExternalStorageRemovable() || Environment.isExternalStorageEmulated()) {
-          typeId = R.string.prefs_sdcard_internal;
-        } else {
-          typeId = R.string.prefs_sdcard_external;
-        }
+
+        // internal files dir
+        result.add(
+            new Storage(context.getString(R.string.prefs_sdcard_internal),
+                context.getFilesDir().getAbsolutePath()));
+
+        // all of these are "external" files dir or related
 
         int number = 1;
+        // this first one is not safe to write on starting from Android 11 - /sdcard.
         if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.Q) {
           // don't show the /sdcard option for people on Android 11
-          result.add(new Storage(context.getString(typeId, number),
+          result.add(new Storage(context.getString(R.string.prefs_sdcard_external, number++),
               Environment.getExternalStorageDirectory().getAbsolutePath(),
               Build.VERSION.SDK_INT >= Build.VERSION_CODES.M));
         }
+
+        // add all the remaining places
         for (File mountPoint : mountPoints) {
-          result.add(new Storage(context.getString(typeId, number++),
+          result.add(new Storage(context.getString(R.string.prefs_sdcard_external, number++),
               mountPoint.getAbsolutePath()));
-          typeId = R.string.prefs_sdcard_external;
         }
       }
       return result;
@@ -128,17 +131,16 @@ public class StorageUtils {
   private static List<Storage> buildMountsList(Context context, List<String> mounts) {
     List<Storage> list = new ArrayList<>(mounts.size());
 
-    int externalSdcardsCount = 0;
+    int externalSdcardsCount;
     if (mounts.size() > 0) {
-      // Follow Android SD Cards naming conventions
-      if (!Environment.isExternalStorageRemovable() || Environment.isExternalStorageEmulated()) {
-        list.add(new Storage(context.getString(R.string.prefs_sdcard_internal),
-            Environment.getExternalStorageDirectory().getAbsolutePath()));
-      } else {
-        externalSdcardsCount = 1;
-        list.add(new Storage(context.getString(R.string.prefs_sdcard_external,
-            externalSdcardsCount), mounts.get(0)));
-      }
+      // internal files dir
+      list.add(
+          new Storage(context.getString(R.string.prefs_sdcard_internal),
+              context.getFilesDir().getAbsolutePath()));
+
+      externalSdcardsCount = 1;
+      list.add(new Storage(context.getString(R.string.prefs_sdcard_external,
+          externalSdcardsCount), mounts.get(0)));
 
       // All other mounts rather than the first mount point are considered as External SD Card
       if (mounts.size() > 1) {

--- a/app/src/main/res/layout/preferences.xml
+++ b/app/src/main/res/layout/preferences.xml
@@ -4,7 +4,8 @@
     android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:id="@+id/root">
+    android:id="@+id/root"
+    android:keepScreenOn="true">
     <androidx.appcompat.widget.Toolbar
         android:id="@+id/toolbar"
         android:layout_width="match_parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -205,7 +205,7 @@
   <string name="prefs_send_logs_title">Send logs</string>
   <string name="prefs_send_logs_summary">Send debug logs to the developer</string>
   <string name="prefs_sdcard_internal">Internal storage</string>
-  <string name="prefs_sdcard_external">External SD card %1$d</string>
+  <string name="prefs_sdcard_external">External storage %1$d</string>
   <string name="prefs_app_size">Current data size is</string>
   <string name="prefs_calculating_app_size">Calculating App Size</string>
   <string name="prefs_copying_app_files">Copying App files</string>


### PR DESCRIPTION
This patch makes internal storage the default directory for Quran for
any new installations. This is because it seems that some third party
phones have software that erases files in external storage to save space
for people (Xiaomi, Oppo, etc). Moreover, people often download sd card
cleaning apps that often delete data from the sdcard injudiciously.
