### PR TITLE
Rename QuranPageModule to QuranDataModule

### DIFF
--- a/app/src/androidTest/java/com/quran/labs/androidquran/di/TestApplicationComponent.kt
+++ b/app/src/androidTest/java/com/quran/labs/androidquran/di/TestApplicationComponent.kt
@@ -2,7 +2,7 @@ package com.quran.labs.androidquran.di
 
 import com.quran.analytics.provider.AnalyticsModule
 import com.quran.common.networking.NetworkModule
-import com.quran.data.page.provider.QuranPageModule
+import com.quran.data.page.provider.QuranDataModule
 import com.quran.labs.androidquran.core.worker.di.WorkerModule
 import com.quran.labs.androidquran.di.component.application.ApplicationComponent
 import com.quran.labs.androidquran.di.module.application.ApplicationModule
@@ -20,7 +20,7 @@ import javax.inject.Singleton
       DatabaseModule::class,
       NetworkModule::class,
       PageAggregationModule::class,
-      QuranPageModule::class,
+      QuranDataModule::class,
       WorkerModule::class,
       BookmarksWidgetUpdaterModule::class]
 )

--- a/app/src/main/java/com/quran/labs/androidquran/di/component/application/ApplicationComponent.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/di/component/application/ApplicationComponent.kt
@@ -2,7 +2,7 @@ package com.quran.labs.androidquran.di.component.application
 
 import com.quran.analytics.provider.AnalyticsModule
 import com.quran.common.networking.NetworkModule
-import com.quran.data.page.provider.QuranPageModule
+import com.quran.data.page.provider.QuranDataModule
 import com.quran.labs.androidquran.QuranApplication
 import com.quran.labs.androidquran.QuranDataActivity
 import com.quran.labs.androidquran.QuranForwarderActivity
@@ -45,7 +45,7 @@ import javax.inject.Singleton
     DatabaseModule::class,
     NetworkModule::class,
     PageAggregationModule::class,
-    QuranPageModule::class,
+    QuranDataModule::class,
     WorkerModule::class,
     BookmarksWidgetUpdaterModule::class
   ]

--- a/pages/madani/src/main/java/com/quran/data/page/provider/QuranDataModule.kt
+++ b/pages/madani/src/main/java/com/quran/data/page/provider/QuranDataModule.kt
@@ -16,7 +16,7 @@ import dagger.multibindings.IntoMap
 import dagger.multibindings.StringKey
 
 @Module
-object QuranPageModule {
+object QuranDataModule {
 
   @Provides
   fun providePageViewFactoryProvider(): PageViewFactoryProvider {


### PR DESCRIPTION
There are 2 QuranPageModules today, one that has the data and is part of
the singleton scope of the app, and the other is one that's really per
page view. This is confusing, so renamed one to QuranDataModule since
it's really about Quran data. A few fields in there probably make sure
to move at some point to QuranPageModule or similar.
