### PR TITLE
Disable split page prefs if dual page mode is not enabled

### DIFF
--- a/app/src/main/res/xml/quran_preferences.xml
+++ b/app/src/main/res/xml/quran_preferences.xml
@@ -48,7 +48,7 @@
         android:key="@string/prefs_sura_translated_name"
         android:persistent="true"
         android:summary="@string/prefs_sura_translated_name_summary"
-        android:title="@string/prefs_sura_translated_name_summary"
+        android:title="@string/prefs_sura_translated_name_title"
         app:iconSpaceReserved="false"/>
 
     <CheckBoxPreference
@@ -119,15 +119,17 @@
 
     <CheckBoxPreference
         android:defaultValue="@bool/use_tablet_interface_by_default"
+        android:disableDependentsState="false"
         android:key="@string/prefs_dual_page_enabled"
         android:persistent="true"
         android:summaryOff="@string/prefs_dual_page_mode_disabled"
         android:summaryOn="@string/prefs_dual_page_mode_enabled"
         android:title="@string/prefs_dual_page_mode_title"
-        app:iconSpaceReserved="false"/>
+        app:iconSpaceReserved="false" />
 
     <CheckBoxPreference
         android:defaultValue="false"
+        android:dependency="@string/prefs_dual_page_enabled"
         android:key="@string/prefs_split_page_and_translation"
         android:persistent="true"
         android:summary="@string/prefs_split_page_and_translation_summary"


### PR DESCRIPTION
Because split page requires dual pages and does not work without it.