### PR TITLE
Allow customization of search for other qira2at

### DIFF
--- a/app/src/madani/java/com/quran/labs/androidquran/data/QuranFileConstants.kt
+++ b/app/src/madani/java/com/quran/labs/androidquran/data/QuranFileConstants.kt
@@ -10,13 +10,12 @@ object QuranFileConstants {
 
   // arabic database
   const val ARABIC_DATABASE = MadaniConstants.ARABIC_DATABASE
-
   const val ARABIC_SHARE_TABLE = DatabaseHandler.SHARE_TEXT_TABLE
 
   // SDK_INT is always >= 21
   const val ARABIC_SHARE_TEXT_HAS_BASMALLAH = true
-
   const val FETCH_QUARTER_NAMES_FROM_DATABASE = false
 
   const val FALLBACK_PAGE_TYPE = "madani"
+  const val SEARCH_EXTRA_REPLACEMENTS = ""
 }

--- a/app/src/main/java/com/quran/labs/androidquran/database/DatabaseHandler.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/database/DatabaseHandler.kt
@@ -21,7 +21,6 @@ import com.quran.labs.androidquran.util.QuranFileUtils
 import com.quran.labs.androidquran.util.TranslationUtil
 import timber.log.Timber
 import java.io.File
-import java.util.*
 
 class DatabaseHandler private constructor(
   context: Context,
@@ -85,7 +84,7 @@ class DatabaseHandler private constructor(
         ContextCompat.getColor(context, R.color.translation_highlight) +
         "\">"
     defaultSearcher = DefaultSearcher(matchString, MATCH_END, ELLIPSES)
-    arabicSearcher = ArabicSearcher(defaultSearcher, matchString, MATCH_END)
+    arabicSearcher = ArabicSearcher(defaultSearcher, matchString, MATCH_END, QuranFileConstants.SEARCH_EXTRA_REPLACEMENTS)
 
     // if there's no Quran base directory, there are no databases
     val base = quranFileUtils.getQuranDatabaseDirectory(context)

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -158,7 +158,7 @@
   <string name="quran_sura_title">سُورَةُ %1$s</string>
 
   <string name="sura_ayah_notification_str">سورة %1$s، آية %2$d</string>
-  <string name="sura_ayah_sharing_str">سورة %1$: %2$d</string>
+  <string name="sura_ayah_sharing_str">سورة %1$s: %2$d</string>
 
   <string name="index_loading">جاري التحميل…</string>
 

--- a/app/src/naskh/java/com/quran/labs/androidquran/data/QuranFileConstants.kt
+++ b/app/src/naskh/java/com/quran/labs/androidquran/data/QuranFileConstants.kt
@@ -14,4 +14,5 @@ object QuranFileConstants {
   const val ARABIC_SHARE_TEXT_HAS_BASMALLAH = false
   const val FETCH_QUARTER_NAMES_FROM_DATABASE = false
   const val FALLBACK_PAGE_TYPE = "naskh"
+  const val SEARCH_EXTRA_REPLACEMENTS = ""
 }

--- a/app/src/qaloon/java/com/quran/labs/androidquran/data/QuranFileConstants.kt
+++ b/app/src/qaloon/java/com/quran/labs/androidquran/data/QuranFileConstants.kt
@@ -14,4 +14,5 @@ object QuranFileConstants {
   const val FETCH_QUARTER_NAMES_FROM_DATABASE = false
 
   const val FALLBACK_PAGE_TYPE = "qaloon"
+  const val SEARCH_EXTRA_REPLACEMENTS = ""
 }

--- a/app/src/shemerly/java/com/quran/labs/androidquran/data/QuranFileConstants.kt
+++ b/app/src/shemerly/java/com/quran/labs/androidquran/data/QuranFileConstants.kt
@@ -14,4 +14,5 @@ object QuranFileConstants {
   const val FETCH_QUARTER_NAMES_FROM_DATABASE = false
 
   const val FALLBACK_PAGE_TYPE = "shemerly"
+  const val SEARCH_EXTRA_REPLACEMENTS = ""
 }

--- a/app/src/warsh/java/com/quran/labs/androidquran/data/QuranFileConstants.kt
+++ b/app/src/warsh/java/com/quran/labs/androidquran/data/QuranFileConstants.kt
@@ -14,4 +14,5 @@ object QuranFileConstants {
   const val FETCH_QUARTER_NAMES_FROM_DATABASE = true
 
   const val FALLBACK_PAGE_TYPE = "warsh"
+  const val SEARCH_EXTRA_REPLACEMENTS = "\u0626"
 }

--- a/common/search/src/main/java/com/quran/common/search/ArabicSearcher.kt
+++ b/common/search/src/main/java/com/quran/common/search/ArabicSearcher.kt
@@ -8,7 +8,10 @@ import java.util.regex.Pattern
 
 class ArabicSearcher(private val defaultSearcher: Searcher,
                      private val matchStart: String,
-                     private val matchEnd: String) : Searcher {
+                     private val matchEnd: String,
+                     extraReplacements: String = "") : Searcher {
+  private val arabicRegex = "[$arabicRegexChars$extraReplacements]".toRegex()
+
   override fun getQuery(withSnippets: Boolean,
                         hasFTS: Boolean,
                         table: String,
@@ -76,6 +79,6 @@ class ArabicSearcher(private val defaultSearcher: Searcher,
   }
 
   companion object {
-    private val arabicRegex =  "[\u0627\u0623\u0621\u062a\u0629\u0647\u0648\u0649]".toRegex()
+    private const val arabicRegexChars =  "\u0627\u0623\u0621\u062a\u0629\u0647\u0648\u0649"
   }
 }

--- a/common/search/src/main/java/com/quran/common/search/arabic/ArabicCharacterHelper.kt
+++ b/common/search/src/main/java/com/quran/common/search/arabic/ArabicCharacterHelper.kt
@@ -1,6 +1,7 @@
 package com.quran.common.search.arabic
 
 object ArabicCharacterHelper {
+  private const val bannedChars = "[()]"
   private val lookupTable = hashMapOf(
       // given: ا
       // match: آأإاﻯ
@@ -32,18 +33,24 @@ object ArabicCharacterHelper {
 
       // given: ﻯ
       // match: ﻯي
-      "\u0649" to "\u0649\u064a"
+      "\u0649" to "\u0649\u064a",
+
+      // given: ئ
+      // match: ئﻯي
+      // this is helpful for rewayat Warsh, and thus only enabled on it
+      "\u0626" to "\u0626\u0649\u064a",
   )
 
   fun generateRegex(query: String): String {
     val characters = query.toCharArray()
     val regexBuilder = StringBuilder()
     characters.forEach {
-      if (lookupTable.containsKey(it.toString())) {
+      val result = lookupTable[it.toString()]
+      if (result != null) {
         regexBuilder.append("[")
-        regexBuilder.append(lookupTable[it.toString()])
+        regexBuilder.append(result)
         regexBuilder.append("]")
-      } else {
+      } else if (it !in bannedChars){
         regexBuilder.append(it)
       }
     }


### PR DESCRIPTION
In warsh, we want to support replacing a hamza with a ya, but we don't
want to do this in hafs for now. This allows search to take extra
match types for certain types.
