### PR TITLE
Fix cropped icon in the search widget

### DIFF
--- a/app/src/main/res/layout/search_widget.xml
+++ b/app/src/main/res/layout/search_widget.xml
@@ -11,6 +11,7 @@
       android:layout_width="0dp"
       android:layout_height="match_parent"
       android:layout_weight="1"
+      android:scaleType="centerInside"
       android:background="@android:color/transparent"
       android:src="@drawable/icon" />
 


### PR DESCRIPTION
When the width is made as small as possible, the icon gets cut. This
makes it center inside the available space.
