### PR TITLE
Allow different qirat to handle patch upgrades

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/presenter/data/QuranDataPresenter.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/presenter/data/QuranDataPresenter.kt
@@ -69,6 +69,7 @@ class QuranDataPresenter @Inject internal constructor(
               .andThen(actuallyCheckPages(pages))
               .flatMap { Single.fromCallable { localDataUpgrade.processData(it) } }
               .map { checkPatchStatus(it) }
+              .flatMap { Single.fromCallable { localDataUpgrade.processPatch(it) } }
               .doOnSuccess {
                 if (!it.havePages()) {
                   try {

--- a/app/src/main/java/com/quran/labs/androidquran/util/QuranFileUtils.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/util/QuranFileUtils.kt
@@ -240,6 +240,18 @@ class QuranFileUtils @Inject constructor(
   }
 
   @WorkerThread
+  override fun removeOldArabicDatabase(): Boolean {
+    val databaseQuranArabicDatabase = File(
+      getQuranDatabaseDirectory(appContext),
+      QuranDataProvider.QURAN_ARABIC_DATABASE
+    )
+
+    return if (databaseQuranArabicDatabase.exists()) {
+      databaseQuranArabicDatabase.delete()
+    } else true
+  }
+
+  @WorkerThread
   private fun copyFromAssets(assetsPath: String, filename: String, destination: String) {
     val assets = appContext.assets
     assets.open(assetsPath)

--- a/common/data/src/main/java/com/quran/data/core/QuranFileManager.kt
+++ b/common/data/src/main/java/com/quran/data/core/QuranFileManager.kt
@@ -10,6 +10,9 @@ interface QuranFileManager {
   fun copyFromAssetsRelative(assetsPath: String, filename: String, destination: String)
 
   @WorkerThread
+  fun removeOldArabicDatabase(): Boolean
+
+  @WorkerThread
   fun hasArabicSearchDatabase(): Boolean
 
   @WorkerThread

--- a/common/upgrade/src/main/java/com/quran/common/upgrade/LocalDataUpgrade.kt
+++ b/common/upgrade/src/main/java/com/quran/common/upgrade/LocalDataUpgrade.kt
@@ -7,7 +7,10 @@ import com.quran.data.model.QuranDataStatus
  * Interface for handling data upgrades (pages, databases, etc) between
  * upgrades of versions of Quran for Android.
  */
-fun interface LocalDataUpgrade {
+interface LocalDataUpgrade {
   @WorkerThread
-  fun processData(quranDataStatus: QuranDataStatus): QuranDataStatus
+  fun processData(quranDataStatus: QuranDataStatus): QuranDataStatus { return quranDataStatus }
+
+  @WorkerThread
+  fun processPatch(quranDataStatus: QuranDataStatus): QuranDataStatus { return quranDataStatus }
 }

--- a/pages/madani/src/main/java/com/quran/data/page/provider/QuranPageModule.kt
+++ b/pages/madani/src/main/java/com/quran/data/page/provider/QuranPageModule.kt
@@ -34,7 +34,7 @@ object QuranPageModule {
 
   @JvmStatic
   @Provides
-  fun provideLocalDataUpgrade(): LocalDataUpgrade = LocalDataUpgrade { it }
+  fun provideLocalDataUpgrade(): LocalDataUpgrade = object : LocalDataUpgrade {  }
 
   @JvmStatic
   @Provides


### PR DESCRIPTION
In the cases of patch upgrades (i.e. from data version 1 to 2), allow
the flavor to handle it (so as to copy the database from assets, for
example, etc).
