### PR TITLE
Minor updates for Warsh upgrade

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/util/QuranFileUtils.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/util/QuranFileUtils.kt
@@ -98,13 +98,16 @@ class QuranFileUtils @Inject constructor(
   }
 
   @WorkerThread
-  override fun removeFilesForWidth(width: Int) {
+  override fun removeFilesForWidth(width: Int, directoryLambda: ((String) -> String)) {
     val widthParam = "_$width"
-    val quranDirectory = getQuranImagesDirectory(appContext, widthParam) ?: return
+    val quranDirectoryWithoutLambda = getQuranImagesDirectory(appContext, widthParam) ?: return
+    val quranDirectory = directoryLambda(quranDirectoryWithoutLambda)
     val file = File(quranDirectory)
     if (file.exists()) {
       deleteFileOrDirectory(file)
-      val ayahinfoFile = File(getQuranAyahDatabaseDirectory(appContext), "ayahinfo_$width.db")
+      val ayahDatabaseDirectoryWithoutLambda = getQuranAyahDatabaseDirectory(appContext) ?: return
+      val ayahDatabaseDirectory = directoryLambda(ayahDatabaseDirectoryWithoutLambda)
+      val ayahinfoFile = File(ayahDatabaseDirectory, "ayahinfo_$width.db")
       if (ayahinfoFile.exists()) {
         ayahinfoFile.delete()
       }

--- a/app/src/warsh/java/com/quran/labs/androidquran/data/QuranFileConstants.java
+++ b/app/src/warsh/java/com/quran/labs/androidquran/data/QuranFileConstants.java
@@ -8,7 +8,7 @@ public class QuranFileConstants {
   public static final int FONT_TYPE = TypefaceManager.TYPE_UTHMANIC_WARSH;
 
   // arabic database
-  public static final String ARABIC_DATABASE = "warsh.db";
+  public static final String ARABIC_DATABASE = "quran.ar.warsh.db";
   public static final String ARABIC_SHARE_TABLE = DatabaseHandler.ARABIC_TEXT_TABLE;
   public static final boolean ARABIC_SHARE_TEXT_HAS_BASMALLAH = true;
 }

--- a/common/data/src/main/java/com/quran/data/core/QuranFileManager.kt
+++ b/common/data/src/main/java/com/quran/data/core/QuranFileManager.kt
@@ -16,7 +16,7 @@ interface QuranFileManager {
   fun writeVersionFile(widthParam: String, version: Int)
 
   @WorkerThread
-  fun removeFilesForWidth(width: Int)
+  fun removeFilesForWidth(width: Int, directoryLambda: ((String) -> String) = { it })
 
   @WorkerThread
   fun writeNoMediaFileRelative(widthParam: String)


### PR DESCRIPTION
For warsh upgrade, rename the warsh Arabic database. Moreover, update
the old directory removal to take an optional lambda. This is necessary
because the PageProvider directory may have changed, and allows the
upgrade code to tweak the directory accordingly.
