### PR TITLE
Allow updating bookmarks during prefs update

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/database/BookmarksDBAdapter.java
+++ b/app/src/main/java/com/quran/labs/androidquran/database/BookmarksDBAdapter.java
@@ -32,8 +32,8 @@ public class BookmarksDBAdapter {
   private SQLiteDatabase db;
   Context context;
 
-  public BookmarksDBAdapter(Context context, int numberOfPages) {
-    BookmarksDBHelper dbHelper = BookmarksDBHelper.getInstance(context, numberOfPages);
+  public BookmarksDBAdapter(Context context) {
+    BookmarksDBHelper dbHelper = BookmarksDBHelper.getInstance(context);
     db = dbHelper.getWritableDatabase();
     this.context = context;
   }
@@ -229,6 +229,25 @@ public class BookmarksDBAdapter {
         params[1] = String.valueOf(item.second);
         db.delete(BookmarkTagTable.TABLE_NAME,
             BookmarkTagTable.BOOKMARK_ID + " = ? AND " + BookmarkTagTable.TAG_ID + " = ?", params);
+      }
+      db.setTransactionSuccessful();
+    } finally {
+      db.endTransaction();
+    }
+  }
+
+  public void updateBookmarks(List<Bookmark> bookmarks) {
+    db.beginTransaction();
+    try {
+      final ContentValues contentValues = new ContentValues();
+      for (int i = 0, size = bookmarks.size(); i < size; i++) {
+        final Bookmark bookmark = bookmarks.get(i);
+
+        contentValues.clear();
+        contentValues.put(BookmarksTable.SURA, bookmark.getSura());
+        contentValues.put(BookmarksTable.AYAH, bookmark.getAyah());
+        db.update(BookmarksTable.TABLE_NAME, contentValues,
+            BookmarksTable.ID + "=" + bookmark.getId(), null);
       }
       db.setTransactionSuccessful();
     } finally {

--- a/app/src/main/java/com/quran/labs/androidquran/database/BookmarksDBHelper.java
+++ b/app/src/main/java/com/quran/labs/androidquran/database/BookmarksDBHelper.java
@@ -96,21 +96,19 @@ class BookmarksDBHelper extends SQLiteOpenHelper {
 
   private static BookmarksDBHelper sInstance;
 
-  public static BookmarksDBHelper getInstance(Context context, int numberOfPages) {
+  public static BookmarksDBHelper getInstance(Context context) {
     if (sInstance == null) {
-      sInstance = new BookmarksDBHelper(context.getApplicationContext(), numberOfPages);
+      sInstance = new BookmarksDBHelper(context.getApplicationContext());
     }
     return sInstance;
   }
 
   private final int lastPage;
-  private final int totalPages;
 
-  private BookmarksDBHelper(Context context, int numberOfPages) {
+  private BookmarksDBHelper(Context context) {
     super(context, DB_NAME, null, DB_VERSION);
     QuranSettings quranSettings = QuranSettings.getInstance(context);
     lastPage = quranSettings.getLastPage();
-    totalPages = numberOfPages;
   }
 
   @Override
@@ -140,7 +138,9 @@ class BookmarksDBHelper extends SQLiteOpenHelper {
 
   private void upgradeToVer3(SQLiteDatabase db) {
     db.execSQL(LAST_PAGES_TABLE);
-    if (this.lastPage >= Constants.PAGES_FIRST && this.lastPage <= totalPages) {
+
+    // the default lastPage is -1
+    if (this.lastPage >= Constants.PAGES_FIRST) {
       db.execSQL("INSERT INTO last_pages(page) values(?)", new Object[] { lastPage });
     }
   }

--- a/app/src/main/java/com/quran/labs/androidquran/database/BookmarksDaoImpl.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/database/BookmarksDaoImpl.kt
@@ -1,0 +1,24 @@
+package com.quran.labs.androidquran.database
+
+import com.quran.data.dao.BookmarksDao
+import com.quran.data.model.bookmark.Bookmark
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+
+class BookmarksDaoImpl @Inject constructor(
+  private val bookmarksDBAdapter: BookmarksDBAdapter
+) : BookmarksDao {
+
+  override suspend fun bookmarks(): List<Bookmark> {
+    return withContext(Dispatchers.IO) {
+      bookmarksDBAdapter.getBookmarks(BookmarksDBAdapter.SORT_DATE_ADDED)
+    }
+  }
+
+  override suspend fun replaceBookmarks(bookmarks: List<Bookmark>) {
+    withContext(Dispatchers.IO) {
+      bookmarksDBAdapter.updateBookmarks(bookmarks)
+    }
+  }
+}

--- a/app/src/main/java/com/quran/labs/androidquran/di/module/application/ApplicationModule.java
+++ b/app/src/main/java/com/quran/labs/androidquran/di/module/application/ApplicationModule.java
@@ -8,12 +8,14 @@ import android.view.Display;
 import android.view.WindowManager;
 
 import com.quran.data.core.QuranFileManager;
+import com.quran.data.dao.Settings;
 import com.quran.data.source.DisplaySize;
 import com.quran.data.source.PageProvider;
 import com.quran.data.source.PageSizeCalculator;
 import com.quran.labs.androidquran.util.QuranFileUtils;
 import com.quran.labs.androidquran.util.QuranSettings;
 
+import com.quran.labs.androidquran.util.SettingsImpl;
 import java.io.File;
 
 import javax.inject.Singleton;
@@ -63,6 +65,11 @@ public class ApplicationModule {
   @Singleton
   QuranSettings provideQuranSettings() {
     return QuranSettings.getInstance(application);
+  }
+
+  @Provides
+  Settings provideSettings(SettingsImpl settingsImpl) {
+    return settingsImpl;
   }
 
   @Provides

--- a/app/src/main/java/com/quran/labs/androidquran/di/module/application/DatabaseModule.java
+++ b/app/src/main/java/com/quran/labs/androidquran/di/module/application/DatabaseModule.java
@@ -2,9 +2,10 @@ package com.quran.labs.androidquran.di.module.application;
 
 import android.content.Context;
 
-import com.quran.data.core.QuranInfo;
+import com.quran.data.dao.BookmarksDao;
 import com.quran.labs.androidquran.database.BookmarksDBAdapter;
 
+import com.quran.labs.androidquran.database.BookmarksDaoImpl;
 import javax.inject.Singleton;
 
 import dagger.Module;
@@ -15,7 +16,13 @@ public class DatabaseModule {
 
   @Provides
   @Singleton
-  static BookmarksDBAdapter provideBookmarkDatabaseAdapter(Context context, QuranInfo quranInfo) {
-    return new BookmarksDBAdapter(context, quranInfo.getNumberOfPages());
+  static BookmarksDBAdapter provideBookmarkDatabaseAdapter(Context context) {
+    return new BookmarksDBAdapter(context);
+  }
+
+  @Provides
+  @Singleton
+  static BookmarksDao provideBookamrksDao(BookmarksDaoImpl daoImpl) {
+    return daoImpl;
   }
 }

--- a/app/src/main/java/com/quran/labs/androidquran/util/QuranSettings.java
+++ b/app/src/main/java/com/quran/labs/androidquran/util/QuranSettings.java
@@ -1,25 +1,18 @@
 package com.quran.labs.androidquran.util;
 
-import android.app.NotificationManager;
 import android.content.Context;
 import android.content.SharedPreferences;
-import android.os.Build;
 import android.preference.PreferenceManager;
-
+import androidx.annotation.NonNull;
+import androidx.annotation.VisibleForTesting;
 import com.quran.common.upgrade.PreferencesUpgrade;
 import com.quran.labs.androidquran.BuildConfig;
 import com.quran.labs.androidquran.R;
 import com.quran.labs.androidquran.data.Constants;
 import com.quran.labs.androidquran.service.QuranDownloadService;
-
-import java.io.File;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.RequiresApi;
-import androidx.annotation.VisibleForTesting;
 
 
 public class QuranSettings {
@@ -88,6 +81,10 @@ public class QuranSettings {
 
   public boolean shouldOverlayPageInfo() {
     return prefs.getBoolean(Constants.PREF_OVERLAY_PAGE_INFO, true);
+  }
+
+  public void setShouldOverlayPageInfo(boolean shouldOverlay) {
+    prefs.edit().putBoolean(Constants.PREF_OVERLAY_PAGE_INFO, shouldOverlay).apply();
   }
 
   public boolean shouldDisplayMarkerPopup() {
@@ -183,6 +180,7 @@ public class QuranSettings {
     int version = getVersion();
     if (version != BuildConfig.VERSION_CODE) {
       if (version == 0) {
+        // try fetching from prefs instead of from per installation prefs
         version = prefs.getInt(Constants.PREF_VERSION, 0);
       }
 

--- a/app/src/main/java/com/quran/labs/androidquran/util/SettingsImpl.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/util/SettingsImpl.kt
@@ -1,0 +1,14 @@
+package com.quran.labs.androidquran.util
+
+import com.quran.data.dao.Settings
+import javax.inject.Inject
+
+class SettingsImpl @Inject constructor(private val quranSettings: QuranSettings) : Settings {
+  override suspend fun setVersion(version: Int) {
+    quranSettings.version = version
+  }
+
+  override suspend fun setShouldOverlayPageInfo(shouldOverlay: Boolean) {
+    quranSettings.setShouldOverlayPageInfo(shouldOverlay)
+  }
+}

--- a/app/src/main/java/com/quran/labs/androidquran/widget/BookmarksWidgetListProvider.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/widget/BookmarksWidgetListProvider.kt
@@ -36,8 +36,8 @@ class BookmarksWidgetListProvider(private val context: Context) : RemoteViewsFac
 
   private fun populateListItem() {
     val appContext = context.applicationContext
-    val mBookmarksDBAdapter = BookmarksDBAdapter(appContext, quranInfo.numberOfPages)
-    val bookmarksList = mBookmarksDBAdapter.getBookmarks(BookmarksDBAdapter.SORT_LOCATION)
+    val bookmarksDBAdapter = BookmarksDBAdapter(appContext)
+    val bookmarksList = bookmarksDBAdapter.getBookmarks(BookmarksDBAdapter.SORT_LOCATION)
     quranRowList = bookmarksList.map { quranRowFactory.fromBookmark(appContext, it) }
   }
 

--- a/common/data/src/main/java/com/quran/data/dao/BookmarksDao.kt
+++ b/common/data/src/main/java/com/quran/data/dao/BookmarksDao.kt
@@ -1,0 +1,8 @@
+package com.quran.data.dao
+
+import com.quran.data.model.bookmark.Bookmark
+
+interface BookmarksDao {
+  suspend fun bookmarks(): List<Bookmark>
+  suspend fun replaceBookmarks(bookmarks: List<Bookmark>)
+}

--- a/common/data/src/main/java/com/quran/data/dao/Settings.kt
+++ b/common/data/src/main/java/com/quran/data/dao/Settings.kt
@@ -1,0 +1,6 @@
+package com.quran.data.dao
+
+interface Settings {
+  suspend fun setVersion(version: Int)
+  suspend fun setShouldOverlayPageInfo(shouldOverlay: Boolean)
+}

--- a/common/data/src/main/java/com/quran/data/pageinfo/mapper/AyahMapper.kt
+++ b/common/data/src/main/java/com/quran/data/pageinfo/mapper/AyahMapper.kt
@@ -11,6 +11,11 @@ interface AyahMapper {
   fun mapAyah(suraAyah: SuraAyah): List<SuraAyah>
 
   /**
+   * Map a kufi [SuraAyah] value to a list of the current counting [SuraAyah] values
+   */
+  fun reverseMapAyah(suraAyah: SuraAyah): List<SuraAyah>
+
+  /**
    * Map the current counting [VerseRange] value to a correspodning kufi [VerseRange] value
    */
   fun mapRange(verseRange: VerseRange): VerseRange

--- a/common/data/src/main/java/com/quran/data/pageinfo/mapper/IdentityAyahMapper.kt
+++ b/common/data/src/main/java/com/quran/data/pageinfo/mapper/IdentityAyahMapper.kt
@@ -6,6 +6,7 @@ import com.quran.data.model.VerseRange
 
 class IdentityAyahMapper : AyahMapper {
   override fun mapAyah(suraAyah: SuraAyah) = listOf(suraAyah)
+  override fun reverseMapAyah(suraAyah: SuraAyah): List<SuraAyah>  = listOf(suraAyah)
   override fun mapRange(verseRange: VerseRange): VerseRange = verseRange
   override fun mapKufiData(targetVerseRange: VerseRange, kufiData: List<QuranText>) = kufiData
 }


### PR DESCRIPTION
This patch updates preference updates to be able to update and change
bookmarks. This is relevant in warsh, for example, where the app
switches from kufi counting to madani counting and needs to update
bookmarks accordingly. Using this, a flavor can have logic run on update
of preferences which modifies bookmarks.
