### PR TITLE
Update compose and expose ayah info file directory

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/util/QuranFileUtils.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/util/QuranFileUtils.kt
@@ -98,6 +98,15 @@ class QuranFileUtils @Inject constructor(
   }
 
   override fun quranImagesDirectory(): String? = getQuranImagesDirectory(appContext)
+  override fun ayahInfoFileDirectory(): String? {
+    val base = quranAyahDatabaseDirectory
+    return if (base != null) {
+      val filename = ayaPositionFileName
+      base + File.separator + filename
+    } else {
+      null
+    }
+  }
 
   @WorkerThread
   override fun removeFilesForWidth(width: Int, directoryLambda: ((String) -> String)) {

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,9 @@ buildscript {
     okioVersion = '2.10.0'
     workManagerVersion = '2.6.0'
     retrofitVersion = '2.9.0'
-    compose_version = '1.1.0-alpha04'
+    supportSqliteVersion = '2.1.0'
+    sqldelightVersion = '1.5.1'
+    composeVersion = '1.1.0-alpha05'
 
     // testing
     junitVersion = '4.13.2'
@@ -47,11 +49,12 @@ buildscript {
   }
 
   dependencies {
-    classpath 'com.android.tools.build:gradle:7.0.2'
-    classpath 'com.google.firebase:firebase-crashlytics-gradle:2.7.1'
+    classpath "com.android.tools.build:gradle:7.0.2"
+    classpath "com.google.firebase:firebase-crashlytics-gradle:2.7.1"
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
     classpath "net.ltgt.gradle:gradle-errorprone-plugin:2.0.2"
-    classpath 'com.google.gms:google-services:4.3.10'
+    classpath "com.google.gms:google-services:4.3.10"
+    classpath "com.squareup.sqldelight:gradle-plugin:$sqldelightVersion"
   }
 }
 

--- a/common/data/src/main/java/com/quran/data/core/QuranFileManager.kt
+++ b/common/data/src/main/java/com/quran/data/core/QuranFileManager.kt
@@ -4,6 +4,7 @@ import androidx.annotation.WorkerThread
 
 interface QuranFileManager {
   fun quranImagesDirectory(): String?
+  fun ayahInfoFileDirectory(): String?
   
   @WorkerThread
   fun isVersion(widthParam: String, version: Int): Boolean


### PR DESCRIPTION
This updates Compose to the latest alpha (compatible with Kotlin
1.5.31). It also exposes a method in FileManager for receiving the ayah
info.
