### PR TITLE
Fix recent pages and last page migration

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/database/BookmarksDBAdapter.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/database/BookmarksDBAdapter.kt
@@ -64,6 +64,10 @@ class BookmarksDBAdapter @Inject constructor(bookmarksDatabase: BookmarksDatabas
     lastPageQueries.addLastPage(page, maxPages)
   }
 
+  fun removeRecentPages() {
+    lastPageQueries.removeLastPages()
+  }
+
   fun getBookmarkTagIds(bookmarkId: Long): List<Long> {
     return bookmarkTagQueries.getTagIdsForBookmark(bookmarkId)
       .executeAsList()

--- a/app/src/main/java/com/quran/labs/androidquran/database/BookmarksDaoImpl.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/database/BookmarksDaoImpl.kt
@@ -34,4 +34,10 @@ class BookmarksDaoImpl @Inject constructor(
       bookmarksDBAdapter.replaceRecentPages(pages)
     }
   }
+
+  override suspend fun removeRecentPages() {
+    withContext(Dispatchers.IO) {
+      bookmarksDBAdapter.removeRecentPages()
+    }
+  }
 }

--- a/app/src/main/java/com/quran/labs/androidquran/model/bookmark/BookmarkModel.java
+++ b/app/src/main/java/com/quran/labs/androidquran/model/bookmark/BookmarkModel.java
@@ -56,8 +56,9 @@ public class BookmarkModel {
     bookmarksPublishSubject.onNext(true);
   }
 
-  public void notifyRecentPagesUpdated() {
+  public void notifyRecentPagesUpdated(int page) {
     recentPageModel.notifyRecentPagesUpdated();
+    recentPageModel.updateLatestPage(page);
   }
 
   public Single<BookmarkData> getBookmarkDataObservable(final int sortOrder) {

--- a/common/bookmark/src/main/sqldelight/com/quran/mobile/bookmark/LastPage.sq
+++ b/common/bookmark/src/main/sqldelight/com/quran/mobile/bookmark/LastPage.sq
@@ -11,6 +11,9 @@ addLastPage {
   );
 }
 
+removeLastPages:
+  DELETE FROM last_pages;
+
 replaceRangeWithPage {
   DELETE FROM last_pages WHERE page >= ? AND page <= ?;
   REPLACE INTO last_pages(page) VALUES(?);

--- a/common/data/src/main/java/com/quran/data/dao/BookmarksDao.kt
+++ b/common/data/src/main/java/com/quran/data/dao/BookmarksDao.kt
@@ -9,5 +9,6 @@ interface BookmarksDao {
 
   // recent pages
   suspend fun recentPages(): List<RecentPage>
+  suspend fun removeRecentPages()
   suspend fun replaceRecentPages(pages: List<RecentPage>)
 }


### PR DESCRIPTION
This patch fixes migrating recent pages when there are less than the
limit of recent pages present. It also properly maintains the order, and
properly allows going to the proper last page (whereas before, the old
last page was still cached).
