### PR TITLE
Update sura name translation (Bahasa Indonesia)

### DIFF
--- a/app/src/main/res/values-in/sura_names.xml
+++ b/app/src/main/res/values-in/sura_names.xml
@@ -121,51 +121,51 @@
        respective item body to keep Android Studio happy -->
   <string-array name="sura_names_translation">
     <item>Pembukaan</item>
-    <item>Sapi Betina</item>
+    <item>Sapi</item>
     <item>Keluarga Imran</item>
     <item>Wanita</item>
-    <item>Jamuan (Hidangan Makanan)</item>
+    <item>Hidangan</item>
     <item>Binatang Ternak</item>
-    <item>Tempat-tempat Tinggi</item>
+    <item>Tempat Tertinggi</item>
     <item>Rampasan Perang</item>
     <item>Pengampunan</item>
     <item>Yunus</item>
     <item>Hud</item>
     <item>Yusuf</item>
-    <item>Guruh (Petir)</item>
+    <item>Guruh</item>
     <item>Ibrahim</item>
-    <item>Bukit</item>
-    <item>Lebah Madu</item>
-    <item>Perjalanan Malam</item>
-    <item>Para Penghuni Gua</item>
+    <item>Hijr</item>
+    <item>Lebah</item>
+    <item>Memperjalankan di Malam Hari</item>
+    <item>Gua</item>
     <item>Maryam</item>
-    <item>Tha-Ha</item>
+    <item>TaHa</item>
     <item>Para Nabi</item>
     <item>Haji</item>
     <item>Orang-orang Mukmin</item>
     <item>Cahaya</item>
     <item>Pembeda</item>
-    <item>Penyair</item>
+    <item>Para Penyair</item>
     <item>Semut</item>
     <item>Kisah-kisah</item>
     <item>Laba-laba</item>
-    <item>Bangsa Romawi</item>
+    <item>Romawi</item>
     <item>Luqman</item>
-    <item>Sujud</item>
+    <item>Sajdah</item>
     <item>Golongan yang Bersekutu</item>
     <item>Saba\'</item>
     <item>Pencipta</item>
     <item>Ya-Sin</item>
     <item>Barisan-barisan</item>
     <item>Shad</item>
-    <item>Para Rombongan</item>
-    <item>Sang Maha Pengampun</item>
+    <item>Rombongan</item>
+    <item>Maha Pengampun</item>
     <item>Yang Dijelaskan</item>
     <item>Musyawarah</item>
     <item>Perhiasan</item>
     <item>Kabut</item>
-    <item>Yang Bertekuk Lutut</item>
-    <item>Bukit-bukit Pasir</item>
+    <item>BerLutut</item>
+    <item>Bukit Pasir</item>
     <item>Muhammad</item>
     <item>Kemenangan</item>
     <item>Kamar-kamar</item>
@@ -174,65 +174,65 @@
     <item>Bukit</item>
     <item>Bintang</item>
     <item>Bulan</item>
-    <item>Yang Maha Pemurah</item>
-    <item>Hari Kiamat</item>
+    <item>Yang Maha Pengasih</item>
+    <item>Hari Kiamat yang Pasti Terjadi</item>
     <item>Besi</item>
-    <item>Wanita yang Menggugat</item>
+    <item>Gugatan</item>
     <item>Pengusiran</item>
     <item>Wanita yang Diuji</item>
     <item>Barisan</item>
-    <item>Hari Jum\'at</item>
-    <item>Kaum Munafik</item>
-    <item>Hari Dinampakkan Kesalahan</item>
-    <item>Perceraian</item>
-    <item>Mengharamkan</item>
+    <item>Jum\'at</item>
+    <item>Orang-orang Munafik</item>
+    <item>Pengungkapan Kesalahan</item>
+    <item>Talak</item>
+    <item>Pengharaman</item>
     <item>Kerajaan</item>
     <item>Pena</item>
-    <item>Kenyataan (Hari Kiamat)</item>
-    <item>Tempat yang Naik</item>
+    <item>Hari Kiamat yang Pasti Datang</item>
+    <item>Tempat-tempat Naik</item>
     <item>Nuh</item>
     <item>Jin</item>
     <item>Orang yang Berselimut</item>
     <item>Orang yang Berkemul</item>
     <item>Hari Berbangkit</item>
     <item>Manusia</item>
-    <item>Malaikat-malaikan yang Diutus</item>
+    <item>Malaikat yang Diutus</item>
     <item>Berita Besar</item>
-    <item>Malaikat yang Mencabut</item>
-    <item>Ia Bermuka Masam</item>
-    <item>Menggulung</item>
+    <item>Yang Mencabut dengan Keras</item>
+    <item>Bermuka Masam</item>
+    <item>Penggulungan</item>
     <item>Terbelah</item>
     <item>Orang-orang Curang</item>
     <item>Terbelah</item>
     <item>Gugusan Bintang</item>
-    <item>Yang Datang di Malam Hari</item>
-    <item>Yang Paling Tinggi</item>
-    <item>Hari Pembalasan</item>
+    <item>Yang Datang Pada Malam Hari</item>
+    <item>Yang Maha Tinggi</item>
+    <item>Hari Kiamat yang Menghilangkan Kesadaran</item>
     <item>Fajar</item>
     <item>Negeri</item>
     <item>Matahari</item>
     <item>Malam</item>
     <item>Waktu Dhuha</item>
-    <item>Melapangkan</item>
+    <item>Pelapangan</item>
     <item>Buah Tin</item>
     <item>Segumpal Darah</item>
     <item>Kemuliaan</item>
-    <item>Pembuktian</item>
-    <item>Kegoncangan</item>
-    <item>Berlari Kencang</item>
-    <item>Hari Kiamat</item>
+    <item>Bukti Nyata</item>
+    <item>Guncangan</item>
+    <item>Kuda Perang yang Berlari Kencang</item>
+    <item>Hari Kiamat yang Menggetarkan</item>
     <item>Bermegah-megahan</item>
-    <item>Waktu Sore</item>
+    <item>Masa</item>
     <item>Pengumpat</item>
     <item>Gajah</item>
-    <item>Suku Quraisy</item>
+    <item>Orang Quraisy</item>
     <item>Barang yang Berguna</item>
-    <item>Nikmat Berlimpah</item>
+    <item>Nikmat yang Banyak</item>
     <item>Orang-orang Kafir</item>
     <item>Pertolongan</item>
     <item>Gejolak Api (Sabut)</item>
     <item>Ikhlash</item>
-    <item>Waktu Shubuh</item>
-    <item>Umat Manusia</item>
+    <item>Fajar</item>
+    <item>Manusia</item>
   </string-array>
 </resources>


### PR DESCRIPTION
Update sura name translation in Bahasa Indonesia based on latest translation from Indonesia ministry of religious affairs.

reference: https://lajnah.kemenag.go.id/unduhan/category/3-terjemah-al-qur-an-tahun-2019
