### PR TITLE
Only highlight the playing ayah in translation

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/ui/translation/TranslationAdapter.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/translation/TranslationAdapter.kt
@@ -423,21 +423,13 @@ internal class TranslationAdapter(
   }
 
   private fun updateHighlight(row: TranslationViewRow, holder: RowViewHolder) {
-    // toggle highlighting of the ayah, but not for sura headers and basmallah
+    // toggle highlighting of the ayah number and Quran text only
     val isHighlighted = row.ayahInfo.ayahId == highlightedAyah
-    if (row.type != TranslationViewRow.Type.SURA_HEADER &&
-      row.type != TranslationViewRow.Type.BASMALLAH &&
-      row.type != TranslationViewRow.Type.SPACER
-    ) {
+    if (row.type == TranslationViewRow.Type.VERSE_NUMBER ||
+      row.type == TranslationViewRow.Type.QURAN_TEXT) {
       holder.wrapperView.setBackgroundColor(
         if (isHighlighted) ayahSelectionColor else 0
       )
-    } else if (holder.divider != null) { // SPACER type
-      if (isHighlighted) {
-        holder.divider.highlight(ayahSelectionColor)
-      } else {
-        holder.divider.unhighlight()
-      }
     }
   }
 


### PR DESCRIPTION
Some people complain that visibility is poor when the entire ayah and
all the translations are highlighted during playback. This patch changes
highlighting for ayah playback to only be on the ayah number and ayah
text while in the full screen translation view.
