### PR TITLE
fixes to prevent scrolling from last position of reading upon resume

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/ui/PagerActivity.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/PagerActivity.java
@@ -707,11 +707,11 @@ public class PagerActivity extends QuranActionBarActivity implements
             shouldReconnect = false;
           }));
     }
-
-    if (highlightedSura > 0 && highlightedAyah > 0) {
-      handler.postDelayed(() ->
-          highlightAyah(highlightedSura, highlightedAyah, false, HighlightType.SELECTION), 750);
-    }
+    // commented out to disable unnecessary scrolling  at resume
+    // if (highlightedSura > 0 && highlightedAyah > 0) {
+    //   handler.postDelayed(() ->
+    //       highlightAyah(highlightedSura, highlightedAyah, false, HighlightType.SELECTION), 750);
+    // }
 
     updateNavigationBar(quranSettings.isNightMode());
   }


### PR DESCRIPTION
Two options were possible here
1. To update the highlightedsura and ayat variables to the last ayat that was being read before closing app.
    Limitation: - The ayat will be highlighted which is undesirable 
2. To comment out the code that highlights and scrolls to the bookmarked ayat at resume.
    Limitation: - none

So my changes for no. 2 options
Please test and revert.