### PR TITLE
Support new page types and fix some bugs

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/pageselect/PageSelectAdapter.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/pageselect/PageSelectAdapter.kt
@@ -92,7 +92,6 @@ class PageSelectAdapter(val inflater: LayoutInflater,
   }
 
   override fun destroyItem(container: ViewGroup, position: Int, o: Any) {
-    super.destroyItem(container, position, o)
     container.removeView(o as View)
   }
 }

--- a/app/src/main/java/com/quran/labs/androidquran/presenter/data/QuranDataPresenter.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/presenter/data/QuranDataPresenter.kt
@@ -203,7 +203,7 @@ class QuranDataPresenter @Inject internal constructor(
       }
 
       val pageType = quranSettings.pageType
-      if (!quranSettings.didCheckPartialImages(pageType)) {
+      if (!quranSettings.didCheckPartialImages(pageType) && !pageType.endsWith("lines")) {
         Timber.d("enqueuing work for $pageType...")
 
         // setup check pages task

--- a/app/src/main/java/com/quran/labs/androidquran/util/QuranFileUtils.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/util/QuranFileUtils.kt
@@ -129,7 +129,8 @@ class QuranFileUtils @Inject constructor(
   fun haveAllImages(context: Context,
     widthParam: String,
     totalPages: Int,
-    makeDirectory: Boolean
+    makeDirectory: Boolean,
+    oneFilePerPage: Boolean = true
   ): Boolean {
     val quranDirectory = getQuranImagesDirectory(context, widthParam)
     Timber.d("haveAllImages: for width %s, directory is: %s", widthParam, quranDirectory)
@@ -145,9 +146,8 @@ class QuranFileUtils @Inject constructor(
         if (fileList == null) {
           Timber.d("haveAllImages: null fileList, checking page by page...")
           for (i in 1..totalPages) {
-            if (!File(dir, getPageFileName(i))
-                    .exists()
-            ) {
+            val name = if (oneFilePerPage) getPageFileName(i) else i.toString()
+            if (!File(dir, name).exists()) {
               Timber.d("haveAllImages: couldn't find page %d", i)
               return false
             }

--- a/app/src/main/java/com/quran/labs/androidquran/util/ZipUtils.java
+++ b/app/src/main/java/com/quran/labs/androidquran/util/ZipUtils.java
@@ -15,9 +15,9 @@ import timber.log.Timber;
 public class ZipUtils {
 
   private static final int BUFFER_SIZE = 512;
-  private static final int MAX_FILES = 2048; // Max number of files
+  private static final int MAX_FILES = 10000; // Max number of files
 
-  @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+  @VisibleForTesting
   static int MAX_UNZIPPED_SIZE = 0x1f400000; // Max size of unzipped data, 500MB
 
   /**

--- a/app/src/main/java/com/quran/labs/androidquran/worker/PartialPageCheckingWorker.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/worker/PartialPageCheckingWorker.kt
@@ -10,7 +10,6 @@ import com.quran.labs.androidquran.util.QuranFileUtils
 import com.quran.labs.androidquran.util.QuranPartialPageChecker
 import com.quran.labs.androidquran.util.QuranScreenInfo
 import com.quran.labs.androidquran.util.QuranSettings
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.coroutineScope
 import timber.log.Timber
 import java.io.File
@@ -26,7 +25,6 @@ class PartialPageCheckingWorker(private val context: Context,
                                 private val quranPartialPageChecker: QuranPartialPageChecker
 ) : CoroutineWorker(context, params) {
 
-  @ExperimentalCoroutinesApi
   override suspend fun doWork(): Result = coroutineScope {
     Timber.d("PartialPageCheckingWorker")
     val requestedPageType = params.inputData.getString(WorkerConstants.PAGE_TYPE)

--- a/common/data/src/main/java/com/quran/data/source/PageContentType.kt
+++ b/common/data/src/main/java/com/quran/data/source/PageContentType.kt
@@ -1,0 +1,5 @@
+package com.quran.data.source
+
+enum class PageContentType {
+  IMAGE, LINE
+}

--- a/common/data/src/main/java/com/quran/data/source/PageProvider.kt
+++ b/common/data/src/main/java/com/quran/data/source/PageProvider.kt
@@ -22,4 +22,6 @@ interface PageProvider {
 
   @StringRes fun getPreviewTitle(): Int
   @StringRes fun getPreviewDescription(): Int
+
+  fun getPageContentType(): PageContentType = PageContentType.IMAGE
 }


### PR DESCRIPTION
This patch adds a field to PageProvider to handle different types of
pages - for example, in the future, pages could be rendered per line, or
using fonts, etc. It also increases the maximum number of files allowed
in a zip file limit.

This also fixes a bug that causes the page selection to crash after
scrolling to the very end.
