### PR TITLE
Fix a crash where juz list loads when not attached

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/ui/fragment/JuzListFragment.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/fragment/JuzListFragment.kt
@@ -137,10 +137,18 @@ class JuzListFragment : Fragment() {
     val quarters = if (QuranFileConstants.FETCH_QUARTER_NAMES_FROM_DATABASE) {
       juzListPresenter.quarters().toTypedArray()
     } else {
-      val res = resources
-      res.getStringArray(array.quarter_prefix_array)
+      val context = context
+      if (context != null) {
+        val res = context.resources
+        res.getStringArray(array.quarter_prefix_array)
+      } else {
+        emptyArray<String>()
+      }
     }
-    updateJuz2List(quarters)
+
+    if (isAdded && quarters.isNotEmpty()) {
+      updateJuz2List(quarters)
+    }
   }
 
   private fun updateJuz2List(quarters: Array<String>) {


### PR DESCRIPTION
In some cases, by the time we try to load the juz' list, the fragment
may be going away. Do nothing in these cases instead of crashing.
