### PR TITLE
Fix night mode page color preference

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/ui/preference/SeekBarBackgroundBrightnessPreference.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/preference/SeekBarBackgroundBrightnessPreference.kt
@@ -10,11 +10,11 @@ class SeekBarBackgroundBrightnessPreference(
   context: Context, attrs: AttributeSet
 ) : SeekBarPreference(context, attrs) {
 
-  override fun getPreviewVisibility(): Int = View.VISIBLE
+  override fun getPreviewVisibility(): Int = View.GONE
 
   override fun onProgressChanged(seekBar: SeekBar, progress: Int, fromUser: Boolean) {
     super.onProgressChanged(seekBar, progress, fromUser)
-    previewBox.visibility = View.GONE
+    previewBox.visibility = View.VISIBLE
 
     val boxColor = Color.argb(255, progress, progress, progress)
     previewBox.setBackgroundColor(boxColor)


### PR DESCRIPTION
The text for "preview" was showing, but the box wasn't showing. This
fixes it.
