### PR TITLE
update english sura_names_translated

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -322,8 +322,7 @@
   <string name="get_translations">Get Translations</string>
 
   <!-- help -->
-  <string name="email_us">If your question is not answered above, you can email quranandroid@gmail.com for support.
-        Please note that we receive lots of emails, so we may not be able to reply to all of them.</string>
+  <string name="email_us">If your question is not answered above, you can email quranandroid@gmail.com for support.         Please note that we receive lots of emails, so we may not be able to reply to all of them.</string>
 
   <!-- sura metainfo -->
   <string name="makki">Makki</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -322,7 +322,8 @@
   <string name="get_translations">Get Translations</string>
 
   <!-- help -->
-  <string name="email_us">If your question is not answered above, you can email quranandroid@gmail.com for support.         Please note that we receive lots of emails, so we may not be able to reply to all of them.</string>
+  <string name="email_us">If your question is not answered above, you can email quranandroid@gmail.com for support.
+        Please note that we receive lots of emails, so we may not be able to reply to all of them.</string>
 
   <!-- sura metainfo -->
   <string name="makki">Makki</string>

--- a/app/src/main/res/values/sura_names.xml
+++ b/app/src/main/res/values/sura_names.xml
@@ -58,9 +58,9 @@
     <item>Ar-Rahmân</item>
     <item>Al-Wâqi`ah</item>
     <item>Al-Hadîd</item>
-    <item>Al-Mujâdalah</item>
+    <item>Al-Mujâdilah</item>
     <item>Al-Hashr</item>
-    <item>Al-Mumtahinah</item>
+    <item>Al-Mumtahanah</item>
     <item>As-Saff</item>
     <item>Al-Jumu`ah</item>
     <item>Al-Munâfiqûn</item>
@@ -120,119 +120,119 @@
   <!-- If sura name has no translation, please add empty double quotes to the
        respective item body to keep Android Studio happy -->
   <string-array name="sura_names_translation">
-    <item>The Opener</item>
+    <item>The Opening</item>
     <item>The Cow</item>
-    <item>Family of Imran</item>
+    <item>The Family of Imran</item>
     <item>The Women</item>
-    <item>The Table Spread</item>
+    <item>The Table Spread With Food</item>
     <item>The Cattle</item>
-    <item>The Heights</item>
+    <item>The Heights (or The Wall with Elevations)</item>
     <item>The Spoils of War</item>
     <item>The Repentance</item>
     <item>Jonah</item>
-    <item>Hud</item>
-    <item>Joseph</item>
+    <item>(Prophet) Hūd</item>
+    <item>(Prophet) Joseph</item>
     <item>The Thunder</item>
-    <item>Abrahim</item>
+    <item>Abraham</item>
     <item>The Rocky Tract</item>
-    <item>The Bee</item>
-    <item>The Night Journey</item>
+    <item>The Bees</item>
+    <item>The Journey by Night</item>
     <item>The Cave</item>
     <item>Mary</item>
-    <item>Ta-Ha</item>
+    <item>""</item>
     <item>The Prophets</item>
     <item>The Pilgrimage</item>
     <item>The Believers</item>
     <item>The Light</item>
-    <item>The Criterian</item>
+    <item>The Criterion</item>
     <item>The Poets</item>
-    <item>The Ant</item>
-    <item>The Stories</item>
+    <item>The Ants</item>
+    <item>The Narration</item>
     <item>The Spider</item>
     <item>The Romans</item>
-    <item>Luqman</item>
+    <item>Luqmān</item>
     <item>The Prostration</item>
-    <item>The Combined Forces</item>
+    <item>The Confederates</item>
     <item>Sheba</item>
-    <item>Originator</item>
-    <item>Ya Sin</item>
-    <item>Those who set the Ranks</item>
-    <item>The Letter &quot;Saad&quot;</item>
-    <item>The Troops</item>
+    <item>The Originator of Creation</item>
+    <item>""</item>
+    <item>Those Ranged in Ranks</item>
+    <item>""</item>
+    <item>The Groups</item>
     <item>The Forgiver</item>
-    <item>Explained in Detail</item>
+    <item>They are explained in detail</item>
     <item>The Consultation</item>
-    <item>The Ornaments of Gold</item>
+    <item>The Gold Adornments</item>
     <item>The Smoke</item>
-    <item>The Crouching</item>
-    <item>The Wind-Curved Sandhills</item>
-    <item>Muhammad</item>
+    <item>The Kneeling</item>
+    <item>The Curved Sand‑hills</item>
+    <item>Muḥammad صَلَّى ٱللَّهُ عَلَيۡهِ وَسَلَّمَ</item>
     <item>The Victory</item>
-    <item>The Rooms</item>
-    <item>The Letter &quot;Qaf&quot;</item>
-    <item>The Winnowing Winds</item>
+    <item>The Dwellings</item>
+    <item>""</item>
+    <item>The Winds that Scatter</item>
     <item>The Mount</item>
     <item>The Star</item>
     <item>The Moon</item>
-    <item>The Beneficent</item>
-    <item>The Inevitable</item>
-    <item>The Iron</item>
-    <item>The Pleading Woman</item>
-    <item>The Exile</item>
-    <item>She that is to be examined</item>
-    <item>The Ranks</item>
-    <item>The Congregation, Friday</item>
+    <item>The Most Gracious</item>
+    <item>The Event</item>
+    <item>Iron</item>
+    <item>The Woman Who Disputes</item>
+    <item>The Gathering</item>
+    <item>The Woman to be examined</item>
+    <item>The Row or the Rank</item>
+    <item>Friday</item>
     <item>The Hypocrites</item>
