### PR TITLE
Fix builds from PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Download Previous Debug APK
         uses: dawidd6/action-download-artifact@v2
         with:
-          github_token: ${{secrets.GITHUB_TOKEN}}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           workflow: post_merge.yml
           name: latest-apk
 
@@ -35,9 +35,15 @@ jobs:
           gh release download -p '*.jar' -R jakewharton/diffuse 0.1.0
           java -jar diffuse-0.1.0-binary.jar diff app-madani-debug.apk app/build/outputs/apk/madani/debug/app-madani-debug.apk > apk_differences.txt
           { echo "\`\`\`"; head -n 17 apk_differences.txt; echo "\`\`\`"; echo; } >> apk_differences_summary.txt
-          gh pr comment ${{ github.event.number }} -F apk_differences_summary.txt
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload Apk Diff Results
+        uses: actions/upload-artifact@v2
+        if: success()
+        with:
+          name: apk_differences
+          path: apk_differences_summary.txt
 
   lint:
     needs: [build]
@@ -132,7 +138,7 @@ jobs:
       - name: Download Previous Dependencies List
         uses: dawidd6/action-download-artifact@v2
         with:
-          github_token: ${{secrets.GITHUB_TOKEN}}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           workflow: post_merge.yml
           name: dependencies
 
@@ -141,11 +147,25 @@ jobs:
           gh release download -p '*.jar' -R careem/dependency-diff-tldr v0.0.2
           echo "Running Dependency Diff"
           java -jar dependency-diff-tldr-r8.jar dependencies.txt current_dependencies.txt > difference.txt
-          if [ -s difference.txt ]; then
-            gh pr comment ${{ github.event.number }} -F difference.txt
-          fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload Dependency Diff Results
+        uses: actions/upload-artifact@v2
+        if: success()
+        with:
+          name: dependency_differences
+          path: difference.txt
+
+      - name: Write the PR Number
+        run: |
+          echo ${{ github.event.number }} > pr.txt
+
+      - name: Upload PR Number
+        uses: actions/upload-artifact@v2
+        with:
+          name: pr
+          path: pr.txt
 
 
 env:

--- a/.github/workflows/post_build.yml
+++ b/.github/workflows/post_build.yml
@@ -1,0 +1,53 @@
+name: Comment on the pull request
+
+on:
+  workflow_run:
+    workflows: ["Android Pull Request"]
+    types:
+      - completed
+
+jobs:
+  comment:
+    name: Comment on Pull Request
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - name: Download PR Number
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          run_id: ${{ github.event.workflow_run.id }}
+          workflow: build.yml
+          name: pr
+
+      - name: Download Apk Diff Results
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          run_id: ${{ github.event.workflow_run.id }}
+          workflow: build.yml
+          name: apk_differences
+
+      - name: Comment with Apk Diff Results
+        run: |
+          export PR=`cat pr.txt | head -1`
+          gh pr -R quran/quran_android comment $PR -F apk_differences_summary.txt
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download Dependency Diff Results
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          run_id: ${{ github.event.workflow_run.id }}
+          workflow: build.yml
+          name: dependency_differences
+
+      - name: Comment with Dependency Diff Results
+        run: |
+          if [ -s difference.txt ]; then
+            export PR=`cat pr.txt | head -1`
+            gh pr -R quran/quran_android comment $PR -F difference.txt
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Pull requests only get access to a read token for security purposes.
This applies the GitHub recommended way of fixing this, which is to
upload artifacts from a workflow that only needs the read token (or no
token at all), and have another workflow run after its completion to
actually do any required write operations.
