### PR TITLE
Fallback to the internal directory when pages lost

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/QuranDataActivity.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/QuranDataActivity.kt
@@ -404,6 +404,14 @@ class QuranDataActivity : Activity(), SimpleDownloadListener, OnRequestPermissio
         } catch (e: Exception) {
           Timber.e(e)
         }
+
+        // pages are lost, switch to internal storage if we aren't on it
+        val path = quranSettings.appCustomLocation
+        val internalDirectory = filesDir.absolutePath
+        if (path != internalDirectory) {
+          quranSettings.appCustomLocation = internalDirectory
+        }
+
         // clear the "pages downloaded" flag
         quranSettings.removeDidDownloadPages()
       }


### PR DESCRIPTION
Despite changing the directory to the internal directory, there's still
a case where people on the old external directory get their files
deleted. This will prompt the app to ask for downloading the files,
which will again download in the same place, causing the files to be
lost again due to the app cleaner. This patch causes the location of the
data to switch to the internal storage when pages are detected to have
been lost.
