### PR TITLE
Implement an improved qari picker

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -130,6 +130,7 @@ dependencies {
   implementation project(path: ':common:upgrade')
 
   implementation project(path: ':feature:audio')
+  implementation project(path: ':feature:qarilist')
 
   implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:${coroutinesVersion}"
   implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:${coroutinesVersion}"
@@ -144,6 +145,9 @@ dependencies {
   implementation "androidx.recyclerview:recyclerview:${androidxRecyclerViewVersion}"
   implementation "com.google.android.material:material:${materialComponentsVersion}"
   implementation "androidx.swiperefreshlayout:swiperefreshlayout:${androidxSwipeRefreshVersion}"
+
+  // okio
+  implementation "com.squareup.okio:okio:${okioVersion}"
 
   // rx
   implementation 'io.reactivex.rxjava3:rxjava:3.1.5'

--- a/app/src/main/java/com/quran/labs/androidquran/di/component/activity/PagerActivityComponent.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/di/component/activity/PagerActivityComponent.kt
@@ -10,6 +10,7 @@ import com.quran.labs.androidquran.ui.fragment.AyahTranslationFragment
 import com.quran.labs.androidquran.ui.fragment.TagBookmarkFragment
 import com.quran.page.common.toolbar.AyahToolBar
 import com.quran.mobile.di.QuranReadingActivityComponent
+import com.quran.mobile.feature.qarilist.QariListWrapper
 import com.squareup.anvil.annotations.MergeSubcomponent
 import dagger.Subcomponent
 
@@ -25,6 +26,8 @@ interface PagerActivityComponent : QuranReadingActivityComponent {
   fun inject(tagBookmarkFragment: TagBookmarkFragment)
   fun inject(ayahPlaybackFragment: AyahPlaybackFragment)
   fun inject(ayahTranslationFragment: AyahTranslationFragment)
+
+  fun inject(qariListWrapper: QariListWrapper)
 
   @Subcomponent.Builder
   interface Builder {

--- a/app/src/main/java/com/quran/labs/androidquran/di/module/application/ApplicationModule.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/di/module/application/ApplicationModule.kt
@@ -22,6 +22,7 @@ import dagger.Provides
 import dagger.multibindings.ElementsIntoSet
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
 import io.reactivex.rxjava3.core.Scheduler
+import okio.FileSystem
 import java.io.File
 import javax.inject.Named
 import javax.inject.Singleton
@@ -80,6 +81,11 @@ class ApplicationModule(private val application: Application) {
   @Provides
   fun provideQuranFileManager(quranFileUtils: QuranFileUtils): QuranFileManager {
     return quranFileUtils
+  }
+
+  @Provides
+  fun provideFileSystem(): FileSystem {
+    return FileSystem.SYSTEM
   }
 
   @Provides

--- a/app/src/main/java/com/quran/labs/androidquran/presenter/translation/BaseTranslationPresenter.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/presenter/translation/BaseTranslationPresenter.kt
@@ -1,25 +1,25 @@
 package com.quran.labs.androidquran.presenter.translation
 
 import com.quran.data.core.QuranInfo
-import com.quran.labs.androidquran.common.LocalTranslation
-import com.quran.labs.androidquran.common.LocalTranslationDisplaySort
-import com.quran.labs.androidquran.common.QuranAyahInfo
 import com.quran.data.model.QuranText
-import com.quran.labs.androidquran.common.TranslationMetadata
 import com.quran.data.model.SuraAyah
 import com.quran.data.model.SuraAyahIterator
 import com.quran.data.model.VerseRange
+import com.quran.labs.androidquran.common.LocalTranslation
+import com.quran.labs.androidquran.common.LocalTranslationDisplaySort
+import com.quran.labs.androidquran.common.QuranAyahInfo
+import com.quran.labs.androidquran.common.TranslationMetadata
 import com.quran.labs.androidquran.database.TranslationsDBAdapter
 import com.quran.labs.androidquran.model.translation.TranslationModel
 import com.quran.labs.androidquran.presenter.Presenter
 import com.quran.labs.androidquran.util.QuranSettings
 import com.quran.labs.androidquran.util.TranslationUtil
+import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
 import io.reactivex.rxjava3.core.Observable
 import io.reactivex.rxjava3.core.Single
-import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
 import io.reactivex.rxjava3.disposables.Disposable
 import io.reactivex.rxjava3.schedulers.Schedulers
-import java.util.*
+import java.util.Collections
 
 internal open class BaseTranslationPresenter<T : Any> internal constructor(
     private val translationModel: TranslationModel,

--- a/app/src/main/java/com/quran/labs/androidquran/service/QuranDownloadService.java
+++ b/app/src/main/java/com/quran/labs/androidquran/service/QuranDownloadService.java
@@ -5,13 +5,19 @@ import android.content.Context;
 import android.content.Intent;
 import android.net.wifi.WifiManager;
 import android.net.wifi.WifiManager.WifiLock;
-import android.os.*;
-
+import android.os.Environment;
+import android.os.Handler;
+import android.os.HandlerThread;
+import android.os.IBinder;
+import android.os.Looper;
+import android.os.Message;
+import android.os.Parcelable;
+import android.os.StatFs;
+import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 import com.quran.data.core.QuranInfo;
-import com.quran.labs.androidquran.QuranApplication;
 import com.quran.data.model.SuraAyah;
+import com.quran.labs.androidquran.QuranApplication;
 import com.quran.labs.androidquran.extension.CloseableExtensionKt;
-import com.quran.mobile.common.download.DownloadInfoStreams;
 import com.quran.labs.androidquran.service.util.QuranDownloadNotifier;
 import com.quran.labs.androidquran.service.util.QuranDownloadNotifier.NotificationDetails;
 import com.quran.labs.androidquran.service.util.QuranDownloadNotifier.ProgressIntent;
@@ -19,17 +25,14 @@ import com.quran.labs.androidquran.util.QuranSettings;
 import com.quran.labs.androidquran.util.QuranUtils;
 import com.quran.labs.androidquran.util.UrlUtil;
 import com.quran.labs.androidquran.util.ZipUtils;
-
+import com.quran.mobile.common.download.DownloadInfoStreams;
 import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
-
 import javax.inject.Inject;
-
-import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 import okhttp3.Call;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
@@ -140,7 +143,6 @@ public class QuranDownloadService extends Service implements
     thread.start();
 
     Context appContext = getApplicationContext();
-    notifier = new QuranDownloadNotifier(this, this, downloadInfoStreams);
     wifiLock = ((WifiManager) appContext.getSystemService(Context.WIFI_SERVICE))
         .createWifiLock(WifiManager.WIFI_MODE_FULL, "downloadLock");
 
@@ -153,6 +155,7 @@ public class QuranDownloadService extends Service implements
 
     ((QuranApplication) getApplication()).getApplicationComponent().inject(this);
     broadcastManager = LocalBroadcastManager.getInstance(appContext);
+    notifier = new QuranDownloadNotifier(this, this, downloadInfoStreams);
   }
 
   private void handleOnStartCommand(Intent intent, int startId) {

--- a/app/src/main/java/com/quran/labs/androidquran/view/CurrentQariBridge.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/view/CurrentQariBridge.kt
@@ -1,0 +1,31 @@
+package com.quran.labs.androidquran.view
+
+import com.quran.labs.androidquran.common.audio.model.QariItem
+import com.quran.labs.androidquran.common.audio.repository.CurrentQariManager
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.observeOn
+import kotlinx.coroutines.withContext
+
+class CurrentQariBridge @Inject constructor(private val currentQariManager: CurrentQariManager) {
+  private val scope: CoroutineScope = CoroutineScope(SupervisorJob())
+
+  fun listenToQaris(lambda: ((QariItem) -> Unit)) {
+    scope.launch {
+      withContext(Dispatchers.Main) {
+        currentQariManager
+          .flow()
+          .collect { lambda(it) }
+      }
+    }
+  }
+
+  fun unsubscribeAll() {
+    scope.cancel()
+  }
+}

--- a/app/src/main/java/com/quran/labs/androidquran/view/JuzView.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/view/JuzView.kt
@@ -1,7 +1,11 @@
 package com.quran.labs.androidquran.view
 
 import android.content.Context
-import android.graphics.*
+import android.graphics.Canvas
+import android.graphics.ColorFilter
+import android.graphics.Paint
+import android.graphics.PixelFormat
+import android.graphics.RectF
 import android.graphics.drawable.Drawable
 import android.text.TextPaint
 import androidx.core.content.ContextCompat

--- a/app/src/main/java/com/quran/labs/androidquran/widget/BookmarksWidget.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/widget/BookmarksWidget.kt
@@ -7,7 +7,11 @@ import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.widget.RemoteViews
-import com.quran.labs.androidquran.*
+import com.quran.labs.androidquran.QuranApplication
+import com.quran.labs.androidquran.QuranDataActivity
+import com.quran.labs.androidquran.R
+import com.quran.labs.androidquran.SearchActivity
+import com.quran.labs.androidquran.ShortcutsActivity
 import com.quran.labs.androidquran.ui.PagerActivity
 import com.quran.labs.androidquran.ui.QuranActivity
 import javax.inject.Inject

--- a/app/src/main/res/layout/quran_page_activity_slider.xml
+++ b/app/src/main/res/layout/quran_page_activity_slider.xml
@@ -23,4 +23,11 @@
         android:layout_height="match_parent"
         layout="@layout/ayah_action_panel_layout"/>
 
+  <!-- overlay -->
+  <FrameLayout
+      android:id="@+id/overlay"
+      android:layout_width="match_parent"
+      android:layout_height="match_parent"
+      android:visibility="gone"/>
+
 </com.quran.labs.androidquran.view.SlidingUpPanelLayout>

--- a/app/src/test/java/com/quran/labs/androidquran/common/audio/extension/QariDownloadInfoExtensionTest.kt
+++ b/app/src/test/java/com/quran/labs/androidquran/common/audio/extension/QariDownloadInfoExtensionTest.kt
@@ -1,0 +1,38 @@
+package com.quran.labs.androidquran.common.audio.extension
+
+import com.quran.data.model.SuraAyah
+import com.quran.labs.androidquran.common.audio.model.PartiallyDownloadedSura
+import com.quran.labs.androidquran.common.audio.model.QariDownloadInfo
+import com.quran.labs.androidquran.common.audio.model.QariItem
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class QariDownloadInfoExtensionTest {
+
+  @Test
+  fun checkDownloadedGaplessFiles() {
+    val qariItem = QariItem(1, "test", "url", "path", false, "database")
+    val qariDownloadInfo = QariDownloadInfo.GaplessQariDownloadInfo(qariItem, listOf(1, 2), listOf(3))
+    assertTrue(qariDownloadInfo.isRangeDownloaded(SuraAyah(1, 1), SuraAyah(2, 286)))
+    // ranges are inclusive, and there are no partial files
+    assertFalse(qariDownloadInfo.isRangeDownloaded(SuraAyah(3, 1), SuraAyah(3, 200)))
+    assertFalse(qariDownloadInfo.isRangeDownloaded(SuraAyah(1, 1), SuraAyah(3, 1)))
+  }
+
+  @Test
+  fun checkDownloadedGappedFiles() {
+    val qariItem = QariItem(1, "test", "url", "path", false, null)
+    val qariDownloadInfo = QariDownloadInfo.GappedQariDownloadInfo(
+      qariItem,
+      listOf(1, 2),
+      listOf(PartiallyDownloadedSura(3, 200, listOf(1)))
+    )
+
+    assertTrue(qariDownloadInfo.isRangeDownloaded(SuraAyah(1, 1), SuraAyah(2, 286)))
+    // ranges are inclusive, and there are incomplete partial files
+    assertFalse(qariDownloadInfo.isRangeDownloaded(SuraAyah(3, 1), SuraAyah(3, 200)))
+    // ranges are inclusive, and there are complete partial files
+    assertTrue(qariDownloadInfo.isRangeDownloaded(SuraAyah(1, 1), SuraAyah(3, 1)))
+  }
+}

--- a/app/src/test/java/com/quran/labs/androidquran/presenter/bookmark/TagBookmarkPresenterTest.kt
+++ b/app/src/test/java/com/quran/labs/androidquran/presenter/bookmark/TagBookmarkPresenterTest.kt
@@ -1,33 +1,29 @@
 package com.quran.labs.androidquran.presenter.bookmark
 
 import androidx.core.util.Pair
-
 import com.google.common.truth.Truth.assertThat
 import com.quran.data.model.bookmark.Tag
 import com.quran.labs.androidquran.model.bookmark.BookmarkModel
 import com.quran.labs.androidquran.ui.fragment.TagBookmarkDialog
-
-import org.junit.Before
-import org.junit.BeforeClass
-import org.junit.Test
-
-import java.util.ArrayList
-import java.util.concurrent.CountDownLatch
-
+import io.reactivex.rxjava3.android.plugins.RxAndroidPlugins
 import io.reactivex.rxjava3.core.Maybe
 import io.reactivex.rxjava3.core.Observable
 import io.reactivex.rxjava3.core.Single
-import io.reactivex.rxjava3.android.plugins.RxAndroidPlugins
 import io.reactivex.rxjava3.schedulers.Schedulers
-
-import org.mockito.ArgumentMatchers.*
+import java.util.concurrent.CountDownLatch
+import org.junit.Before
+import org.junit.BeforeClass
+import org.junit.Test
+import org.mockito.ArgumentMatchers.any
+import org.mockito.ArgumentMatchers.anyBoolean
+import org.mockito.ArgumentMatchers.anyInt
 import org.mockito.Mock
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
-import org.mockito.Mockito.`when` as whenever
 import org.mockito.MockitoAnnotations
+import org.mockito.Mockito.`when` as whenever
 
 class TagBookmarkPresenterTest {
 

--- a/app/src/test/java/com/quran/labs/androidquran/widget/BookmarksWidgetSubscriberTest.kt
+++ b/app/src/test/java/com/quran/labs/androidquran/widget/BookmarksWidgetSubscriberTest.kt
@@ -4,18 +4,19 @@ import com.quran.labs.androidquran.model.bookmark.BookmarkModel
 import io.reactivex.rxjava3.android.plugins.RxAndroidPlugins
 import io.reactivex.rxjava3.schedulers.TestScheduler
 import io.reactivex.rxjava3.subjects.PublishSubject
+import java.util.concurrent.TimeUnit
 import org.junit.AfterClass
 import org.junit.BeforeClass
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.InjectMocks
 import org.mockito.Mock
-import org.mockito.Mockito.*
-import org.mockito.Mockito.`when` as whenever
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
 import org.mockito.junit.MockitoJUnit
 import org.mockito.junit.MockitoRule
 import org.mockito.quality.Strictness
-import java.util.concurrent.TimeUnit
+import org.mockito.Mockito.`when` as whenever
 
 
 class BookmarksWidgetSubscriberTest {

--- a/common/audio/src/main/java/com/quran/labs/androidquran/common/audio/cache/AudioCacheInvalidator.kt
+++ b/common/audio/src/main/java/com/quran/labs/androidquran/common/audio/cache/AudioCacheInvalidator.kt
@@ -9,7 +9,7 @@ import javax.inject.Singleton
 
 @Singleton
 class AudioCacheInvalidator @Inject constructor() {
-  private val cache = MutableSharedFlow<Int>(onBufferOverflow = BufferOverflow.DROP_OLDEST)
+  private val cache = MutableSharedFlow<Int>(extraBufferCapacity = 1, onBufferOverflow = BufferOverflow.DROP_OLDEST)
 
   fun qarisToInvalidate(): Flow<Int> = cache.filter { it > -1 }
 

--- a/common/audio/src/main/java/com/quran/labs/androidquran/common/audio/cache/QariDownloadInfoStorageCache.kt
+++ b/common/audio/src/main/java/com/quran/labs/androidquran/common/audio/cache/QariDownloadInfoStorageCache.kt
@@ -3,8 +3,6 @@ package com.quran.labs.androidquran.common.audio.cache
 import com.quran.labs.androidquran.common.audio.model.QariDownloadInfo
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
-import javax.inject.Inject
-import javax.inject.Singleton
 
 internal class QariDownloadInfoStorageCache {
   private val cache = MutableStateFlow<List<QariDownloadInfo>>(emptyList())

--- a/common/audio/src/main/java/com/quran/labs/androidquran/common/audio/cache/command/AudioInfoCommand.kt
+++ b/common/audio/src/main/java/com/quran/labs/androidquran/common/audio/cache/command/AudioInfoCommand.kt
@@ -1,6 +1,7 @@
 package com.quran.labs.androidquran.common.audio.cache.command
 
 import android.content.Context
+import com.quran.labs.androidquran.common.audio.model.PartiallyDownloadedSura
 import com.quran.labs.androidquran.common.audio.model.QariDownloadInfo
 import com.quran.labs.androidquran.common.audio.model.QariItem
 import com.quran.labs.androidquran.common.audio.util.QariUtil
@@ -39,15 +40,22 @@ class AudioInfoCommand @Inject constructor(
   }
 
   private fun generateQariDownloadInfoWithPath(qariItem: QariItem, path: Path?): QariDownloadInfo {
-    return if (path == null) {
-      QariDownloadInfo(qariItem, emptyList(), emptyList())
+    return if (qariItem.isGapless) {
+      val (fullDownloads, partialDownloads) =
+        if (path == null) {
+          emptyList<Int>() to emptyList()
+        } else {
+          gaplessAudioInfoCommand.gaplessDownloads(path)
+        }
+      QariDownloadInfo.GaplessQariDownloadInfo(qariItem, fullDownloads, partialDownloads)
     } else {
-      val (fullDownloads, partialDownloads) = if (qariItem.isGapless) {
-        gaplessAudioInfoCommand.gaplessDownloads(path)
-      } else {
-        gappedAudioInfoCommand.gappedDownloads(path)
-      }
-      QariDownloadInfo(qariItem, fullDownloads, partialDownloads)
+      val (fullDownloads, partiallyDownloadedSuras) =
+        if (path == null) {
+          emptyList<Int>() to emptyList()
+        } else {
+          gappedAudioInfoCommand.gappedDownloads(path)
+        }
+      QariDownloadInfo.GappedQariDownloadInfo(qariItem, fullDownloads, partiallyDownloadedSuras)
     }
   }
 }

--- a/common/audio/src/main/java/com/quran/labs/androidquran/common/audio/extension/PartiallyDownloadedSuraExtension.kt
+++ b/common/audio/src/main/java/com/quran/labs/androidquran/common/audio/extension/PartiallyDownloadedSuraExtension.kt
@@ -1,0 +1,8 @@
+package com.quran.labs.androidquran.common.audio.extension
+
+import com.quran.labs.androidquran.common.audio.model.PartiallyDownloadedSura
+
+fun PartiallyDownloadedSura.didDownloadAyat(currentSura: Int, start: Int, end: Int): Boolean {
+  val ayat = IntRange(start, end)
+  return sura == currentSura && ayat.all { it in downloadedAyat }
+}

--- a/common/audio/src/main/java/com/quran/labs/androidquran/common/audio/extension/QariDownloadInfoExtension.kt
+++ b/common/audio/src/main/java/com/quran/labs/androidquran/common/audio/extension/QariDownloadInfoExtension.kt
@@ -1,0 +1,38 @@
+package com.quran.labs.androidquran.common.audio.extension
+
+import com.quran.data.model.SuraAyah
+import com.quran.labs.androidquran.common.audio.model.QariDownloadInfo
+
+/**
+ * Determine whether the range of verses is downloaded
+ * This will check, for gapless files, if every sura is fully downloaded or not.
+ * For gapped files, it will do the aforementioned check, and will alternatively
+ * check that all ayat in the range are downloaded.
+ *
+ * Note that "partially downloaded gapless files" are not really a portion today.
+ * Those are simply determined by a .part file existing, and we don't try to figure
+ * out which portion of the file is there and which isn't since playback of downloaded
+ * gapless files is all or none.
+ */
+fun QariDownloadInfo.isRangeDownloaded(start: SuraAyah, end: SuraAyah): Boolean {
+  val suraRange = IntRange(start.sura, end.sura)
+  return when (this) {
+    is QariDownloadInfo.GaplessQariDownloadInfo -> suraRange.all { it in fullyDownloadedSuras }
+    is QariDownloadInfo.GappedQariDownloadInfo -> {
+      suraRange.all { sura ->
+        if (sura in fullyDownloadedSuras) {
+          true
+        } else {
+          val start = if (start.sura == sura) start.ayah else 1
+          val partiallyDownloadedSuraInfo = partiallyDownloadedSuras.firstOrNull { it.sura == sura }
+          if (partiallyDownloadedSuraInfo != null) {
+            val end = if (end.sura == sura) end.ayah else partiallyDownloadedSuraInfo.expectedAyahCount
+            partiallyDownloadedSuraInfo.didDownloadAyat(sura, start, end)
+          } else {
+            false
+          }
+        }
+      }
+    }
+  }
+}

--- a/common/audio/src/main/java/com/quran/labs/androidquran/common/audio/model/PartiallyDownloadedSura.kt
+++ b/common/audio/src/main/java/com/quran/labs/androidquran/common/audio/model/PartiallyDownloadedSura.kt
@@ -1,0 +1,3 @@
+package com.quran.labs.androidquran.common.audio.model
+
+data class PartiallyDownloadedSura(val sura: Int, val expectedAyahCount: Int, val downloadedAyat: List<Int>)

--- a/common/audio/src/main/java/com/quran/labs/androidquran/common/audio/model/QariDownloadInfo.kt
+++ b/common/audio/src/main/java/com/quran/labs/androidquran/common/audio/model/QariDownloadInfo.kt
@@ -1,7 +1,18 @@
 package com.quran.labs.androidquran.common.audio.model
 
-data class QariDownloadInfo(
-  val qariItem: QariItem,
-  val fullyDownloadedSuras: List<Int>,
-  val partiallyDownloadedSuras: List<Int>
-)
+sealed class QariDownloadInfo {
+  abstract val qariItem: QariItem
+  abstract val fullyDownloadedSuras: List<Int>
+
+  data class GaplessQariDownloadInfo(
+    override val qariItem: QariItem,
+    override val fullyDownloadedSuras: List<Int>,
+    val partiallyDownloadedSuras: List<Int>
+  ) : QariDownloadInfo()
+
+  data class GappedQariDownloadInfo(
+    override val qariItem: QariItem,
+    override val fullyDownloadedSuras: List<Int>,
+    val partiallyDownloadedSuras: List<PartiallyDownloadedSura>
+  ) : QariDownloadInfo()
+}

--- a/common/audio/src/main/java/com/quran/labs/androidquran/common/audio/repository/CurrentQariManager.kt
+++ b/common/audio/src/main/java/com/quran/labs/androidquran/common/audio/repository/CurrentQariManager.kt
@@ -1,0 +1,30 @@
+package com.quran.labs.androidquran.common.audio.repository
+
+import android.content.Context
+import android.preference.PreferenceManager
+import com.quran.labs.androidquran.common.audio.model.QariItem
+import com.quran.labs.androidquran.common.audio.util.QariUtil
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class CurrentQariManager @Inject constructor(appContext: Context, private val qariUtil: QariUtil) {
+  private val prefs = PreferenceManager.getDefaultSharedPreferences(appContext)
+  private val currentQariFlow = MutableStateFlow(prefs.getInt(PREF_DEFAULT_QARI, 0))
+  private val qaris by lazy { qariUtil.getQariList(appContext) }
+
+  fun flow(): Flow<QariItem> = currentQariFlow
+    .map { qariId -> qaris.firstOrNull { it.id == qariId } ?: qaris.first() }
+
+  fun setCurrentQari(qariId: Int) {
+    prefs.edit().putInt(PREF_DEFAULT_QARI, qariId).apply()
+    currentQariFlow.value = qariId
+  }
+
+  companion object {
+    const val PREF_DEFAULT_QARI = "defaultQari"
+  }
+}

--- a/common/audio/src/test/java/com/quran/labs/androidquran/common/audio/cache/command/GappedAudioInfoCommandTest.kt
+++ b/common/audio/src/test/java/com/quran/labs/androidquran/common/audio/cache/command/GappedAudioInfoCommandTest.kt
@@ -3,6 +3,7 @@ package com.quran.labs.androidquran.common.audio.cache.command
 import com.google.common.truth.Truth
 import com.quran.data.core.QuranInfo
 import com.quran.data.pageinfo.common.MadaniDataSource
+import com.quran.labs.androidquran.common.audio.model.PartiallyDownloadedSura
 import okio.Path.Companion.toPath
 import okio.fakefilesystem.FakeFileSystem
 import org.junit.Test
@@ -27,7 +28,7 @@ class GappedAudioInfoCommandTest {
   }
 
   @Test
-  fun testGaplessAudioWithPartials() {
+  fun testGappedAudioWithPartials() {
     val qariPath = "/quran/audio/minshawi".toPath()
     val filesystem = FakeFileSystem()
     filesystem.createDirectories(qariPath)
@@ -37,16 +38,19 @@ class GappedAudioInfoCommandTest {
     filesystem.write(qariPath / "114001.mp3") { }
 
     val quranInfo = QuranInfo(MadaniDataSource())
-    val gaplessAudioInfoCommand = GappedAudioInfoCommand(quranInfo, filesystem)
-    val downloads = gaplessAudioInfoCommand.gappedDownloads(qariPath)
+    val gappedAudioInfoCommand = GappedAudioInfoCommand(quranInfo, filesystem)
+    val downloads = gappedAudioInfoCommand.gappedDownloads(qariPath)
     Truth.assertThat(downloads.first).hasSize(1)
     Truth.assertThat(downloads.second).hasSize(1)
     Truth.assertThat(downloads.first).containsExactly(103)
-    Truth.assertThat(downloads.second).containsExactly(114)
+    Truth.assertThat(downloads.second).hasSize(1)
+    Truth.assertThat(downloads.second.first()).isEqualTo(
+      PartiallyDownloadedSura(114, 6, listOf(1))
+    )
   }
 
   @Test
-  fun testGaplessAudioWithIllegalFilenames() {
+  fun testGappedAudioWithIllegalFilenames() {
     val qariPath = "/quran/audio/minshawi".toPath()
     val filesystem = FakeFileSystem()
     filesystem.createDirectories(qariPath)
@@ -57,8 +61,8 @@ class GappedAudioInfoCommandTest {
     filesystem.write(qariPath / "115001.mp3") { }
 
     val quranInfo = QuranInfo(MadaniDataSource())
-    val gaplessAudioInfoCommand = GappedAudioInfoCommand(quranInfo, filesystem)
-    val downloads = gaplessAudioInfoCommand.gappedDownloads(qariPath)
+    val gappedAudioInfoCommand = GappedAudioInfoCommand(quranInfo, filesystem)
+    val downloads = gappedAudioInfoCommand.gappedDownloads(qariPath)
     Truth.assertThat(downloads.first).isEmpty()
     Truth.assertThat(downloads.second).isEmpty()
   }

--- a/common/data/src/main/java/com/quran/data/core/QuranInfo.kt
+++ b/common/data/src/main/java/com/quran/data/core/QuranInfo.kt
@@ -7,7 +7,6 @@ import com.quran.data.core.QuranConstants.NUMBER_OF_SURAS
 import com.quran.data.model.SuraAyah
 import com.quran.data.model.VerseRange
 import com.quran.data.source.QuranDataSource
-import java.util.*
 import javax.inject.Inject
 import kotlin.math.abs
 

--- a/feature/qarilist/build.gradle
+++ b/feature/qarilist/build.gradle
@@ -1,0 +1,58 @@
+plugins {
+  id 'com.android.library'
+  id 'org.jetbrains.kotlin.android'
+  id 'com.squareup.anvil'
+}
+
+android {
+  compileSdkVersion deps.android.build.compileSdkVersion
+  defaultConfig {
+    minSdkVersion deps.android.build.minSdkVersion
+    targetSdkVersion deps.android.build.targetSdkVersion
+  }
+
+  buildFeatures {
+    compose true
+  }
+
+  composeOptions {
+    kotlinCompilerVersion kotlinVersion
+    kotlinCompilerExtensionVersion composeCompilerVersion
+  }
+
+  kotlinOptions {
+    freeCompilerArgs += [
+        "-opt-in=androidx.compose.foundation.ExperimentalFoundationApi",
+        "-opt-in=androidx.compose.material.ExperimentalMaterialApi"
+    ]
+  }
+}
+
+anvil { generateDaggerFactories = true }
+
+dependencies {
+  implementation project(path: ':common:audio')
+  implementation project(path: ':common:data')
+  implementation project(path: ':common:ui:core')
+
+  implementation "androidx.annotation:annotation:${androidxAnnotationVersion}"
+
+  // dagger
+  implementation deps.dagger.runtime
+
+  // compose
+  implementation "androidx.compose.animation:animation:$composeVersion"
+  implementation "androidx.compose.compiler:compiler:$composeCompilerVersion"
+  implementation "androidx.compose.foundation:foundation:$composeVersion"
+  implementation "androidx.compose.material:material:$composeVersion"
+  implementation "androidx.compose.material3:material3:$material3Version"
+  // https://issuetracker.google.com/issues/209688774
+  api "androidx.compose.runtime:runtime:$composeVersion"
+  implementation "androidx.compose.ui:ui:$composeVersion"
+  implementation "androidx.compose.ui:ui-tooling-preview:$composeVersion"
+  debugImplementation "androidx.compose.ui:ui-tooling:$composeVersion"
+
+  // coroutines
+  implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:${coroutinesVersion}"
+  implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:${coroutinesVersion}"
+}

--- a/feature/qarilist/src/main/AndroidManifest.xml
+++ b/feature/qarilist/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest package="com.quran.mobile.feature.qarilist"/>

--- a/feature/qarilist/src/main/kotlin/com/quran/mobile/feature/qarilist/QariListWrapper.kt
+++ b/feature/qarilist/src/main/kotlin/com/quran/mobile/feature/qarilist/QariListWrapper.kt
@@ -1,0 +1,117 @@
+package com.quran.mobile.feature.qarilist
+
+import android.content.Context
+import android.widget.FrameLayout
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.ModalBottomSheetLayout
+import androidx.compose.material.ModalBottomSheetValue
+import androidx.compose.material.Text
+import androidx.compose.material.TopAppBar
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.rememberModalBottomSheetState
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.quran.data.model.SuraAyah
+import com.quran.labs.androidquran.common.audio.model.QariItem
+import com.quran.labs.androidquran.common.audio.repository.CurrentQariManager
+import com.quran.labs.androidquran.common.ui.core.QuranTheme
+import com.quran.mobile.feature.qarilist.di.QariListWrapperInjector
+import com.quran.mobile.feature.qarilist.presenter.QariListPresenter
+import com.quran.mobile.feature.qarilist.ui.QariList
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+class QariListWrapper(
+  context: Context,
+  private val startAyah: SuraAyah,
+  private val endAyah: SuraAyah,
+): FrameLayout(context) {
+
+  @Inject
+  lateinit var qariListPresenter: QariListPresenter
+
+  @Inject
+  lateinit var currentQariManager: CurrentQariManager
+
+  init {
+    (context as? QariListWrapperInjector)?.injectQariListWrapper(this)
+
+    val composeView = ComposeView(context).apply {
+      setContent {
+        QuranTheme {
+          QariListBottomSheet()
+        }
+      }
+    }
+    addView(composeView, LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT)
+  }
+
+  @Composable
+  fun QariListBottomSheet() {
+    val state = rememberModalBottomSheetState(initialValue = ModalBottomSheetValue.HalfExpanded)
+    val qariListFlow = qariListPresenter.qariList(startAyah, endAyah)
+    val qariListState = qariListFlow.collectAsState(emptyList())
+    val currentQariFlow = currentQariManager.flow()
+    val currentQariState = currentQariFlow.collectAsState(null)
+
+    val coroutineScope: CoroutineScope = rememberCoroutineScope()
+    val closeDialog = {
+      coroutineScope.launch {
+        state.hide()
+      }
+    }
+
+    val onQariSelected = { qari: QariItem ->
+      closeDialog()
+      currentQariManager.setCurrentQari(qari.id)
+    }
+
+    ModalBottomSheetLayout(
+      sheetState = state,
+      sheetShape = RoundedCornerShape(16.dp),
+      sheetContent = {
+        Column {
+          TopAppBar(
+            backgroundColor = MaterialTheme.colorScheme.primary,
+            title = {
+              Text(
+                stringResource(R.string.qarilist_select_qari),
+                style = MaterialTheme.typography.titleLarge,
+                color = MaterialTheme.colorScheme.primaryContainer
+              )
+            },
+            navigationIcon = {
+              IconButton(onClick = { closeDialog() }) {
+                Icon(
+                  imageVector = Icons.Filled.Close,
+                  contentDescription = stringResource(R.string.qarilist_dismiss),
+                  tint = MaterialTheme.colorScheme.primaryContainer
+                )
+              }
+            }
+          )
+
+          QariList(
+            qariListState.value,
+            selectedQariId = currentQariState.value?.id ?: -1,
+            onQariSelected = onQariSelected,
+            modifier = Modifier.fillMaxHeight(0.95f)
+          )
+        }
+      },
+    ) {
+    }
+  }
+}

--- a/feature/qarilist/src/main/kotlin/com/quran/mobile/feature/qarilist/di/QariListWrapperInjector.kt
+++ b/feature/qarilist/src/main/kotlin/com/quran/mobile/feature/qarilist/di/QariListWrapperInjector.kt
@@ -1,0 +1,7 @@
+package com.quran.mobile.feature.qarilist.di
+
+import com.quran.mobile.feature.qarilist.QariListWrapper
+
+interface QariListWrapperInjector {
+  fun injectQariListWrapper(qariListWrapper: QariListWrapper)
+}

--- a/feature/qarilist/src/main/kotlin/com/quran/mobile/feature/qarilist/model/QariUiModel.kt
+++ b/feature/qarilist/src/main/kotlin/com/quran/mobile/feature/qarilist/model/QariUiModel.kt
@@ -1,0 +1,9 @@
+package com.quran.mobile.feature.qarilist.model
+
+import androidx.annotation.StringRes
+import com.quran.labs.androidquran.common.audio.model.QariItem
+
+data class QariUiModel(
+  val qariItem: QariItem,
+  @StringRes val sectionHeader: Int
+)

--- a/feature/qarilist/src/main/kotlin/com/quran/mobile/feature/qarilist/presenter/QariListPresenter.kt
+++ b/feature/qarilist/src/main/kotlin/com/quran/mobile/feature/qarilist/presenter/QariListPresenter.kt
@@ -1,0 +1,40 @@
+package com.quran.mobile.feature.qarilist.presenter
+
+import com.quran.data.model.SuraAyah
+import com.quran.labs.androidquran.common.audio.cache.QariDownloadInfoManager
+import com.quran.labs.androidquran.common.audio.extension.isRangeDownloaded
+import com.quran.labs.androidquran.common.audio.model.QariDownloadInfo
+import com.quran.mobile.feature.qarilist.R
+import com.quran.mobile.feature.qarilist.model.QariUiModel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+class QariListPresenter @Inject constructor(private val qariDownloadInfoManager: QariDownloadInfoManager) {
+
+  fun qariList(start: SuraAyah, end: SuraAyah): Flow<List<QariUiModel>> {
+    return qariDownloadInfoManager.downloadedQariInfo().map { list ->
+        list.filter { qariDownloadInfo ->
+          val qariItem = qariDownloadInfo.qariItem
+          val gappedItem = qariDownloadInfo as? QariDownloadInfo.GappedQariDownloadInfo
+          qariItem.isGapless ||
+              (qariItem.hasGaplessAlternative && qariDownloadInfo.fullyDownloadedSuras.isEmpty() &&
+                  (gappedItem?.partiallyDownloadedSuras?.isEmpty() ?: false)
+              )
+        }
+      }
+      .map { unsortedQariList ->
+        val qariList = unsortedQariList.sortedBy { it.qariItem.name }
+        val readyToPlay = qariList.filter { it.isRangeDownloaded(start, end) }
+        val qarisWithDownloads = qariList.filter { it.fullyDownloadedSuras.isNotEmpty() }
+          .filter { it !in readyToPlay }
+        val gapless = qariList.filter { it.qariItem.isGapless }
+        val gapped = qariList.filter { !it.qariItem.isGapless }
+
+        readyToPlay.map { QariUiModel(it.qariItem, R.string.qarilist_ready_to_play) } +
+            qarisWithDownloads.map { QariUiModel(it.qariItem, R.string.qarilist_qaris_with_downloads) } +
+            gapless.map { QariUiModel(it.qariItem, R.string.qarilist_gapless) } +
+            gapped.map { QariUiModel(it.qariItem, R.string.qarilist_gapped) }
+      }
+  }
+}

--- a/feature/qarilist/src/main/kotlin/com/quran/mobile/feature/qarilist/ui/QariList.kt
+++ b/feature/qarilist/src/main/kotlin/com/quran/mobile/feature/qarilist/ui/QariList.kt
@@ -1,0 +1,24 @@
+package com.quran.mobile.feature.qarilist.ui
+
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.quran.labs.androidquran.common.audio.model.QariItem
+import com.quran.mobile.feature.qarilist.model.QariUiModel
+
+@Composable
+fun QariList(qaris: List<QariUiModel>, selectedQariId: Int, onQariSelected: ((QariItem) -> Unit), modifier: Modifier) {
+  val qarisBySection = qaris.groupBy { it.sectionHeader }
+  LazyColumn(modifier = modifier) {
+    qarisBySection.forEach { (section, sectionQaris) ->
+      stickyHeader {
+        QariSection(section)
+      }
+
+      items(sectionQaris) { qariUiModel ->
+        QariRow(qariUiModel.qariItem, selectedQariId == qariUiModel.qariItem.id, onQariSelected)
+      }
+    }
+  }
+}

--- a/feature/qarilist/src/main/kotlin/com/quran/mobile/feature/qarilist/ui/QariRow.kt
+++ b/feature/qarilist/src/main/kotlin/com/quran/mobile/feature/qarilist/ui/QariRow.kt
@@ -1,0 +1,48 @@
+package com.quran.mobile.feature.qarilist.ui
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Icon
+import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.quran.labs.androidquran.common.audio.model.QariItem
+import com.quran.mobile.feature.qarilist.R
+
+@Composable
+fun QariRow(
+  qariItem: QariItem,
+  isSelected: Boolean,
+  onItemSelected: ((QariItem) -> Unit),
+  modifier: Modifier = Modifier
+) {
+  Row(
+    modifier
+      .fillMaxWidth()
+      .clickable { onItemSelected(qariItem) }
+      .padding(horizontal = 16.dp, vertical = 16.dp)
+  ) {
+    Text(
+      text = qariItem.name,
+      style = MaterialTheme.typography.bodyLarge,
+      modifier = Modifier.align(Alignment.CenterVertically).weight(1f)
+    )
+
+    if (isSelected) {
+      Icon(
+        imageVector = Icons.Filled.Check,
+        contentDescription = stringResource(R.string.qarilist_selected),
+        tint = MaterialTheme.colorScheme.primary,
+        modifier = Modifier.align(Alignment.CenterVertically)
+      )
+    }
+  }
+}

--- a/feature/qarilist/src/main/kotlin/com/quran/mobile/feature/qarilist/ui/QariSection.kt
+++ b/feature/qarilist/src/main/kotlin/com/quran/mobile/feature/qarilist/ui/QariSection.kt
@@ -1,0 +1,25 @@
+package com.quran.mobile.feature.qarilist.ui
+
+import androidx.annotation.StringRes
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Text
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun QariSection(@StringRes sectionHeader: Int) {
+  Text(
+    text = stringResource(sectionHeader),
+    style = MaterialTheme.typography.titleMedium,
+    color = MaterialTheme.colorScheme.onSecondaryContainer,
+    modifier = Modifier
+      .fillMaxWidth()
+      .background(MaterialTheme.colorScheme.secondaryContainer)
+      .padding(8.dp)
+  )
+}

--- a/feature/qarilist/src/main/res/values-ar/strings.xml
+++ b/feature/qarilist/src/main/res/values-ar/strings.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="qarilist_select_qari">اختر قارئ</string>
+  <string name="qarilist_ready_to_play">جاهز للتشغيل</string>
+  <string name="qarilist_qaris_with_downloads">قراء تم تحميلهم</string>
+  <string name="qarilist_gapless">تلاوات متواصلة</string>
+  <string name="qarilist_gapped">تلاوات غير متواصلة</string>
+  <string name="qarilist_selected">تم الإختيار</string>
+  <string name="qarilist_dismiss">رفض</string>
+</resources>

--- a/feature/qarilist/src/main/res/values/strings.xml
+++ b/feature/qarilist/src/main/res/values/strings.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="qarilist_select_qari">Select a Qari</string>
+  <string name="qarilist_ready_to_play">Ready to Play</string>
+  <string name="qarilist_qaris_with_downloads">Qaris with Downloads</string>
+  <string name="qarilist_gapless">Gapless</string>
+  <string name="qarilist_gapped">Gapped</string>
+  <string name="qarilist_selected">Selected</string>
+  <string name="qarilist_dismiss">Dismiss</string>
+</resources>

--- a/settings.gradle
+++ b/settings.gradle
@@ -15,6 +15,7 @@ include ':common:upgrade'
 include ':common:ui:core'
 include ':feature:analytics-noop'
 include ':feature:audio'
+include ':feature:qarilist'
 include ':feature:recitation'
 include ':pages:madani'
 


### PR DESCRIPTION
This changes the spinner of the Qari picker to a bottom sheet that shows
4 categories - qaris that are ready to play (i.e. downloaded on the
device for the current pages), qaris that have downloads (even for other
suras), gapless, and gapped. More categories may be added later.
