### PR TITLE
Add an interface for QuranPageInfo

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/di/module/activity/PagerActivityModule.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/di/module/activity/PagerActivityModule.kt
@@ -3,10 +3,13 @@ package com.quran.labs.androidquran.di.module.activity
 import android.content.Context
 import androidx.core.content.ContextCompat
 import com.quran.data.core.QuranInfo
+import com.quran.data.core.QuranPageInfo
 import com.quran.labs.androidquran.R
 import com.quran.data.di.ActivityScope
+import com.quran.labs.androidquran.data.QuranDisplayData
 import com.quran.labs.androidquran.ui.PagerActivity
 import com.quran.labs.androidquran.ui.helpers.AyahSelectedListener
+import com.quran.labs.androidquran.util.QuranPageInfoImpl
 import com.quran.labs.androidquran.util.QuranScreenInfo
 import com.quran.labs.androidquran.util.QuranUtils
 import com.quran.labs.androidquran.util.TranslationUtil
@@ -19,6 +22,14 @@ class PagerActivityModule(private val pagerActivity: PagerActivity) {
   @Provides
   fun provideAyahSelectedListener(): AyahSelectedListener {
     return pagerActivity
+  }
+
+  @Provides
+  fun provideQuranPageInfo(
+    quranInfo: QuranInfo,
+    quranDisplayData: QuranDisplayData
+  ): QuranPageInfo {
+    return QuranPageInfoImpl(pagerActivity, quranInfo, quranDisplayData)
   }
 
   @Provides

--- a/app/src/main/java/com/quran/labs/androidquran/util/QuranPageInfoImpl.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/util/QuranPageInfoImpl.kt
@@ -1,0 +1,30 @@
+package com.quran.labs.androidquran.util
+
+import android.content.Context
+import com.quran.data.core.QuranInfo
+import com.quran.data.core.QuranPageInfo
+import com.quran.labs.androidquran.data.QuranDisplayData
+import com.quran.labs.androidquran.ui.helpers.QuranDisplayHelper
+
+class QuranPageInfoImpl constructor(
+  private val context: Context,
+  private val quranInfo: QuranInfo,
+  private val quranDisplayData: QuranDisplayData
+): QuranPageInfo {
+
+  override fun juz(page: Int): String {
+    return quranDisplayData.getJuzDisplayStringForPage(context, page)
+  }
+
+  override fun suraName(page: Int): String {
+    return quranDisplayData.getSuraNameFromPage(context, page, true)
+  }
+
+  override fun displayRub3(page: Int): String {
+    return QuranDisplayHelper.displayRub3(context, quranInfo, page)
+  }
+
+  override fun localizedPage(page: Int): String {
+    return QuranUtils.getLocalizedNumber(context, page)
+  }
+}

--- a/common/data/src/main/java/com/quran/data/core/QuranPageInfo.kt
+++ b/common/data/src/main/java/com/quran/data/core/QuranPageInfo.kt
@@ -1,0 +1,8 @@
+package com.quran.data.core
+
+interface QuranPageInfo {
+  fun juz(page: Int): String
+  fun suraName(page: Int): String
+  fun displayRub3(page: Int): String
+  fun localizedPage(page: Int): String
+}


### PR DESCRIPTION
This adds an interface for getting some information about a page (the
sura name, juz', rub3, etc). While the info itself is present within
QuranInfo, there are some utility methods that should ideally be used.
