### PR TITLE
Fix selection across multiple pages

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/presenter/quran/ayahtracker/AyahTrackerPresenter.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/presenter/quran/ayahtracker/AyahTrackerPresenter.kt
@@ -271,7 +271,7 @@ class AyahTrackerPresenter @Inject constructor(
       }
     }
 
-    val toolBarPosition = getToolBarPosition(startAyah.sura, startAyah.ayah)
+    val toolBarPosition = getToolBarPosition(selectedAyah.sura, selectedAyah.ayah)
     return if (endAyah == null) {
       AyahSelection.Ayah(startAyah, toolBarPosition)
     } else {

--- a/app/src/main/java/com/quran/labs/androidquran/ui/PagerActivity.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/PagerActivity.java
@@ -404,8 +404,8 @@ public class PagerActivity extends AppCompatActivity implements
             final SelectionIndicator updatedSelectionIndicator =
                 SelectionIndicatorKt.withXScroll(selectionIndicator, -positionOffsetPixels);
             readingEventPresenterBridge.withSelectionIndicator(updatedSelectionIndicator);
-          } else if (position == barPos - 1) {
-            // Swiping to prev ViewPager page (i.e. next quran page)
+          } else if (position == barPos - 1 || position == barPos + 1) {
+            // Swiping to previous or next ViewPager page (i.e. next or previous quran page)
             final SelectionIndicator updatedSelectionIndicator =
                 SelectionIndicatorKt.withXScroll(selectionIndicator, viewPager.getWidth() - positionOffsetPixels);
             readingEventPresenterBridge.withSelectionIndicator(updatedSelectionIndicator);

--- a/app/src/main/java/com/quran/labs/androidquran/util/QuranPageInfoImpl.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/util/QuranPageInfoImpl.kt
@@ -27,4 +27,8 @@ class QuranPageInfoImpl constructor(
   override fun localizedPage(page: Int): String {
     return QuranUtils.getLocalizedNumber(context, page)
   }
+
+  override fun pageForSuraAyah(sura: Int, ayah: Int): Int {
+    return quranInfo.getPageFromSuraAyah(sura, ayah)
+  }
 }

--- a/common/data/src/main/java/com/quran/data/core/QuranPageInfo.kt
+++ b/common/data/src/main/java/com/quran/data/core/QuranPageInfo.kt
@@ -5,4 +5,5 @@ interface QuranPageInfo {
   fun suraName(page: Int): String
   fun displayRub3(page: Int): String
   fun localizedPage(page: Int): String
+  fun pageForSuraAyah(sura: Int, ayah: Int): Int
 }


### PR DESCRIPTION
When selecting ayahs over multiple pages, the menu did not move to the
new page. This patch fixes it so now ayat can be selected on multiple
pages as was the case before. Note that there is a limit of 2 pages
worth of ayat (well, 4 if in tablet mode or side by side view, which
probably should be reduced in the future).
