### PR TITLE
Fallback to images if page types fail to download

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/presenter/data/QuranDataPresenter.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/presenter/data/QuranDataPresenter.kt
@@ -15,6 +15,7 @@ import com.quran.data.core.QuranInfo
 import com.quran.data.model.QuranDataStatus
 import com.quran.data.source.PageProvider
 import com.quran.common.upgrade.LocalDataUpgrade
+import com.quran.data.source.PageContentType
 import com.quran.labs.androidquran.QuranDataActivity
 import com.quran.labs.androidquran.data.Constants
 import com.quran.labs.androidquran.presenter.Presenter
@@ -110,6 +111,17 @@ class QuranDataPresenter @Inject internal constructor(
     WorkManager.getInstance(appContext)
         .enqueueUniquePeriodicWork(Constants.AUDIO_UPDATE_UNIQUE_WORK,
             ExistingPeriodicWorkPolicy.KEEP, updateAudioTask)
+  }
+
+  fun imagesVersion() = quranPageProvider.getImageVersion()
+
+  fun canProceedWithoutDownload() = quranPageProvider.getPageContentType() == PageContentType.IMAGE
+
+  fun fallbackToImageType() {
+    val fallbackType = quranPageProvider.getFallbackPageType()
+    if (fallbackType != null) {
+      quranSettings.pageType = fallbackType
+    }
   }
 
   fun getDebugLog(): String = debugLog ?: ""

--- a/common/data/src/main/java/com/quran/data/source/PageProvider.kt
+++ b/common/data/src/main/java/com/quran/data/source/PageProvider.kt
@@ -24,4 +24,5 @@ interface PageProvider {
   @StringRes fun getPreviewDescription(): Int
 
   fun getPageContentType(): PageContentType = PageContentType.IMAGE
+  fun getFallbackPageType(): String? = null
 }


### PR DESCRIPTION
Whereas the normal full pages can be loaded on demand, the new line by
line images need to all be present for them to be used. This patch
updates the image checking code to fall back to the full madani pages if
the line by line pages fail to download completely.

Refs #1589.
