### PR TITLE
url fixed

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/data/Constants.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/data/Constants.kt
@@ -30,8 +30,8 @@ object Constants {
   const val MAX_RECENT_PAGES = 3
 
   // quranapp
-  const val QURAN_APP_BASE = "http://quranapp.com/"
-  const val QURAN_APP_ENDPOINT = "http://quranapp.com/note"
+  const val QURAN_APP_BASE = "http://quran.com/"
+  const val QURAN_APP_ENDPOINT = "http://quran.com/note"
 
   // Notification Ids
   const val NOTIFICATION_ID_DOWNLOADING = 1


### PR DESCRIPTION
When sharing using the link option, the generated link (eg. [current link](http://quranapp.com/1/7-7)) is broken.
I think the actual link should be [link](http://quran.com/1/7-7) which works.

@ahmedre , is this ok?