### PR TITLE
Migrate bookmarks and recents on page type change

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/database/BookmarksDBAdapter.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/database/BookmarksDBAdapter.kt
@@ -48,6 +48,12 @@ class BookmarksDBAdapter @Inject constructor(bookmarksDatabase: BookmarksDatabas
       .executeAsList()
   }
 
+  fun replaceRecentPages(pages: List<RecentPage>) {
+    lastPageQueries.transaction {
+      pages.forEach { addRecentPage(it.page) }
+    }
+  }
+
   fun replaceRecentRangeWithPage(deleteRangeStart: Int, deleteRangeEnd: Int, page: Int) {
     val maxPages = Constants.MAX_RECENT_PAGES.toLong()
     lastPageQueries.replaceRangeWithPage(deleteRangeStart, deleteRangeEnd, page, maxPages)

--- a/app/src/main/java/com/quran/labs/androidquran/database/BookmarksDaoImpl.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/database/BookmarksDaoImpl.kt
@@ -2,6 +2,7 @@ package com.quran.labs.androidquran.database
 
 import com.quran.data.dao.BookmarksDao
 import com.quran.data.model.bookmark.Bookmark
+import com.quran.data.model.bookmark.RecentPage
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
@@ -19,6 +20,18 @@ class BookmarksDaoImpl @Inject constructor(
   override suspend fun replaceBookmarks(bookmarks: List<Bookmark>) {
     withContext(Dispatchers.IO) {
       bookmarksDBAdapter.updateBookmarks(bookmarks)
+    }
+  }
+
+  override suspend fun recentPages(): List<RecentPage> {
+    return withContext(Dispatchers.IO) {
+      bookmarksDBAdapter.getRecentPages()
+    }
+  }
+
+  override suspend fun replaceRecentPages(pages: List<RecentPage>) {
+    withContext(Dispatchers.IO) {
+      bookmarksDBAdapter.replaceRecentPages(pages)
     }
   }
 }

--- a/app/src/main/java/com/quran/labs/androidquran/model/bookmark/BookmarkModel.java
+++ b/app/src/main/java/com/quran/labs/androidquran/model/bookmark/BookmarkModel.java
@@ -52,6 +52,14 @@ public class BookmarkModel {
     return bookmarksPublishSubject.hide();
   }
 
+  public void notifyBookmarksUpdated() {
+    bookmarksPublishSubject.onNext(true);
+  }
+
+  public void notifyRecentPagesUpdated() {
+    recentPageModel.notifyRecentPagesUpdated();
+  }
+
   public Single<BookmarkData> getBookmarkDataObservable(final int sortOrder) {
     return Single.zip(getTagsObservable(),
         getBookmarksObservable(sortOrder),

--- a/app/src/main/java/com/quran/labs/androidquran/pageselect/PageSelectActivity.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/pageselect/PageSelectActivity.kt
@@ -10,6 +10,9 @@ import com.quran.labs.androidquran.QuranDataActivity
 import com.quran.labs.androidquran.R
 import com.quran.labs.androidquran.ui.helpers.QuranDisplayHelper
 import com.quran.labs.androidquran.util.QuranSettings
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 class PageSelectActivity : AppCompatActivity() {
@@ -18,6 +21,9 @@ class PageSelectActivity : AppCompatActivity() {
 
   private lateinit var adapter : PageSelectAdapter
   private lateinit var viewPager: ViewPager
+
+  private val scope = MainScope()
+  private var isProcessing = false
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
@@ -55,6 +61,7 @@ class PageSelectActivity : AppCompatActivity() {
 
   override fun onDestroy() {
     adapter.cleanUp()
+    scope.cancel()
     super.onDestroy()
   }
 
@@ -65,13 +72,26 @@ class PageSelectActivity : AppCompatActivity() {
   private fun onPageTypeSelected(type: String) {
     val pageType = quranSettings.pageType
     if (pageType != type) {
-      quranSettings.removeDidDownloadPages()
-      quranSettings.pageType = type
-      val intent = Intent(this, QuranDataActivity::class.java).apply {
-        addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_NEW_TASK)
+      isProcessing = true
+      scope.launch {
+        // migrate the bookmarks
+        presenter.migrateBookmarksData(pageType, type)
+
+        // we need to re-check the pages now
+        quranSettings.removeDidDownloadPages()
+        // and we can set up our new page type
+        quranSettings.pageType = type
+
+        // go back to Quran Data Activity
+        val intent = Intent(this@PageSelectActivity, QuranDataActivity::class.java).apply {
+          addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+        startActivity(intent)
+        finish()
       }
-      startActivity(intent)
+    } else {
+      finish()
     }
-    finish()
+    isProcessing = false
   }
 }

--- a/app/src/main/java/com/quran/labs/androidquran/pageselect/PageSelectPresenter.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/pageselect/PageSelectPresenter.kt
@@ -1,6 +1,10 @@
 package com.quran.labs.androidquran.pageselect
 
+import com.quran.data.core.QuranInfo
+import com.quran.data.dao.BookmarksDao
 import com.quran.data.source.PageProvider
+import com.quran.labs.androidquran.database.BookmarksDBAdapter
+import com.quran.labs.androidquran.model.bookmark.BookmarkModel
 import com.quran.labs.androidquran.presenter.Presenter
 import com.quran.labs.androidquran.util.ImageUtil
 import com.quran.labs.androidquran.util.QuranFileUtils
@@ -9,19 +13,27 @@ import dagger.Reusable
 import io.reactivex.rxjava3.core.Scheduler
 import io.reactivex.rxjava3.disposables.CompositeDisposable
 import io.reactivex.rxjava3.schedulers.Schedulers
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import timber.log.Timber
 import java.io.File
 import javax.inject.Inject
 
 @Reusable
 class PageSelectPresenter @Inject
-    constructor(private val imageUtil: ImageUtil,
-                private val quranFileUtils: QuranFileUtils,
-                private val mainThreadScheduler: Scheduler,
-                private val urlUtil: UrlUtil,
-                private val pageTypes:
-                Map<@JvmSuppressWildcards String, @JvmSuppressWildcards PageProvider>) :
-    Presenter<PageSelectActivity> {
+constructor(
+  private val imageUtil: ImageUtil,
+  private val quranFileUtils: QuranFileUtils,
+  private val mainThreadScheduler: Scheduler,
+  private val urlUtil: UrlUtil,
+  private val bookmarksDao: BookmarksDao,
+  // unfortunately needed for now due to the old Rx code
+  // not knowing about changes from BookmarksDao, etc.
+  private val bookmarkModel: BookmarkModel,
+  private val pageTypes:
+  Map<@JvmSuppressWildcards String, @JvmSuppressWildcards PageProvider>
+) :
+  Presenter<PageSelectActivity> {
   private val baseUrl = "https://android.quran.com/data/pagetypes/snips"
   private val compositeDisposable = CompositeDisposable()
   private val downloadingSet = mutableSetOf<String>()
@@ -41,28 +53,89 @@ class PageSelectPresenter @Inject
         val previewImage = File(outputPath, "${it.key}.png")
         val downloadedImage = if (previewImage.exists()) {
           previewImage
-        } else if (!downloadingSet.contains(it.key)){
+        } else if (!downloadingSet.contains(it.key)) {
           downloadingSet.add(it.key)
           val url = "$baseUrl/${it.key}.png"
           compositeDisposable.add(
-              imageUtil.downloadImage(url, previewImage)
-                  .onErrorResumeWith(
-                      imageUtil.downloadImage(urlUtil.fallbackUrl(url), previewImage))
-                  .subscribeOn(Schedulers.io())
-                  .observeOn(mainThreadScheduler)
-                  .subscribe({ generateData() }, { e -> Timber.e(e) })
+            imageUtil.downloadImage(url, previewImage)
+              .onErrorResumeWith(
+                imageUtil.downloadImage(urlUtil.fallbackUrl(url), previewImage)
+              )
+              .subscribeOn(Schedulers.io())
+              .observeOn(mainThreadScheduler)
+              .subscribe({ generateData() }, { e -> Timber.e(e) })
           )
           null
         } else {
           // already downloading
           null
         }
-        PageTypeItem(it.key,
-            downloadedImage,
-            provider.getPreviewTitle(),
-            provider.getPreviewDescription())
+        PageTypeItem(
+          it.key,
+          downloadedImage,
+          provider.getPreviewTitle(),
+          provider.getPreviewDescription()
+        )
       }
       currentView?.onUpdatedData(data)
+    }
+  }
+
+  /**
+   * Migrate bookmark and recent page data between two page types
+   * Consider a page set like madani (604 pages) versus one like Shemerly (521 pages).
+   * When switching between them, bookmarks need to be mapped so that the same bookmark
+   * retains its meaning.
+   *
+   * Note that this does not support non-Hafs qira'at yet, where the ayah numbers may
+   * have changed due to kufi versus madani counting.
+   */
+  suspend fun migrateBookmarksData(sourcePageType: String, destinationPageType: String) {
+    val source = pageTypes[sourcePageType]?.getDataSource()
+    val destination = pageTypes[destinationPageType]?.getDataSource()
+    if (source != null && destination != null && source.getNumberOfPages() != destination.getNumberOfPages()) {
+      val sourcePageSuraStart = source.getSuraForPageArray()
+      val sourcePageAyahStart = source.getAyahForPageArray()
+      val destinationQuranInfo = QuranInfo(destination)
+
+      val suraAyahFromPage = { page: Int ->
+        sourcePageSuraStart[page - 1] to sourcePageAyahStart[page - 1]
+      }
+
+      // update the bookmarks
+      val updatedBookmarks = bookmarksDao.bookmarks()
+        .map {
+          val page = it.page
+          val (pageSura, pageAyah) = suraAyahFromPage(page)
+          val sura = it.sura ?: pageSura
+          val ayah = it.ayah ?: pageAyah
+
+          val mappedPage = destinationQuranInfo.getPageFromSuraAyah(sura, ayah)
+
+          // we only copy the page because sura and ayah are the same.
+          it.copy(page = mappedPage)
+        }
+
+      if (updatedBookmarks.isNotEmpty()) {
+        bookmarksDao.replaceBookmarks(updatedBookmarks)
+        bookmarkModel.notifyBookmarksUpdated()
+      }
+
+      // and update the recents
+      val updatedRecentPages = bookmarksDao.recentPages()
+        .sortedBy { it.timestamp }
+        .map {
+          val page = it.page
+          val (pageSura, pageAyah) = suraAyahFromPage(page)
+
+          val mappedPage = destinationQuranInfo.getPageFromSuraAyah(pageSura, pageAyah)
+          it.copy(page = mappedPage)
+        }
+
+      if (updatedRecentPages.isNotEmpty()) {
+        bookmarksDao.replaceRecentPages(updatedRecentPages)
+        bookmarkModel.notifyRecentPagesUpdated()
+      }
     }
   }
 

--- a/app/src/main/java/com/quran/labs/androidquran/presenter/bookmark/BookmarkPresenter.java
+++ b/app/src/main/java/com/quran/labs/androidquran/presenter/bookmark/BookmarkPresenter.java
@@ -2,18 +2,19 @@ package com.quran.labs.androidquran.presenter.bookmark;
 
 import android.annotation.SuppressLint;
 import android.content.Context;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.VisibleForTesting;
-import com.google.android.material.snackbar.Snackbar;
 
+import com.google.android.material.snackbar.Snackbar;
 import com.quran.data.core.QuranInfo;
 import com.quran.data.model.bookmark.Bookmark;
 import com.quran.data.model.bookmark.BookmarkData;
 import com.quran.data.model.bookmark.RecentPage;
 import com.quran.data.model.bookmark.Tag;
+import com.quran.labs.androidquran.dao.bookmark.BookmarkResult;
 import com.quran.labs.androidquran.data.Constants;
 import com.quran.labs.androidquran.model.bookmark.BookmarkModel;
-import com.quran.labs.androidquran.dao.bookmark.BookmarkResult;
 import com.quran.labs.androidquran.model.translation.ArabicDatabaseUtils;
 import com.quran.labs.androidquran.presenter.Presenter;
 import com.quran.labs.androidquran.ui.fragment.BookmarksFragment;
@@ -31,16 +32,14 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import javax.inject.Inject;
-import javax.inject.Singleton;
 
+import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers;
 import io.reactivex.rxjava3.core.Observable;
 import io.reactivex.rxjava3.core.Single;
-import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers;
 import io.reactivex.rxjava3.observers.DisposableSingleObserver;
 import io.reactivex.rxjava3.schedulers.Schedulers;
 import timber.log.Timber;
 
-@Singleton
 public class BookmarkPresenter implements Presenter<BookmarksFragment> {
   @Snackbar.Duration public static final int DELAY_DELETION_DURATION_IN_MS = 4 * 1000; // 4 seconds
   private static final long BOOKMARKS_WITHOUT_TAGS_ID = -1;

--- a/app/src/main/java/com/quran/labs/androidquran/ui/helpers/QuranRowFactory.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/helpers/QuranRowFactory.java
@@ -1,19 +1,17 @@
 package com.quran.labs.androidquran.ui.helpers;
 
 import android.content.Context;
+
 import androidx.core.content.ContextCompat;
 
 import com.quran.data.core.QuranInfo;
-import com.quran.labs.androidquran.R;
 import com.quran.data.model.bookmark.Bookmark;
 import com.quran.data.model.bookmark.Tag;
+import com.quran.labs.androidquran.R;
 import com.quran.labs.androidquran.data.QuranDisplayData;
 
 import javax.inject.Inject;
 
-import dagger.Reusable;
-
-@Reusable
 public class QuranRowFactory {
   private final QuranInfo quranInfo;
   private final QuranDisplayData quranDisplayData;

--- a/common/data/src/main/java/com/quran/data/dao/BookmarksDao.kt
+++ b/common/data/src/main/java/com/quran/data/dao/BookmarksDao.kt
@@ -1,8 +1,13 @@
 package com.quran.data.dao
 
 import com.quran.data.model.bookmark.Bookmark
+import com.quran.data.model.bookmark.RecentPage
 
 interface BookmarksDao {
   suspend fun bookmarks(): List<Bookmark>
   suspend fun replaceBookmarks(bookmarks: List<Bookmark>)
+
+  // recent pages
+  suspend fun recentPages(): List<RecentPage>
+  suspend fun replaceRecentPages(pages: List<RecentPage>)
 }


### PR DESCRIPTION
This patch migrates bookmarks bookmarks and recent pages when the page
type changes to pages with a different number of overall pages. Note
that this is imprecise for page bookmarks, since the first ayah on a
page in the madani mushaf may be the last ayah on a page in shemerly or
vice versa.