-    <item>The Mutual Disillusion</item>
+    <item>Mutual Loss and Gain</item>
     <item>The Divorce</item>
-    <item>The Prohibtiion</item>
-    <item>The Sovereignty</item>
+    <item>The Prohibition</item>
+    <item>Dominion</item>
     <item>The Pen</item>
-    <item>The Reality</item>
-    <item>The Ascending Stairways</item>
+    <item>The Inevitable</item>
+    <item>The Ways of Ascent</item>
     <item>Noah</item>
     <item>The Jinn</item>
-    <item>The Enshrouded One</item>
-    <item>The Cloaked One</item>
+    <item>The One wrapped in Garments</item>
+    <item>The One Enveloped</item>
     <item>The Resurrection</item>
-    <item>The Man</item>
-    <item>The Emissaries</item>
-    <item>The Tidings</item>
-    <item>Those who drag forth</item>
+    <item>Man</item>
+    <item>Those sent forth</item>
+    <item>The News</item>
+    <item>Those Who Pull Out</item>
     <item>He Frowned</item>
-    <item>The Overthrowing</item>
+    <item>Winding Round and losing its Light</item>
     <item>The Cleaving</item>
-    <item>The Defrauding</item>
-    <item>The Sundering</item>
-    <item>The Mansions of the Stars</item>
-    <item>The Nightcommer</item>
+    <item>Those Who Deal in Fraud</item>
+    <item>The Splitting Asunder</item>
+    <item>The Big Stars “Burūj”</item>
+    <item>The Night‑Comer</item>
     <item>The Most High</item>
     <item>The Overwhelming</item>
-    <item>The Dawn</item>
+    <item>The Break of Day or the Dawn</item>
     <item>The City</item>
     <item>The Sun</item>
     <item>The Night</item>
-    <item>The Morning Hours</item>
-    <item>The Relief</item>
+    <item>The Forenoon ‑ “After Sunrise”</item>
+    <item>The Opening Forth</item>
     <item>The Fig</item>
     <item>The Clot</item>
-    <item>The Power</item>
-    <item>The Clear Proof</item>
+    <item>The Night of Decree</item>
+    <item>The Clear Evidence</item>
     <item>The Earthquake</item>
-    <item>The Courser</item>
-    <item>The Calamity</item>
-    <item>The Rivalry in world increase</item>
-    <item>The Declining Day</item>
-    <item>The Traducer</item>
+    <item>Those That Run</item>
+    <item>The Striking Hour</item>
+    <item>The piling Up — The Emulous Desire</item>
+    <item>The Time</item>
+    <item>The Slanderer</item>
     <item>The Elephant</item>
-    <item>Quraysh</item>
+    <item>Quraish</item>
     <item>The Small Kindnesses</item>
-    <item>The Abundance</item>
+    <item>A River in Paradise</item>
     <item>The Disbelievers</item>
-    <item>The Divine Support</item>
-    <item>The Palm Fiber, Flame</item>
-    <item>The Sincerity</item>
+    <item>The Help</item>
+    <item>The Palm Fibre</item>
+    <item>The Purity</item>
     <item>The Daybreak</item>
-    <item>The Mankind</item>
+    <item>Mankind</item>
   </string-array>
 </resources>

--- a/app/src/main/res/values/sura_names.xml
+++ b/app/src/main/res/values/sura_names.xml
@@ -139,7 +139,7 @@
     <item>The Journey by Night</item>
     <item>The Cave</item>
     <item>Mary</item>
-    <item>""</item>
+    <item>Ta-Ha</item>
     <item>The Prophets</item>
     <item>The Pilgrimage</item>
     <item>The Believers</item>
@@ -155,9 +155,9 @@
     <item>The Confederates</item>
     <item>Sheba</item>
     <item>The Originator of Creation</item>
-    <item>""</item>
+    <item>Ya Sin</item>
     <item>Those Ranged in Ranks</item>
-    <item>""</item>
+    <item>The Letter &quot;Saad&quot;</item>
     <item>The Groups</item>
     <item>The Forgiver</item>
     <item>They are explained in detail</item>
@@ -169,7 +169,7 @@
     <item>Muḥammad صَلَّى ٱللَّهُ عَلَيۡهِ وَسَلَّمَ</item>
     <item>The Victory</item>
     <item>The Dwellings</item>
-    <item>""</item>
+    <item>The Letter &quot;Qaf&quot;</item>
     <item>The Winds that Scatter</item>
     <item>The Mount</item>
     <item>The Star</item>


### PR DESCRIPTION
The new list matches [Hilali&Khan 1441 print](https://www.almeshkat.net/book/15401). Except Surah 35, where I removed ", or The Angels" since we only have "Fâtir" instead of "Sūrat Fāṭir or Al-Malā’ikah". Other exceptions with similar arguments: Surah 40 and Surah 47 and Surah 76.

For Surah 47, I used "صَلَّى ٱللَّهُ عَلَيۡهِ وَسَلَّمَ" instead of "".

I also changed "Al-Mujâdalah" to "Al-Mujâdilah" to match "The Woman Who Disputes". Similarly, changed "Al-Mumtahinah" to "Al-Mumtahanah" to match "The Woman to be examined".


Also, empty entries in the pdf are kept as before.