### PR TITLE
Support injecting QuranPageDependencies

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -25,7 +25,6 @@ android {
     versionCode 3070
     versionName "3.0.7"
     testInstrumentationRunner "com.quran.labs.androidquran.core.QuranTestRunner"
-    multiDexEnabled true
   }
 
   signingConfigs {
@@ -134,7 +133,6 @@ dependencies {
   implementation "androidx.recyclerview:recyclerview:${androidxRecyclerViewVersion}"
   implementation "com.google.android.material:material:${materialComponentsVersion}"
   implementation "androidx.swiperefreshlayout:swiperefreshlayout:${androidxSwipeRefreshVersion}"
-  implementation "androidx.multidex:multidex:2.0.1"
 
   // rx
   implementation 'io.reactivex.rxjava3:rxjava:3.1.1'

--- a/app/src/main/java/com/quran/labs/androidquran/QuranApplication.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/QuranApplication.kt
@@ -1,10 +1,12 @@
 package com.quran.labs.androidquran
 
+import android.app.Application
 import android.content.Context
 import android.content.res.Resources
-import androidx.multidex.MultiDexApplication
 import androidx.work.Configuration
 import androidx.work.WorkManager
+import com.quran.data.di.QuranPageDependencies
+import com.quran.data.di.QuranPageDependenciesProvider
 import com.quran.labs.androidquran.core.worker.QuranWorkerFactory
 import com.quran.labs.androidquran.di.component.application.ApplicationComponent
 import com.quran.labs.androidquran.di.component.application.DaggerApplicationComponent
@@ -16,14 +18,12 @@ import timber.log.Timber
 import java.util.Locale
 import javax.inject.Inject
 
-open class QuranApplication : MultiDexApplication() {
+open class QuranApplication : Application(), QuranPageDependenciesProvider {
   lateinit var applicationComponent: ApplicationComponent
 
-  @Inject
-  lateinit var quranWorkerFactory: QuranWorkerFactory
-
-  @Inject
-  lateinit var bookmarksWidgetSubscriber: BookmarksWidgetSubscriber
+  @Inject lateinit var quranWorkerFactory: QuranWorkerFactory
+  @Inject lateinit var bookmarksWidgetSubscriber: BookmarksWidgetSubscriber
+  @Inject lateinit var quranPageDependencies: QuranPageDependencies
 
   override fun onCreate() {
     super.onCreate()
@@ -48,6 +48,8 @@ open class QuranApplication : MultiDexApplication() {
         .applicationModule(ApplicationModule(this))
         .build()
   }
+
+  override fun provideQuranPageDependencies(): QuranPageDependencies = quranPageDependencies
 
   fun refreshLocale(
     context: Context,

--- a/app/src/main/java/com/quran/labs/androidquran/di/component/application/ApplicationComponent.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/di/component/application/ApplicationComponent.kt
@@ -56,40 +56,40 @@ interface ApplicationComponent {
   fun quranActivityComponentBuilder(): QuranActivityComponent.Builder
 
   // application
-  fun inject(quranApplication: QuranApplication?)
+  fun inject(quranApplication: QuranApplication)
 
   // content provider
-  fun inject(quranDataProvider: QuranDataProvider?)
+  fun inject(quranDataProvider: QuranDataProvider)
 
   // services
-  fun inject(audioService: AudioService?)
-  fun inject(quranDownloadService: QuranDownloadService?)
+  fun inject(audioService: AudioService)
+  fun inject(quranDownloadService: QuranDownloadService)
 
   // activities
-  fun inject(quranDataActivity: QuranDataActivity?)
-  fun inject(quranImportActivity: QuranImportActivity?)
-  fun inject(audioManagerActivity: AudioManagerActivity?)
-  fun inject(sheikhAudioManagerActivity: SheikhAudioManagerActivity?)
-  fun inject(quranForwarderActivity: QuranForwarderActivity?)
-  fun inject(searchActivity: SearchActivity?)
-  fun inject(pageSelectActivity: PageSelectActivity?)
-  fun inject(showJumpFragmentActivity: ShowJumpFragmentActivity?)
+  fun inject(quranDataActivity: QuranDataActivity)
+  fun inject(quranImportActivity: QuranImportActivity)
+  fun inject(audioManagerActivity: AudioManagerActivity)
+  fun inject(sheikhAudioManagerActivity: SheikhAudioManagerActivity)
+  fun inject(quranForwarderActivity: QuranForwarderActivity)
+  fun inject(searchActivity: SearchActivity)
+  fun inject(pageSelectActivity: PageSelectActivity)
+  fun inject(showJumpFragmentActivity: ShowJumpFragmentActivity)
 
   // fragments
-  fun inject(bookmarksFragment: BookmarksFragment?)
-  fun inject(fragment: QuranSettingsFragment?)
-  fun inject(translationManagerActivity: TranslationManagerActivity?)
-  fun inject(quranAdvancedSettingsFragment: QuranAdvancedSettingsFragment?)
-  fun inject(suraListFragment: SuraListFragment?)
-  fun inject(juzListFragment: JuzListFragment?)
-  fun inject(ayahPlaybackFragment: AyahPlaybackFragment?)
-  fun inject(jumpFragment: JumpFragment?)
+  fun inject(bookmarksFragment: BookmarksFragment)
+  fun inject(fragment: QuranSettingsFragment)
+  fun inject(translationManagerActivity: TranslationManagerActivity)
+  fun inject(quranAdvancedSettingsFragment: QuranAdvancedSettingsFragment)
+  fun inject(suraListFragment: SuraListFragment)
+  fun inject(juzListFragment: JuzListFragment)
+  fun inject(ayahPlaybackFragment: AyahPlaybackFragment)
+  fun inject(jumpFragment: JumpFragment)
 
   // dialogs
-  fun inject(tagBookmarkDialog: TagBookmarkDialog?)
-  fun inject(addTagDialog: AddTagDialog?)
+  fun inject(tagBookmarkDialog: TagBookmarkDialog)
+  fun inject(addTagDialog: AddTagDialog)
 
   // widgets
-  fun inject(bookmarksWidgetListProvider: BookmarksWidgetListProvider?)
-  fun inject(bookmarksWidget: BookmarksWidget?)
+  fun inject(bookmarksWidgetListProvider: BookmarksWidgetListProvider)
+  fun inject(bookmarksWidget: BookmarksWidget)
 }

--- a/app/src/main/java/com/quran/labs/androidquran/di/module/application/PageAggregationModule.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/di/module/application/PageAggregationModule.kt
@@ -1,6 +1,8 @@
 package com.quran.labs.androidquran.di.module.application
 
 import com.quran.data.constant.DependencyInjectionConstants
+import com.quran.data.di.QuranPageDependencies
+import com.quran.data.di.impl.QuranPageDependenciesImpl
 import com.quran.data.source.PageProvider
 import com.quran.data.source.QuranDataSource
 import dagger.Module
@@ -19,7 +21,15 @@ object PageAggregationModule {
     return providers[pageType]!!
   }
 
-  @Provides fun provideQuranDataSource(pageProvider: PageProvider): QuranDataSource {
+  @Provides
+  fun provideQuranDataSource(pageProvider: PageProvider): QuranDataSource {
     return pageProvider.getDataSource()
+  }
+
+  @Provides
+  fun provideQuranPageDependencies(
+    quranPageDependenciesImpl: QuranPageDependenciesImpl
+  ): QuranPageDependencies {
+    return quranPageDependenciesImpl
   }
 }

--- a/app/src/main/java/com/quran/labs/androidquran/util/QuranFileUtils.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/util/QuranFileUtils.kt
@@ -97,6 +97,8 @@ class QuranFileUtils @Inject constructor(
     return null
   }
 
+  override fun quranImagesDirectory(): String? = getQuranImagesDirectory(appContext)
+
   @WorkerThread
   override fun removeFilesForWidth(width: Int, directoryLambda: ((String) -> String)) {
     val widthParam = "_$width"

--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ buildscript {
     okioVersion = '2.10.0'
     workManagerVersion = '2.6.0'
     retrofitVersion = '2.9.0'
+    compose_version = '1.1.0-alpha04'
 
     // testing
     junitVersion = '4.13.2'

--- a/common/data/src/main/java/com/quran/data/core/QuranFileManager.kt
+++ b/common/data/src/main/java/com/quran/data/core/QuranFileManager.kt
@@ -3,6 +3,8 @@ package com.quran.data.core
 import androidx.annotation.WorkerThread
 
 interface QuranFileManager {
+  fun quranImagesDirectory(): String?
+  
   @WorkerThread
   fun isVersion(widthParam: String, version: Int): Boolean
 

--- a/common/data/src/main/java/com/quran/data/di/QuranPageDependencies.kt
+++ b/common/data/src/main/java/com/quran/data/di/QuranPageDependencies.kt
@@ -1,0 +1,11 @@
+package com.quran.data.di
+
+import com.quran.data.core.QuranFileManager
+
+interface QuranPageDependencies {
+  fun provideQuranFileManager(): QuranFileManager
+}
+
+interface QuranPageDependenciesProvider {
+  fun provideQuranPageDependencies(): QuranPageDependencies
+}

--- a/common/data/src/main/java/com/quran/data/di/impl/QuranPageDependenciesImpl.kt
+++ b/common/data/src/main/java/com/quran/data/di/impl/QuranPageDependenciesImpl.kt
@@ -1,0 +1,12 @@
+package com.quran.data.di.impl
+
+import com.quran.data.core.QuranFileManager
+import com.quran.data.di.QuranPageDependencies
+import javax.inject.Inject
+
+class QuranPageDependenciesImpl @Inject constructor(
+  private val quranFileManager: QuranFileManager
+) : QuranPageDependencies {
+
+  override fun provideQuranFileManager(): QuranFileManager = quranFileManager
+}


### PR DESCRIPTION
This patch does a few things:
- adds a QuranPageDependencies for pages living outside of the app
  module giving dependencies that they need.
- allows modules to ask the application for these dependencies to use
  within their own Dagger graph.
- add a method to get the images directory into the file manager
  interface.
- clean up various things (remove multidex since we're minSdk 21 now)
  and remove nullability on some fields that can't be null.
