### PR TITLE
Update Compose to 1.0.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     coroutinesVersion = '1.5.2'
 
     daggerVersion = '2.39.1'
-    composeVersion = '1.1.0-alpha05'
+    composeVersion = '1.0.4'
 
     androidxMediaVersion = '1.4.2'
     androidxAnnotationVersion = '1.2.0'


### PR DESCRIPTION
Now that Jetpack Compose 1.0.4 supports Kotlin 1.5.31, switch to it
instead of the alpha version.
