### PR TITLE
Respect first ayah start time

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/service/AudioService.java
+++ b/app/src/main/java/com/quran/labs/androidquran/service/AudioService.java
@@ -503,7 +503,12 @@ public class AudioService extends Service implements OnCompletionListener,
         int ayah = audioQueue.getCurrentAyah();
         int time = gaplessSuraData.get(ayah);
         if (ayah == 1 && !isRepeating) {
-          return gaplessSuraData.get(0);
+          final int whence = gaplessSuraData.get(0, -1);
+          if (whence == -1) {
+            return gaplessSuraData.get(1);
+          } else {
+            return whence;
+          }
         }
         return time;
       }


### PR DESCRIPTION
Today, when starting at the first ayah, we'd return the position of the
"0th" ayah to get a basmallah, etc if present. This causes an issue when
there is no "0th" ayah set. In those cases, the file starts playback at
the very start instead of at the position where the first ayah should
start. This patch fixes this issue.
