### PR TITLE
Fix scope on ReadingEventPresenter

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/di/component/activity/PagerActivityComponent.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/di/component/activity/PagerActivityComponent.kt
@@ -5,7 +5,9 @@ import com.quran.data.di.ActivityScope
 import com.quran.labs.androidquran.di.component.fragment.QuranPageComponent
 import com.quran.labs.androidquran.di.module.activity.PagerActivityModule
 import com.quran.labs.androidquran.ui.PagerActivity
+import com.quran.labs.androidquran.ui.fragment.AyahPlaybackFragment
 import com.quran.labs.androidquran.ui.fragment.AyahTranslationFragment
+import com.quran.labs.androidquran.ui.fragment.TagBookmarkFragment
 import com.quran.page.common.toolbar.AyahToolBar
 import com.squareup.anvil.annotations.MergeSubcomponent
 import dagger.Subcomponent
@@ -17,8 +19,11 @@ interface PagerActivityComponent {
   fun quranPageComponentBuilder(): QuranPageComponent.Builder
 
   fun inject(pagerActivity: PagerActivity)
-  fun inject(ayahTranslationFragment: AyahTranslationFragment)
   fun inject(ayahToolBar: AyahToolBar)
+
+  fun inject(tagBookmarkFragment: TagBookmarkFragment)
+  fun inject(ayahPlaybackFragment: AyahPlaybackFragment)
+  fun inject(ayahTranslationFragment: AyahTranslationFragment)
 
   @Subcomponent.Builder
   interface Builder {

--- a/app/src/main/java/com/quran/labs/androidquran/di/component/application/ApplicationComponent.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/di/component/application/ApplicationComponent.kt
@@ -84,7 +84,6 @@ interface ApplicationComponent {
   fun inject(quranAdvancedSettingsFragment: QuranAdvancedSettingsFragment)
   fun inject(suraListFragment: SuraListFragment)
   fun inject(juzListFragment: JuzListFragment)
-  fun inject(ayahPlaybackFragment: AyahPlaybackFragment)
   fun inject(jumpFragment: JumpFragment)
 
   // dialogs

--- a/app/src/main/java/com/quran/labs/androidquran/ui/fragment/AyahPlaybackFragment.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/fragment/AyahPlaybackFragment.kt
@@ -12,7 +12,6 @@ import android.widget.Button
 import android.widget.CheckBox
 import com.quran.data.core.QuranInfo
 import com.quran.data.model.SuraAyah
-import com.quran.labs.androidquran.QuranApplication
 import com.quran.labs.androidquran.R
 import com.quran.labs.androidquran.R.array
 import com.quran.labs.androidquran.R.dimen
@@ -134,7 +133,7 @@ class AyahPlaybackFragment : AyahActionFragment() {
 
   override fun onAttach(context: Context) {
     super.onAttach(context)
-    (context.applicationContext as QuranApplication).applicationComponent.inject(this)
+    (activity as? PagerActivity)?.pagerActivityComponent?.inject(this)
   }
 
   private val onClickListener = View.OnClickListener { v: View ->

--- a/app/src/main/java/com/quran/labs/androidquran/ui/fragment/TagBookmarkFragment.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/fragment/TagBookmarkFragment.kt
@@ -1,0 +1,62 @@
+package com.quran.labs.androidquran.ui.fragment
+
+import android.content.Context
+import android.os.Bundle
+import com.quran.data.core.QuranInfo
+import com.quran.data.model.SuraAyah
+import com.quran.data.model.selection.AyahSelection
+import com.quran.data.model.selection.startSuraAyah
+import com.quran.labs.androidquran.ui.PagerActivity
+import com.quran.reading.common.AudioEventPresenter
+import com.quran.reading.common.ReadingEventPresenter
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.launchIn
+import javax.inject.Inject
+
+class TagBookmarkFragment : TagBookmarkDialog() {
+  private var scope: CoroutineScope = MainScope()
+
+  @Inject
+  lateinit var readingEventPresenter: ReadingEventPresenter
+
+  @Inject
+  lateinit var audioEventPresenter: AudioEventPresenter
+
+  @Inject
+  lateinit var quranInfo: QuranInfo
+
+  override fun onAttach(context: Context) {
+    super.onAttach(context)
+    (activity as? PagerActivity)?.pagerActivityComponent?.inject(this)
+  }
+
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+
+    scope = MainScope()
+    readingEventPresenter.ayahSelectionFlow
+      .combine(audioEventPresenter.audioPlaybackAyahFlow) { selectedAyah, playbackAyah ->
+        val start = when {
+          selectedAyah !is AyahSelection.None -> selectedAyah.startSuraAyah()
+          playbackAyah != null -> playbackAyah
+          else -> null
+        }
+
+        if (start != null) {
+          val page = quranInfo.getPageFromSuraAyah(start.sura, start.ayah)
+          tagBookmarkPresenter.setAyahBookmarkMode(start.sura, start.ayah, page)
+        }
+      }
+      .launchIn(scope)
+  }
+
+  override fun onDestroy() {
+    scope.cancel()
+    super.onDestroy()
+  }
+
+  override fun shouldInject() = false
+}

--- a/app/src/main/java/com/quran/labs/androidquran/ui/helpers/SlidingPagerAdapter.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/helpers/SlidingPagerAdapter.java
@@ -7,6 +7,7 @@ import com.quran.labs.androidquran.R;
 import com.quran.labs.androidquran.ui.fragment.AyahPlaybackFragment;
 import com.quran.labs.androidquran.ui.fragment.AyahTranslationFragment;
 import com.quran.labs.androidquran.ui.fragment.TagBookmarkDialog;
+import com.quran.labs.androidquran.ui.fragment.TagBookmarkFragment;
 import com.quran.labs.androidquran.view.IconPageIndicator;
 
 public class SlidingPagerAdapter extends FragmentStatePagerAdapter implements
@@ -43,7 +44,7 @@ public class SlidingPagerAdapter extends FragmentStatePagerAdapter implements
     final int pos = getPagePosition(position);
     switch (pos) {
       case TAG_PAGE:
-        return new TagBookmarkDialog();
+        return new TagBookmarkFragment();
       case TRANSLATION_PAGE:
         return new AyahTranslationFragment();
       case AUDIO_PAGE:

--- a/common/reading/src/main/java/com/quran/reading/common/ReadingEventPresenter.kt
+++ b/common/reading/src/main/java/com/quran/reading/common/ReadingEventPresenter.kt
@@ -1,6 +1,7 @@
 package com.quran.reading.common
 
 import com.quran.data.core.QuranInfo
+import com.quran.data.di.ActivityScope
 import com.quran.data.model.SuraAyah
 import com.quran.data.model.selection.AyahSelection
 import com.quran.data.model.selection.SelectionIndicator
@@ -13,9 +14,8 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import javax.inject.Inject
-import javax.inject.Singleton
 
-@Singleton
+@ActivityScope
 class ReadingEventPresenter @Inject constructor(private val quranInfo: QuranInfo) {
   private val clicksInternalFlow = MutableSharedFlow<Unit>(
     replay = 0,


### PR DESCRIPTION
In a previous patch, ReadingEventPresenter was changed from activity
scope to singleton scope, mainly because some of the fragments in the
bottom panel were injected with an application scope. This fixes it by
injecting those with an activity scope.

Tags is a bit of a special case since it is shared both by the bottom
panel, and as a dialog in other cases. This bottom panel version needs
some extra things (observing the stream of changes, for example) that
the dialog version doesn't. This patch thus also splits the tag dialog
to have a subclass just for the bottom panel, and moves the relevant
logic to it.
