### PR TITLE
Fix compilation with Dagger 2.40.5

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -139,6 +139,10 @@ dependencies {
   implementation "com.google.android.material:material:${materialComponentsVersion}"
   implementation "androidx.swiperefreshlayout:swiperefreshlayout:${androidxSwipeRefreshVersion}"
 
+  // Dagger 2.40.5 will not be able to resolve @StabilityInferred without this
+  // see https://github.com/google/dagger/issues/3090
+  implementation "androidx.compose.runtime:runtime:$composeVersion"
+
   // rx
   implementation 'io.reactivex.rxjava3:rxjava:3.1.3'
   implementation 'io.reactivex.rxjava3:rxandroid:3.0.0'

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
     kotlinVersion = '1.5.31'
     coroutinesVersion = '1.5.2'
 
-    daggerVersion = '2.40.3'
+    daggerVersion = '2.40.5'
     composeVersion = '1.0.4'
 
     androidxMediaVersion = '1.4.3'


### PR DESCRIPTION
Compilation with Dagger 2.40.4 or 2.40.5 would fail when including the
non-open source code. This patch fixes it.
