### PR TITLE
Fix ImageUtil crash during call when canceled

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/util/ImageUtil.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/util/ImageUtil.kt
@@ -20,45 +20,44 @@ class ImageUtil @Inject constructor(private val okHttpClient: OkHttpClient) {
       if (!outputPath.exists()) {
         val destination = File(outputPath.path + ".tmp")
         val request = Request.Builder()
-            .url(url)
-            .build()
+          .url(url)
+          .build()
         val call = okHttpClient.newCall(request)
 
-        val response = call.execute()
-
-        if (response.isSuccessful) {
-          try {
+        try {
+          val response = call.execute()
+          if (response.isSuccessful) {
             // save the png from the download to a temporary file
             response.body
-                ?.source()
-                ?.use { source ->
-                  destination.sink()
-                      .buffer()
-                      .use { destination ->
-                        destination.writeAll(source)
-                      }
-                }
+              ?.source()
+              ?.use { source ->
+                destination.sink()
+                  .buffer()
+                  .use { destination ->
+                    destination.writeAll(source)
+                  }
+              }
 
             // and write it to the normal file
             destination.source()
-                .use { source ->
-                  outputPath.sink()
-                      .buffer()
-                      .use { destination ->
-                        destination.writeAll(source)
-                      }
-                }
+              .use { source ->
+                outputPath.sink()
+                  .buffer()
+                  .use { destination ->
+                    destination.writeAll(source)
+                  }
+              }
 
             // and delete the old one
             destination.delete()
-          } catch (interruptedIoException: InterruptedIOException) {
-            // if we're interrupted, pretend nothing happened. This happened
-            // due to a dispose / cancellation. Maybe's fromCallable will not
-            // actually emit in this case.
-            //
-            // a more proper fix would probably be to use Maybe.create and
-            // set a cancellation handler to stop the network call.
           }
+        } catch (interruptedIoException: InterruptedIOException) {
+          // if we're interrupted, pretend nothing happened. This happened
+          // due to a dispose / cancellation. Maybe's fromCallable will not
+          // actually emit in this case.
+          //
+          // a more proper fix would probably be to use Maybe.create and
+          // set a cancellation handler to stop the network call.
         }
       }
       outputPath


### PR DESCRIPTION
If the stream is canceled due to the activity going away during the call
itself (before the try block), we'd crash with an InterruptedException.
This adds the call itself into the try to avoid this from crashing.
