### PR TITLE
Minor performance improvements

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/view/AudioStatusBar.java
+++ b/app/src/main/java/com/quran/labs/androidquran/view/AudioStatusBar.java
@@ -307,8 +307,7 @@ public class AudioStatusBar extends LeftToRightLinearLayout {
           });
     }
     spinner.setSelection(currentQari);
-    final LayoutParams params = new LayoutParams(0, ViewGroup.LayoutParams.MATCH_PARENT);
-    params.weight = 1;
+    final LayoutParams params = new LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT);
     if (isRtl) {
       ViewCompat.setLayoutDirection(spinner, ViewCompat.LAYOUT_DIRECTION_RTL);
       params.leftMargin = spinnerPadding;


### PR DESCRIPTION
onCreateOptionsMenu is re-called every time the menu is invalidated in a
toolbar world. This can be expensive, especially when we are inflating a
SearchView each time. This patch fixes this by caching the menu item and
modifying the enabled state of it instead.

Moreover, replace a weight 1 on a single view with match parent to avoid
unnecessary measurement of spinner children.
