### PR TITLE
Add setting for removing downloaded pages

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/util/SettingsImpl.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/util/SettingsImpl.kt
@@ -8,6 +8,10 @@ class SettingsImpl @Inject constructor(private val quranSettings: QuranSettings)
     quranSettings.version = version
   }
 
+  override suspend fun removeDidDownloadPages() {
+    quranSettings.removeDidDownloadPages()
+  }
+
   override suspend fun setShouldOverlayPageInfo(shouldOverlay: Boolean) {
     quranSettings.setShouldOverlayPageInfo(shouldOverlay)
   }

--- a/common/data/src/main/java/com/quran/data/dao/Settings.kt
+++ b/common/data/src/main/java/com/quran/data/dao/Settings.kt
@@ -2,5 +2,6 @@ package com.quran.data.dao
 
 interface Settings {
   suspend fun setVersion(version: Int)
+  suspend fun removeDidDownloadPages()
   suspend fun setShouldOverlayPageInfo(shouldOverlay: Boolean)
 }


### PR DESCRIPTION
Some types of pages, like warsh, will want to clear the downloaded pages
flag since they will replace the pages with different pages. This makes
the flag available.
