### PR TITLE
Fix dark mode on Xiaomi devices

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -35,7 +35,7 @@
         android:name=".QuranDataActivity"
         android:label="@string/app_name"
         android:configChanges="keyboardHidden|orientation|screenSize"
-        android:theme="@style/Theme.AppCompat.NoActionBar">
+        android:theme="@style/QuranToolBar">
       <intent-filter>
         <action android:name="android.intent.action.MAIN"/>
         <category android:name="android.intent.category.LAUNCHER"/>
@@ -151,7 +151,7 @@
       </intent-filter>
     </activity>
     <activity android:name=".pageselect.PageSelectActivity"
-        android:theme="@style/Theme.AppCompat.NoActionBar"/>
+        android:theme="@style/QuranToolBar"/>
 
     <service
         android:enabled="true"
@@ -191,7 +191,7 @@
         android:name=".widget.ShowJumpFragmentActivity"
         android:launchMode="singleInstance"
         android:excludeFromRecents="true"
-        android:theme="@style/Theme.AppCompat.Dialog" />
+        android:theme="@style/QuranDialog" />
 
     <activity android:name=".ui.SheikhAudioManagerActivity" />
 

--- a/app/src/main/res/values-v29/themes.xml
+++ b/app/src/main/res/values-v29/themes.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <style name="Quran" parent="Theme.AppCompat">
+    <item name="colorAccent">@color/accent_color</item>
+    <item name="spinnerStyle">?attr/actionDropDownStyle</item>
+    <item name="spinnerDropDownItemStyle">@style/SherlockDropDownItem</item>
+    <item name="spinnerItemStyle">@style/SherlockSpinnerItem</item>
+    <item name="android:forceDarkAllowed">false</item>
+  </style>
+
+  <style name="QuranToolBar" parent="Theme.AppCompat.NoActionBar">
+    <item name="colorAccent">@color/accent_color</item>
+    <item name="windowActionModeOverlay">true</item>
+    <item name="spinnerStyle">?attr/actionDropDownStyle</item>
+    <item name="spinnerDropDownItemStyle">@style/SherlockDropDownItem</item>
+    <item name="spinnerItemStyle">@style/SherlockSpinnerItem</item>
+    <item name="android:forceDarkAllowed">false</item>
+  </style>
+
+  <style name="QuranDialog" parent="Theme.AppCompat.Dialog">
+    <item name="android:forceDarkAllowed">false</item>
+  </style>
+</resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -18,4 +18,6 @@
     <style name="QuranToolBar.Overlay">
         <item name="windowActionBarOverlay">true</item>
     </style>
+
+    <style name="QuranDialog" parent="Theme.AppCompat.Dialog" />
 </resources>


### PR DESCRIPTION
Xiaomi devices have a force dark mode that breaks the app's reading view
and other views by trying to force them to be dark mode and changing the
colors on their own. This disables this functionality.
