### PR TITLE
Allow changing audio in panel during playback

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/ui/PagerActivity.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/PagerActivity.java
@@ -1887,10 +1887,12 @@ public class PagerActivity extends AppCompatActivity implements
         endAyahMode();
       }
       slidingPanel.hidePane();
+      readingEventPresenter.onPanelClosed();
     }
 
     @Override
     public void onPanelExpanded(View panel) {
+      readingEventPresenter.onPanelOpened();
     }
 
     @Override

--- a/app/src/main/java/com/quran/labs/androidquran/ui/fragment/AyahActionFragment.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/fragment/AyahActionFragment.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 
 abstract class AyahActionFragment : Fragment() {
@@ -44,12 +45,19 @@ abstract class AyahActionFragment : Fragment() {
       }
       .launchIn(scope)
 
+    readingEventPresenter.detailsPanelFlow
+      .map {
+        onToggleDetailsPanel(it)
+      }
+      .launchIn(scope)
   }
 
   override fun onDestroy() {
     scope.cancel()
     super.onDestroy()
   }
+
+  open fun onToggleDetailsPanel(isVisible: Boolean) { }
 
   protected abstract fun refreshView()
 }

--- a/app/src/main/java/com/quran/labs/androidquran/ui/fragment/AyahPlaybackFragment.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/fragment/AyahPlaybackFragment.kt
@@ -49,6 +49,7 @@ class AyahPlaybackFragment : AyahActionFragment() {
   private lateinit var endingAyahAdapter: ArrayAdapter<CharSequence>
 
   private var lastSeenAudioRequest: AudioRequest? = null
+  private var isOpen: Boolean = false
 
   @Inject
   lateinit var quranInfo: QuranInfo
@@ -278,13 +279,20 @@ class AyahPlaybackFragment : AyahActionFragment() {
     }
   }
 
+  override fun onToggleDetailsPanel(isVisible: Boolean) {
+    isOpen = isVisible
+    if (!isOpen) {
+      refreshView()
+    }
+  }
+
   override fun refreshView() {
     val context: Context? = activity
     val selectionEnd = end
     val selectionStart = start
 
     var shouldReset = true
-    if (context is PagerActivity && selectionStart != null && selectionEnd != null) {
+    if (context is PagerActivity && selectionStart != null && selectionEnd != null && !isOpen) {
       val lastRequest = context.lastAudioRequest
       val start: SuraAyah
       val ending: SuraAyah

--- a/common/reading/src/main/java/com/quran/reading/common/ReadingEventPresenter.kt
+++ b/common/reading/src/main/java/com/quran/reading/common/ReadingEventPresenter.kt
@@ -22,9 +22,11 @@ class ReadingEventPresenter @Inject constructor(private val quranInfo: QuranInfo
     extraBufferCapacity = 1,
     onBufferOverflow = DROP_OLDEST
   )
+  private val detailsPanelInternalFlow = MutableStateFlow<Boolean>(false)
   private val ayahSelectionInternalFlow = MutableStateFlow<AyahSelection>(AyahSelection.None)
 
   val clicksFlow: Flow<Unit> = clicksInternalFlow.asSharedFlow()
+  val detailsPanelFlow: Flow<Boolean> = detailsPanelInternalFlow.asSharedFlow()
   val ayahSelectionFlow: StateFlow<AyahSelection> = ayahSelectionInternalFlow.asStateFlow()
 
   fun onClick() {
@@ -82,5 +84,13 @@ class ReadingEventPresenter @Inject constructor(private val quranInfo: QuranInfo
         onAyahSelection(AyahSelection.Ayah(updatedAyah, SelectionIndicator.None))
       }
     }
+  }
+
+  fun onPanelOpened() {
+    detailsPanelInternalFlow.value = true
+  }
+
+  fun onPanelClosed() {
+    detailsPanelInternalFlow.value = false
   }
 }


### PR DESCRIPTION
This patch adds a flow for whether or not the panel is open, and does
not refresh the view if the audio panel is open, but does so when the
audio panel is closed.
