### PR TITLE
Use NumberPicker for Range and Verse Repeat Selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,4 @@ Please keep use of this code for non-profit purposes only. Also, please note tha
 * [Dagger2](https://google.github.io/dagger/)
 * [Timber](https://github.com/JakeWharton/timber)
 * [dnsjava](http://dnsjava.org)
+* [NumberPicker](https://github.com/ShawnLin013/NumberPicker)

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -176,4 +176,7 @@ dependencies {
   errorprone 'com.google.errorprone:error_prone_core:2.3.3'
   //noinspection GradleDynamicVersion
   errorproneJavac("com.google.errorprone:javac:9+181-r4173-1")
+
+  // Number Picker
+  implementation 'com.shawnlin:number-picker:2.4.11'
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,7 +16,7 @@
   <uses-feature android:name="android.hardware.touchscreen" android:required="false" />
 
   <!-- minSdk 15 vs 14 - really doesn't matter tbh since no one uses 14 at all, but  ¯\_(ツ)_/¯ -->
-  <uses-sdk tools:overrideLibrary="timber.log, dev.chrisbanes.insetter, dev.chrisbanes.insetter.ktx, com.google.firebase.crashlytics"/>
+  <uses-sdk tools:overrideLibrary="timber.log, dev.chrisbanes.insetter, dev.chrisbanes.insetter.ktx, com.google.firebase.crashlytics, com.shawnlin.numberpicker"/>
 
   <application
       android:icon="@drawable/icon"

--- a/app/src/main/res/layout-ar-land-v17/audio_panel.xml
+++ b/app/src/main/res/layout-ar-land-v17/audio_panel.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
              android:layout_width="match_parent"
              android:layout_height="match_parent"
              android:paddingLeft="12dp"
@@ -86,7 +87,6 @@
       <LinearLayout
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
-          android:layout_marginBottom="12dp"
           android:orientation="horizontal"
           >
         <TextView
@@ -96,17 +96,30 @@
             android:text="@string/play_verses_range"
             android:textAppearance="@style/PanelLabel"
             />
-        <com.quran.labs.androidquran.view.QuranSpinner
-            android:id="@+id/repeat_range_spinner"
+        <com.shawnlin.numberpicker.NumberPicker
+            android:id="@+id/repeat_range_picker"
             android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
+            android:layout_height="40dp"
+            android:layout_centerInParent="true"
+            app:np_orientation="horizontal"
+            app:np_width="135dp"
+            app:np_height="48dp"
+            app:np_max="99"
+            app:np_value="7"
+            app:np_min="1"
+            app:np_textSize="27sp"
+            app:np_selectedTextSize="33sp"
+            app:np_selectedTextColor="@color/panel_label"
+            app:np_dividerColor="@color/panel_label"
+            app:np_dividerType="underline"
+            app:np_fadingEdgeEnabled="true"
+            app:np_wrapSelectorWheel="true"
             />
       </LinearLayout>
 
       <LinearLayout
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
-          android:layout_marginBottom="12dp"
           android:orientation="horizontal"
           >
         <TextView
@@ -116,10 +129,24 @@
             android:text="@string/play_each_verse"
             android:textAppearance="@style/PanelLabel"
             />
-        <com.quran.labs.androidquran.view.QuranSpinner
-            android:id="@+id/repeat_verse_spinner"
+        <com.shawnlin.numberpicker.NumberPicker
+            android:id="@+id/repeat_verse_picker"
             android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
+            android:layout_height="40dp"
+            android:layout_centerInParent="true"
+            app:np_orientation="horizontal"
+            app:np_width="135dp"
+            app:np_height="48dp"
+            app:np_max="99"
+            app:np_value="3"
+            app:np_min="1"
+            app:np_textSize="27sp"
+            app:np_selectedTextSize="33sp"
+            app:np_selectedTextColor="@color/panel_label"
+            app:np_dividerColor="@color/panel_label"
+            app:np_dividerType="underline"
+            app:np_fadingEdgeEnabled="true"
+            app:np_wrapSelectorWheel="true"
             />
       </LinearLayout>
 

--- a/app/src/main/res/layout-ar-land/audio_panel.xml
+++ b/app/src/main/res/layout-ar-land/audio_panel.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
              android:layout_width="match_parent"
              android:layout_height="match_parent"
     >
@@ -89,14 +90,27 @@
       <LinearLayout
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
-          android:layout_marginBottom="16dp"
           android:orientation="horizontal"
           android:layout_gravity="end"
           >
-        <com.quran.labs.androidquran.view.QuranSpinner
-            android:id="@+id/repeat_range_spinner"
+        <com.shawnlin.numberpicker.NumberPicker
+            android:id="@+id/repeat_range_picker"
             android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
+            android:layout_height="40dp"
+            android:layout_centerInParent="true"
+            app:np_orientation="horizontal"
+            app:np_width="135dp"
+            app:np_height="48dp"
+            app:np_max="99"
+            app:np_value="7"
+            app:np_min="1"
+            app:np_textSize="27sp"
+            app:np_selectedTextSize="33sp"
+            app:np_selectedTextColor="@color/panel_label"
+            app:np_dividerColor="@color/panel_label"
+            app:np_dividerType="underline"
+            app:np_fadingEdgeEnabled="true"
+            app:np_wrapSelectorWheel="true"
             />
         <TextView
             android:layout_width="wrap_content"
@@ -110,14 +124,27 @@
       <LinearLayout
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
-          android:layout_marginBottom="16dp"
           android:orientation="horizontal"
           android:layout_gravity="end"
           >
-        <com.quran.labs.androidquran.view.QuranSpinner
-            android:id="@+id/repeat_verse_spinner"
+        <com.shawnlin.numberpicker.NumberPicker
+            android:id="@+id/repeat_verse_picker"
             android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
+            android:layout_height="40dp"
+            android:layout_centerInParent="true"
+            app:np_orientation="horizontal"
+            app:np_width="135dp"
+            app:np_height="48dp"
+            app:np_max="99"
+            app:np_value="3"
+            app:np_min="1"
+            app:np_textSize="27sp"
+            app:np_selectedTextSize="33sp"
+            app:np_selectedTextColor="@color/panel_label"
+            app:np_dividerColor="@color/panel_label"
+            app:np_dividerType="underline"
+            app:np_fadingEdgeEnabled="true"
+            app:np_wrapSelectorWheel="true"
             />
         <TextView
             android:layout_width="wrap_content"

--- a/app/src/main/res/layout-ar-v17/audio_panel.xml
+++ b/app/src/main/res/layout-ar-v17/audio_panel.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:fadeScrollbars="false"
@@ -64,7 +65,6 @@
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginBottom="12dp"
         android:orientation="horizontal"
         >
       <TextView
@@ -74,17 +74,30 @@
           android:text="@string/play_verses_range"
           android:textAppearance="@style/PanelLabel"
           />
-      <com.quran.labs.androidquran.view.QuranSpinner
-          android:id="@+id/repeat_range_spinner"
+      <com.shawnlin.numberpicker.NumberPicker
+          android:id="@+id/repeat_range_picker"
           android:layout_width="wrap_content"
-          android:layout_height="wrap_content"
+          android:layout_height="40dp"
+          android:layout_centerInParent="true"
+          app:np_orientation="horizontal"
+          app:np_width="135dp"
+          app:np_height="48dp"
+          app:np_max="99"
+          app:np_value="7"
+          app:np_min="1"
+          app:np_textSize="27sp"
+          app:np_selectedTextSize="33sp"
+          app:np_selectedTextColor="@color/panel_label"
+          app:np_dividerColor="@color/panel_label"
+          app:np_dividerType="underline"
+          app:np_fadingEdgeEnabled="true"
+          app:np_wrapSelectorWheel="true"
           />
     </LinearLayout>
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginBottom="12dp"
         android:orientation="horizontal"
         >
       <TextView
@@ -94,10 +107,24 @@
           android:text="@string/play_each_verse"
           android:textAppearance="@style/PanelLabel"
           />
-      <com.quran.labs.androidquran.view.QuranSpinner
-          android:id="@+id/repeat_verse_spinner"
+      <com.shawnlin.numberpicker.NumberPicker
+          android:id="@+id/repeat_verse_picker"
           android:layout_width="wrap_content"
-          android:layout_height="wrap_content"
+          android:layout_height="40dp"
+          android:layout_centerInParent="true"
+          app:np_orientation="horizontal"
+          app:np_width="135dp"
+          app:np_height="48dp"
+          app:np_max="99"
+          app:np_value="3"
+          app:np_min="1"
+          app:np_textSize="27sp"
+          app:np_selectedTextSize="33sp"
+          app:np_selectedTextColor="@color/panel_label"
+          app:np_dividerColor="@color/panel_label"
+          app:np_dividerType="underline"
+          app:np_fadingEdgeEnabled="true"
+          app:np_wrapSelectorWheel="true"
           />
     </LinearLayout>
 

--- a/app/src/main/res/layout-ar/audio_panel.xml
+++ b/app/src/main/res/layout-ar/audio_panel.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:fadeScrollbars="false"
@@ -66,14 +67,27 @@
     <LinearLayout
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginBottom="12dp"
         android:layout_gravity="end"
         android:orientation="horizontal"
         >
-      <com.quran.labs.androidquran.view.QuranSpinner
-          android:id="@+id/repeat_range_spinner"
+      <com.shawnlin.numberpicker.NumberPicker
+          android:id="@+id/repeat_range_picker"
           android:layout_width="wrap_content"
-          android:layout_height="wrap_content"
+          android:layout_height="40dp"
+          android:layout_centerInParent="true"
+          app:np_orientation="horizontal"
+          app:np_width="135dp"
+          app:np_height="48dp"
+          app:np_max="99"
+          app:np_value="7"
+          app:np_min="1"
+          app:np_textSize="27sp"
+          app:np_selectedTextSize="33sp"
+          app:np_selectedTextColor="@color/panel_label"
+          app:np_dividerColor="@color/panel_label"
+          app:np_dividerType="underline"
+          app:np_fadingEdgeEnabled="true"
+          app:np_wrapSelectorWheel="true"
           />
       <TextView
           android:layout_width="wrap_content"
@@ -87,14 +101,27 @@
     <LinearLayout
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginBottom="12dp"
         android:layout_gravity="end"
         android:orientation="horizontal"
         >
-      <com.quran.labs.androidquran.view.QuranSpinner
-          android:id="@+id/repeat_verse_spinner"
+      <com.shawnlin.numberpicker.NumberPicker
+          android:id="@+id/repeat_verse_picker"
           android:layout_width="wrap_content"
-          android:layout_height="wrap_content"
+          android:layout_height="40dp"
+          android:layout_centerInParent="true"
+          app:np_orientation="horizontal"
+          app:np_width="135dp"
+          app:np_height="48dp"
+          app:np_max="99"
+          app:np_value="3"
+          app:np_min="1"
+          app:np_textSize="27sp"
+          app:np_selectedTextSize="33sp"
+          app:np_selectedTextColor="@color/panel_label"
+          app:np_dividerColor="@color/panel_label"
+          app:np_dividerType="underline"
+          app:np_fadingEdgeEnabled="true"
+          app:np_wrapSelectorWheel="true"
           />
       <TextView
           android:layout_width="wrap_content"

--- a/app/src/main/res/layout-land/audio_panel.xml
+++ b/app/src/main/res/layout-land/audio_panel.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
              android:layout_width="match_parent"
              android:layout_height="match_parent"
              android:paddingLeft="12dp"
@@ -86,7 +87,6 @@
       <LinearLayout
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
-          android:layout_marginBottom="12dp"
           android:orientation="horizontal"
           >
         <TextView
@@ -96,17 +96,30 @@
             android:text="@string/play_verses_range"
             android:textAppearance="@style/PanelLabel"
             />
-        <com.quran.labs.androidquran.view.QuranSpinner
-            android:id="@+id/repeat_range_spinner"
+        <com.shawnlin.numberpicker.NumberPicker
+            android:id="@+id/repeat_range_picker"
             android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
+            android:layout_height="40dp"
+            android:layout_centerInParent="true"
+            app:np_orientation="horizontal"
+            app:np_width="135dp"
+            app:np_height="48dp"
+            app:np_max="99"
+            app:np_value="7"
+            app:np_min="1"
+            app:np_textSize="27sp"
+            app:np_selectedTextSize="33sp"
+            app:np_selectedTextColor="@color/panel_label"
+            app:np_dividerColor="@color/panel_label"
+            app:np_dividerType="underline"
+            app:np_fadingEdgeEnabled="true"
+            app:np_wrapSelectorWheel="true"
             />
       </LinearLayout>
 
       <LinearLayout
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
-          android:layout_marginBottom="12dp"
           android:orientation="horizontal"
           >
         <TextView
@@ -116,10 +129,24 @@
             android:text="@string/play_each_verse"
             android:textAppearance="@style/PanelLabel"
             />
-        <com.quran.labs.androidquran.view.QuranSpinner
-            android:id="@+id/repeat_verse_spinner"
+        <com.shawnlin.numberpicker.NumberPicker
+            android:id="@+id/repeat_verse_picker"
             android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
+            android:layout_height="40dp"
+            android:layout_centerInParent="true"
+            app:np_orientation="horizontal"
+            app:np_width="135dp"
+            app:np_height="48dp"
+            app:np_max="99"
+            app:np_value="3"
+            app:np_min="1"
+            app:np_textSize="27sp"
+            app:np_selectedTextSize="33sp"
+            app:np_selectedTextColor="@color/panel_label"
+            app:np_dividerColor="@color/panel_label"
+            app:np_dividerType="underline"
+            app:np_fadingEdgeEnabled="true"
+            app:np_wrapSelectorWheel="true"
             />
       </LinearLayout>
 

--- a/app/src/main/res/layout/audio_panel.xml
+++ b/app/src/main/res/layout/audio_panel.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:fadeScrollbars="false"
@@ -64,7 +65,6 @@
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginBottom="12dp"
         android:orientation="horizontal"
         >
       <TextView
@@ -74,17 +74,30 @@
           android:text="@string/play_verses_range"
           android:textAppearance="@style/PanelLabel"
           />
-      <com.quran.labs.androidquran.view.QuranSpinner
-          android:id="@+id/repeat_range_spinner"
+      <com.shawnlin.numberpicker.NumberPicker
+          android:id="@+id/repeat_range_picker"
           android:layout_width="wrap_content"
-          android:layout_height="wrap_content"
+          android:layout_height="40dp"
+          android:layout_centerInParent="true"
+          app:np_orientation="horizontal"
+          app:np_width="135dp"
+          app:np_height="48dp"
+          app:np_max="99"
+          app:np_value="7"
+          app:np_min="1"
+          app:np_textSize="27sp"
+          app:np_selectedTextSize="33sp"
+          app:np_selectedTextColor="@color/panel_label"
+          app:np_dividerColor="@color/panel_label"
+          app:np_dividerType="underline"
+          app:np_fadingEdgeEnabled="true"
+          app:np_wrapSelectorWheel="true"
           />
     </LinearLayout>
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginBottom="12dp"
         android:orientation="horizontal"
         >
       <TextView
@@ -94,11 +107,25 @@
           android:text="@string/play_each_verse"
           android:textAppearance="@style/PanelLabel"
           />
-      <com.quran.labs.androidquran.view.QuranSpinner
-          android:id="@+id/repeat_verse_spinner"
+      <com.shawnlin.numberpicker.NumberPicker
+          android:id="@+id/repeat_verse_picker"
           android:layout_width="wrap_content"
-          android:layout_height="wrap_content"
-          />
+          android:layout_height="40dp"
+          android:layout_centerInParent="true"
+          app:np_orientation="horizontal"
+          app:np_width="135dp"
+          app:np_height="48dp"
+          app:np_max="99"
+          app:np_value="3"
+          app:np_min="1"
+          app:np_textSize="27sp"
+          app:np_selectedTextSize="33sp"
+          app:np_selectedTextColor="@color/panel_label"
+          app:np_dividerColor="@color/panel_label"
+          app:np_dividerType="underline"
+          app:np_fadingEdgeEnabled="true"
+          app:np_wrapSelectorWheel="true"
+      />
     </LinearLayout>
 
     <CheckBox

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -81,6 +81,8 @@
   <string name="about_timber_url" translatable="false">https://github.com/JakeWharton/timber</string>
   <string name="about_kotlin" translatable="false">Kotlin</string>
   <string name="about_kotlin_url" translatable="false">https://kotlinlang.org</string>
+  <string name="about_numberPicker" translatable="false">Number Picker</string>
+  <string name="about_numberPicker_url" translatable="false">https://github.com/ShawnLin013/NumberPicker</string>
   <string name="about_okhttp" translatable="false">OkHttp</string>
   <string name="about_okhttp_url" translatable="false">https://github.com/square/okhttp</string>
   <string name="about_rxjava" translatable="false">RxJava</string>

--- a/app/src/main/res/xml/about.xml
+++ b/app/src/main/res/xml/about.xml
@@ -205,6 +205,15 @@
           android:action="android.intent.action.VIEW"
           android:data="@string/about_dnsjava_url"/>
     </Preference>
+
+    <Preference
+        android:summary="@string/about_numberPicker_url"
+        android:title="@string/about_numberPicker"
+        app:iconSpaceReserved="false">
+      <intent
+          android:action="android.intent.action.VIEW"
+          android:data="@string/about_numberPicker_url"/>
+    </Preference>
   </PreferenceCategory>
 
   <PreferenceCategory


### PR DESCRIPTION
This is a replacement of #1220 Thanks to @fnzainal for starting this.
Should fix #985 
Now we have 99 options for repeating. And yes, we lost the suffix 'time' or 'times'.
For Arabic, I used a string array to flip the visual appearance of the horizontal number picker.