### PR TITLE
localize qari picker

### DIFF
--- a/feature/qarilist/src/main/res/values-az/strings.xml
+++ b/feature/qarilist/src/main/res/values-az/strings.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="qarilist_select_qari">Kari seç</string>
+  <string name="qarilist_ready_to_play">Dinləməyə hazır</string>
+  <string name="qarilist_qaris_with_downloads">Endirilənlər</string>
+  <string name="qarilist_gapless">Davamlı</string>
+  <string name="qarilist_gapped">Davamlı Olmayan</string>
+  <string name="qarilist_selected">Seçili</string>
+  <string name="qarilist_dismiss">Rədd</string>
+</resources>

--- a/feature/qarilist/src/main/res/values-bg/strings.xml
+++ b/feature/qarilist/src/main/res/values-bg/strings.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="qarilist_select_qari">Изберете Кари</string>
+  <string name="qarilist_ready_to_play">Готови за слушане</string>
+  <string name="qarilist_qaris_with_downloads">Рецитатори с изтегляния</string>
+  <string name="qarilist_gapless">непрекъснат</string>
+  <string name="qarilist_gapped">непрекъсната</string>
+  <string name="qarilist_selected">Избрани</string>
+  <string name="qarilist_dismiss">Отмяна на</string>
+</resources>

--- a/feature/qarilist/src/main/res/values-bn/strings.xml
+++ b/feature/qarilist/src/main/res/values-bn/strings.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="qarilist_select_qari">একটি ক্বারী নির্বাচন করুন</string>
+  <string name="qarilist_ready_to_play">শোনার জন্য প্রস্তুত</string>
+  <string name="qarilist_qaris_with_downloads">ডাউনলোডসহ ক্বারীগণ</string>
+  <string name="qarilist_gapless">অবিরাম</string>
+  <string name="qarilist_gapped">অ-অবিচ্ছিন্ন</string>
+  <string name="qarilist_selected">নির্বাচিত</string>
+  <string name="qarilist_dismiss">বরখাস্ত করুন</string>
+</resources>

--- a/feature/qarilist/src/main/res/values-bs/strings.xml
+++ b/feature/qarilist/src/main/res/values-bs/strings.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="qarilist_select_qari">Odaberite Qari</string>
+  <string name="qarilist_ready_to_play">Spremni za slušanje</string>
+  <string name="qarilist_qaris_with_downloads">Recitiri sa downloadima</string>
+  <string name="qarilist_gapless">Kontinuirano</string>
+  <string name="qarilist_gapped">ne Kontinuirano</string>
+  <string name="qarilist_selected">Izabrane</string>
+  <string name="qarilist_dismiss">Otpusti</string>
+</resources>

--- a/feature/qarilist/src/main/res/values-cs/strings.xml
+++ b/feature/qarilist/src/main/res/values-cs/strings.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="qarilist_select_qari">Výběr karího</string>
+  <string name="qarilist_ready_to_play">Připraveno k poslechu</string>
+  <string name="qarilist_qaris_with_downloads">Recitátoři se soubory ke stažení</string>
+  <string name="qarilist_gapless">průběžně</string>
+  <string name="qarilist_gapped">nekontinuální</string>
+  <string name="qarilist_selected">Vybrané</string>
+  <string name="qarilist_dismiss">Odmítnout</string>
+</resources>

--- a/feature/qarilist/src/main/res/values-da/strings.xml
+++ b/feature/qarilist/src/main/res/values-da/strings.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="qarilist_select_qari">Vælg en qari</string>
+  <string name="qarilist_ready_to_play">Klar til at lytte</string>
+  <string name="qarilist_qaris_with_downloads">Recitatorer med downloads</string>
+  <string name="qarilist_gapless">løbende</string>
+  <string name="qarilist_gapped">ikke-kontinuerlig</string>
+  <string name="qarilist_selected">Udvalgte</string>
+  <string name="qarilist_dismiss">Afvis</string>
+</resources>

--- a/feature/qarilist/src/main/res/values-de/strings.xml
+++ b/feature/qarilist/src/main/res/values-de/strings.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="qarilist_select_qari">Wählen Sie einen Qari</string>
+  <string name="qarilist_ready_to_play">Bereit zum Zuhören</string>
+  <string name="qarilist_qaris_with_downloads">Qaris mit Downloads</string>
+  <string name="qarilist_gapless">kontinuierlich</string>
+  <string name="qarilist_gapped">nicht-kontinuierlich</string>
+  <string name="qarilist_selected">Ausgewählte</string>
+  <string name="qarilist_dismiss">Ablehnen</string>
+</resources>

--- a/feature/qarilist/src/main/res/values-el/strings.xml
+++ b/feature/qarilist/src/main/res/values-el/strings.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="qarilist_select_qari">Επιλέξτε ένα Καρί</string>
+  <string name="qarilist_ready_to_play">Έτοιμοι για ακρόαση</string>
+  <string name="qarilist_qaris_with_downloads">Απαγγελίες με λήψεις</string>
+  <string name="qarilist_gapless">Συνεχής</string>
+  <string name="qarilist_gapped">Μη συνεχής</string>
+  <string name="qarilist_selected">Επιλεγμένα</string>
+  <string name="qarilist_dismiss">Απορρίψτε το</string>
+</resources>

--- a/feature/qarilist/src/main/res/values-es/strings.xml
+++ b/feature/qarilist/src/main/res/values-es/strings.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="qarilist_select_qari">Seleccione un Qari</string>
+  <string name="qarilist_ready_to_play">Listo para escuchar</string>
+  <string name="qarilist_qaris_with_downloads">Recitadores con descargas</string>
+  <string name="qarilist_gapless">Continuo</string>
+  <string name="qarilist_gapped">No continuo</string>
+  <string name="qarilist_selected">Seleccionado</string>
+  <string name="qarilist_dismiss">Descartar</string>
+</resources>

--- a/feature/qarilist/src/main/res/values-et/strings.xml
+++ b/feature/qarilist/src/main/res/values-et/strings.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="qarilist_select_qari">Valige kari</string>
+  <string name="qarilist_ready_to_play">Valmis kuulamiseks</string>
+  <string name="qarilist_qaris_with_downloads">Ettekandjad koos allalaadimistega</string>
+  <string name="qarilist_gapless">Pidev</string>
+  <string name="qarilist_gapped">mittekontuurne</string>
+  <string name="qarilist_selected">Valitud</string>
+  <string name="qarilist_dismiss">Loobu</string>
+</resources>

--- a/feature/qarilist/src/main/res/values-fa/strings.xml
+++ b/feature/qarilist/src/main/res/values-fa/strings.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="qarilist_select_qari">یک قاری را انتخاب کنید</string>
+  <string name="qarilist_ready_to_play">آماده برای گوش دادن</string>
+  <string name="qarilist_qaris_with_downloads">قاری با دانلود</string>
+  <string name="qarilist_gapless">مداوم</string>
+  <string name="qarilist_gapped">غیر پیوسته</string>
+  <string name="qarilist_selected">انتخاب</string>
+  <string name="qarilist_dismiss">اخراج</string>
+</resources>

--- a/feature/qarilist/src/main/res/values-fi/strings.xml
+++ b/feature/qarilist/src/main/res/values-fi/strings.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="qarilist_select_qari">Valitse Kari</string>
+  <string name="qarilist_ready_to_play">Valmis kuuntelemaan</string>
+  <string name="qarilist_qaris_with_downloads">Reciters kanssa Lataukset</string>
+  <string name="qarilist_gapless">Jatkuva</string>
+  <string name="qarilist_gapped">Ei-jatkuva</string>
+  <string name="qarilist_selected">Valitut</string>
+  <string name="qarilist_dismiss">Vapauttakaa</string>
+</resources>

--- a/feature/qarilist/src/main/res/values-fr/strings.xml
+++ b/feature/qarilist/src/main/res/values-fr/strings.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="qarilist_select_qari">Choisir un Qari</string>
+  <string name="qarilist_ready_to_play">Prêt à écouter</string>
+  <string name="qarilist_qaris_with_downloads">Récitants avec téléchargements</string>
+  <string name="qarilist_gapless">Continu</string>
+  <string name="qarilist_gapped">Non-continu</string>
+  <string name="qarilist_selected">Sélectionné</string>
+  <string name="qarilist_dismiss">Rejeter</string>
+</resources>

--- a/feature/qarilist/src/main/res/values-hi/strings.xml
+++ b/feature/qarilist/src/main/res/values-hi/strings.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="qarilist_select_qari">एक Qari का चयन करें</string>
+  <string name="qarilist_ready_to_play">सुनने के लिए तैयार</string>
+  <string name="qarilist_qaris_with_downloads">डाउनलोड के साथ Qaris</string>
+  <string name="qarilist_gapless">लगातार</string>
+  <string name="qarilist_gapped">गैर-निरंतर</string>
+  <string name="qarilist_selected">चयनित</string>
+  <string name="qarilist_dismiss">हटा</string>
+</resources>

--- a/feature/qarilist/src/main/res/values-hr/strings.xml
+++ b/feature/qarilist/src/main/res/values-hr/strings.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="qarilist_select_qari">Odabir Qari</string>
+  <string name="qarilist_ready_to_play">Spremni za slušanje</string>
+  <string name="qarilist_qaris_with_downloads">Recibilizatori s preuzimanjima</string>
+  <string name="qarilist_gapless">Kontinuiran</string>
+  <string name="qarilist_gapped">Neprekinuto</string>
+  <string name="qarilist_selected">Odabrani</string>
+  <string name="qarilist_dismiss">Odbaciti</string>
+</resources>

--- a/feature/qarilist/src/main/res/values-hu/strings.xml
+++ b/feature/qarilist/src/main/res/values-hu/strings.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="qarilist_select_qari">Válasszon egy Qari-t</string>
+  <string name="qarilist_ready_to_play">Készen áll a meghallgatásra</string>
+  <string name="qarilist_qaris_with_downloads">Reciterek letöltésekkel</string>
+  <string name="qarilist_gapless">Folyamatos</string>
+  <string name="qarilist_gapped">Nem folyamatos</string>
+  <string name="qarilist_selected">Kiválasztott</string>
+  <string name="qarilist_dismiss">Elbocsát</string>
+</resources>

--- a/feature/qarilist/src/main/res/values-id/strings.xml
+++ b/feature/qarilist/src/main/res/values-id/strings.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="qarilist_select_qari">Pilih Qari</string>
+  <string name="qarilist_ready_to_play">Siap untuk mendengarkan</string>
+  <string name="qarilist_qaris_with_downloads">Pembaca dengan Unduhan</string>
+  <string name="qarilist_gapless">Berkelanjutan</string>
+  <string name="qarilist_gapped">Tidak Berkesinambungan</string>
+  <string name="qarilist_selected">Terpilih</string>
+  <string name="qarilist_dismiss">Bubar</string>
+</resources>

--- a/feature/qarilist/src/main/res/values-it/strings.xml
+++ b/feature/qarilist/src/main/res/values-it/strings.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="qarilist_select_qari">Selezionare un Qari</string>
+  <string name="qarilist_ready_to_play">Pronto per l\'ascolto</string>
+  <string name="qarilist_qaris_with_downloads">Recitatori con download</string>
+  <string name="qarilist_gapless">Continuo</string>
+  <string name="qarilist_gapped">Non continuo</string>
+  <string name="qarilist_selected">Selezionato</string>
+  <string name="qarilist_dismiss">Congedo</string>
+</resources>

--- a/feature/qarilist/src/main/res/values-ja/strings.xml
+++ b/feature/qarilist/src/main/res/values-ja/strings.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="qarilist_select_qari">クアリを選択する</string>
+  <string name="qarilist_ready_to_play">試聴の準備</string>
+  <string name="qarilist_qaris_with_downloads">ダウンロードできる録音機</string>
+  <string name="qarilist_gapless">連続</string>
+  <string name="qarilist_gapped">非連続</string>
+  <string name="qarilist_selected">選択された</string>
+  <string name="qarilist_dismiss">解散</string>
+</resources>

--- a/feature/qarilist/src/main/res/values-kk/strings.xml
+++ b/feature/qarilist/src/main/res/values-kk/strings.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="qarilist_select_qari">Кари параметрін таңдау</string>
+  <string name="qarilist_ready_to_play">Тыңдауға дайын</string>
+  <string name="qarilist_qaris_with_downloads">Жүктеулері бар реципитерлер</string>
+  <string name="qarilist_gapless">Үздіксіз</string>
+  <string name="qarilist_gapped">Үздіксіз емес</string>
+  <string name="qarilist_selected">Таңдалған</string>
+  <string name="qarilist_dismiss">Жұмыстан шығару</string>
+</resources>

--- a/feature/qarilist/src/main/res/values-ko/strings.xml
+++ b/feature/qarilist/src/main/res/values-ko/strings.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="qarilist_select_qari">카리 선택</string>
+  <string name="qarilist_ready_to_play">듣기 준비 완료</string>
+  <string name="qarilist_qaris_with_downloads">다운로드가 있는 리사이터</string>
+  <string name="qarilist_gapless">지속적</string>
+  <string name="qarilist_gapped">비연속</string>
+  <string name="qarilist_selected">선택한</string>
+  <string name="qarilist_dismiss">해고하다</string>
+</resources>

--- a/feature/qarilist/src/main/res/values-ku/strings.xml
+++ b/feature/qarilist/src/main/res/values-ku/strings.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="qarilist_select_qari">قەرەییەک دیاریبکە</string>
+  <string name="qarilist_ready_to_play">ئامادەیە بۆ گوێگرتن</string>
+  <string name="qarilist_qaris_with_downloads">قەرەی لەگەڵ داگرتنەکان</string>
+  <string name="qarilist_gapless">بەردەوام</string>
+  <string name="qarilist_gapped">بێ بەردەوام</string>
+  <string name="qarilist_selected">هەڵبژێردراو</string>
+  <string name="qarilist_dismiss">لادان</string>
+</resources>

--- a/feature/qarilist/src/main/res/values-lt/strings.xml
+++ b/feature/qarilist/src/main/res/values-lt/strings.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="qarilist_select_qari">Pasirinkite Karį</string>
+  <string name="qarilist_ready_to_play">Paruošta klausytis</string>
+  <string name="qarilist_qaris_with_downloads">Recitatoriai su atsisiuntimais</string>
+  <string name="qarilist_gapless">Nuolatinis</string>
+  <string name="qarilist_gapped">Nepertraukiamas</string>
+  <string name="qarilist_selected">Pasirinkta</string>
+  <string name="qarilist_dismiss">Atmesti</string>
+</resources>

--- a/feature/qarilist/src/main/res/values-lv/strings.xml
+++ b/feature/qarilist/src/main/res/values-lv/strings.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="qarilist_select_qari">Izvēlieties Qari</string>
+  <string name="qarilist_ready_to_play">Gatavs klausīties</string>
+  <string name="qarilist_qaris_with_downloads">Atskaņotāji ar lejupielādes</string>
+  <string name="qarilist_gapless">Nepārtraukts</string>
+  <string name="qarilist_gapped">bez nepārtrauktas</string>
+  <string name="qarilist_selected">Atlasīts</string>
+  <string name="qarilist_dismiss">Atbrīvot</string>
+</resources>

--- a/feature/qarilist/src/main/res/values-ms/strings.xml
+++ b/feature/qarilist/src/main/res/values-ms/strings.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="qarilist_select_qari">Pilih Qari</string>
+  <string name="qarilist_ready_to_play">Sedia untuk mendengar</string>
+  <string name="qarilist_qaris_with_downloads">Qari dengan Muat Turun</string>
+  <string name="qarilist_gapless">Berterusan</string>
+  <string name="qarilist_gapped">Tidak Berterusan</string>
+  <string name="qarilist_selected">Dipilih</string>
+  <string name="qarilist_dismiss">Memecat</string>
+</resources>

--- a/feature/qarilist/src/main/res/values-nl/strings.xml
+++ b/feature/qarilist/src/main/res/values-nl/strings.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="qarilist_select_qari">Kies een Qari</string>
+  <string name="qarilist_ready_to_play">Klaar om te luisteren</string>
+  <string name="qarilist_qaris_with_downloads">Recitanten met Downloads</string>
+  <string name="qarilist_gapless">continu</string>
+  <string name="qarilist_gapped">niet-continu</string>
+  <string name="qarilist_selected">Geselecteerd</string>
+  <string name="qarilist_dismiss">Ontsla</string>
+</resources>

--- a/feature/qarilist/src/main/res/values-pl/strings.xml
+++ b/feature/qarilist/src/main/res/values-pl/strings.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="qarilist_select_qari">Wybierz Qari</string>
+  <string name="qarilist_ready_to_play">Gotowy do słuchania</string>
+  <string name="qarilist_qaris_with_downloads">Recytatorzy z możliwością pobrania</string>
+  <string name="qarilist_gapless">Ciągłe</string>
+  <string name="qarilist_gapped">Nieprzerwanie</string>
+  <string name="qarilist_selected">Wybrane</string>
+  <string name="qarilist_dismiss">Odrzucić</string>
+</resources>

--- a/feature/qarilist/src/main/res/values-ps/strings.xml
+++ b/feature/qarilist/src/main/res/values-ps/strings.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="qarilist_select_qari">قاری انتخاب کړئ</string>
+  <string name="qarilist_ready_to_play">اورېدلو ته چمتو</string>
+  <string name="qarilist_qaris_with_downloads">قاریان د ډاونلوډ سره</string>
+  <string name="qarilist_gapless">پرله پسې</string>
+  <string name="qarilist_gapped">غیر پرله پسې</string>
+  <string name="qarilist_selected">ټاکل شوی</string>
+  <string name="qarilist_dismiss">ګوښه کول</string>
+</resources>

--- a/feature/qarilist/src/main/res/values-pt-rBR/strings.xml
+++ b/feature/qarilist/src/main/res/values-pt-rBR/strings.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="qarilist_select_qari">Selecione um Qari</string>
+  <string name="qarilist_ready_to_play">Pronto para ouvir</string>
+  <string name="qarilist_qaris_with_downloads">Recitadores com Downloads</string>
+  <string name="qarilist_gapless">Contínuo</string>
+  <string name="qarilist_gapped">Não-Continuidade</string>
+  <string name="qarilist_selected">Selecionado</string>
+  <string name="qarilist_dismiss">Despedimento</string>
+</resources>

--- a/feature/qarilist/src/main/res/values-pt/strings.xml
+++ b/feature/qarilist/src/main/res/values-pt/strings.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="qarilist_select_qari">Seleccione um Qari</string>
+  <string name="qarilist_ready_to_play">Pronto para ouvir</string>
+  <string name="qarilist_qaris_with_downloads">Recitadores com Downloads</string>
+  <string name="qarilist_gapless">Contínuo</string>
+  <string name="qarilist_gapped">Não-Continuidade</string>
+  <string name="qarilist_selected">Seleccionado</string>
+  <string name="qarilist_dismiss">Indeferimento</string>
+</resources>

--- a/feature/qarilist/src/main/res/values-ro/strings.xml
+++ b/feature/qarilist/src/main/res/values-ro/strings.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="qarilist_select_qari">Selectați un Qari</string>
+  <string name="qarilist_ready_to_play">Gata de ascultare</string>
+  <string name="qarilist_qaris_with_downloads">Reciteri cu descărcări</string>
+  <string name="qarilist_gapless">Continuă</string>
+  <string name="qarilist_gapped">Non-continuă</string>
+  <string name="qarilist_selected">Selectată</string>
+  <string name="qarilist_dismiss">Respingeți</string>
+</resources>

--- a/feature/qarilist/src/main/res/values-ru/strings.xml
+++ b/feature/qarilist/src/main/res/values-ru/strings.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="qarilist_select_qari">Выберите Кари</string>
+  <string name="qarilist_ready_to_play">Готовность к прослушиванию</string>
+  <string name="qarilist_qaris_with_downloads">Чтецы с загрузками</string>
+  <string name="qarilist_gapless">Непрерывный</string>
+  <string name="qarilist_gapped">неконтинуальный</string>
+  <string name="qarilist_selected">Избранное</string>
+  <string name="qarilist_dismiss">Отклонить</string>
+</resources>

--- a/feature/qarilist/src/main/res/values-sk/strings.xml
+++ b/feature/qarilist/src/main/res/values-sk/strings.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="qarilist_select_qari">Vyberte Qari</string>
+  <string name="qarilist_ready_to_play">Pripravené na počúvanie</string>
+  <string name="qarilist_qaris_with_downloads">Recitátori so súbormi na stiahnutie</string>
+  <string name="qarilist_gapless">Kontinuálne</string>
+  <string name="qarilist_gapped">nekontinuálne</string>
+  <string name="qarilist_selected">Vybrané</string>
+  <string name="qarilist_dismiss">Odmietnuť</string>
+</resources>

--- a/feature/qarilist/src/main/res/values-sl/strings.xml
+++ b/feature/qarilist/src/main/res/values-sl/strings.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="qarilist_select_qari">Izberite Qari</string>
+  <string name="qarilist_ready_to_play">Pripravljeni na poslušanje</string>
+  <string name="qarilist_qaris_with_downloads">Recitatorji s prenosi</string>
+  <string name="qarilist_gapless">Stalno</string>
+  <string name="qarilist_gapped">nepretrgoma</string>
+  <string name="qarilist_selected">Izbrani</string>
+  <string name="qarilist_dismiss">Zavrnite</string>
+</resources>

--- a/feature/qarilist/src/main/res/values-sq/strings.xml
+++ b/feature/qarilist/src/main/res/values-sq/strings.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="qarilist_select_qari">Zgjidh një Qari</string>
+  <string name="qarilist_ready_to_play">Gati për të dëgjuar</string>
+  <string name="qarilist_qaris_with_downloads">Recitues me shkarkime</string>
+  <string name="qarilist_gapless">E vazhdueshme</string>
+  <string name="qarilist_gapped">Jo i vazhdueshëm</string>
+  <string name="qarilist_selected">Zgjedhur</string>
+  <string name="qarilist_dismiss">Hiqe</string>
+</resources>

--- a/feature/qarilist/src/main/res/values-sr/strings.xml
+++ b/feature/qarilist/src/main/res/values-sr/strings.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="qarilist_select_qari">Izaberite Qari</string>
+  <string name="qarilist_ready_to_play">Spreman za slušanje</string>
+  <string name="qarilist_qaris_with_downloads">Reciteri sa preuzimanjima</string>
+  <string name="qarilist_gapless">Neprekidno</string>
+  <string name="qarilist_gapped">Zapušeno</string>
+  <string name="qarilist_selected">Izabrali</string>
+  <string name="qarilist_dismiss">Otpusti</string>
+</resources>

--- a/feature/qarilist/src/main/res/values-sv/strings.xml
+++ b/feature/qarilist/src/main/res/values-sv/strings.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="qarilist_select_qari">Välj en Qari</string>
+  <string name="qarilist_ready_to_play">Redo för att lyssna</string>
+  <string name="qarilist_qaris_with_downloads">Recitatorer med nedladdningar</string>
+  <string name="qarilist_gapless">Kontinuerlig</string>
+  <string name="qarilist_gapped">Icke-kontinuerlig</string>
+  <string name="qarilist_selected">Utvald</string>
+  <string name="qarilist_dismiss">Avvisa</string>
+</resources>

--- a/feature/qarilist/src/main/res/values-th/strings.xml
+++ b/feature/qarilist/src/main/res/values-th/strings.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="qarilist_select_qari">เลือก Qari</string>
+  <string name="qarilist_ready_to_play">พร้อมสําหรับการฟัง</string>
+  <string name="qarilist_qaris_with_downloads">ผู้บรรยายพร้อมการดาวน์โหลด</string>
+  <string name="qarilist_gapless">ต่อเนื่อง</string>
+  <string name="qarilist_gapped">ไม่ต่อเนื่อง</string>
+  <string name="qarilist_selected">เลือก</string>
+  <string name="qarilist_dismiss">ไล่ออก</string>
+</resources>

--- a/feature/qarilist/src/main/res/values-tr/strings.xml
+++ b/feature/qarilist/src/main/res/values-tr/strings.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="qarilist_select_qari">Bir Kari Seçin</string>
+  <string name="qarilist_ready_to_play">Dinlemeye hazır</string>
+  <string name="qarilist_qaris_with_downloads">İndirilebilir Okuyucular</string>
+  <string name="qarilist_gapless">Sürekli</string>
+  <string name="qarilist_gapped">Sürekli Olmayan</string>
+  <string name="qarilist_selected">Seçilmiş</string>
+  <string name="qarilist_dismiss">Dağılın</string>
+</resources>

--- a/feature/qarilist/src/main/res/values-ug/strings.xml
+++ b/feature/qarilist/src/main/res/values-ug/strings.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="qarilist_select_qari">ئوقۇرمەننى تاللاڭ</string>
+  <string name="qarilist_ready_to_play">ئاڭلاشقا تەييار</string>
+  <string name="qarilist_qaris_with_downloads">چۈشۈرۈش بىلەن كارى</string>
+  <string name="qarilist_gapless">ئۈزلۈكسىز</string>
+  <string name="qarilist_gapped">ئىزچىل ئەمەس</string>
+  <string name="qarilist_selected">تاللانغان</string>
+  <string name="qarilist_dismiss">خىزمەتتىن ھەيدەش</string>
+</resources>

--- a/feature/qarilist/src/main/res/values-uk/strings.xml
+++ b/feature/qarilist/src/main/res/values-uk/strings.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="qarilist_select_qari">Виберіть Кари</string>
+  <string name="qarilist_ready_to_play">Готовий до прослуховування</string>
+  <string name="qarilist_qaris_with_downloads">Декламатори із завантаженнями</string>
+  <string name="qarilist_gapless">Безперервний</string>
+  <string name="qarilist_gapped">Неперервний</string>
+  <string name="qarilist_selected">Вибрані</string>
+  <string name="qarilist_dismiss">Звільнити</string>
+</resources>

--- a/feature/qarilist/src/main/res/values-ur/strings.xml
+++ b/feature/qarilist/src/main/res/values-ur/strings.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="qarilist_select_qari">قاری منتخب کریں</string>
+  <string name="qarilist_ready_to_play">سننے کے لئے تیار</string>
+  <string name="qarilist_qaris_with_downloads">ڈاؤن لوڈ کے ساتھ قاری</string>
+  <string name="qarilist_gapless">مسلسل</string>
+  <string name="qarilist_gapped">غیر متواتر</string>
+  <string name="qarilist_selected">منتخب</string>
+  <string name="qarilist_dismiss">برخاست کریں</string>
+</resources>

--- a/feature/qarilist/src/main/res/values-uz/strings.xml
+++ b/feature/qarilist/src/main/res/values-uz/strings.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="qarilist_select_qari">Qori tanlang</string>
+  <string name="qarilist_ready_to_play">Eshitishga tayyor</string>
+  <string name="qarilist_qaris_with_downloads">Yuklab olish bilan tilovatchilar</string>
+  <string name="qarilist_gapless">uzluksiz</string>
+  <string name="qarilist_gapped">Bo\'shashgan</string>
+  <string name="qarilist_selected">Tanlangan</string>
+  <string name="qarilist_dismiss">Rad etish</string>
+</resources>

--- a/feature/qarilist/src/main/res/values-zh/strings.xml
+++ b/feature/qarilist/src/main/res/values-zh/strings.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="qarilist_select_qari">选择一个卡里</string>
+  <string name="qarilist_ready_to_play">准备聆听</string>
+  <string name="qarilist_qaris_with_downloads">有下载的朗诵者</string>
+  <string name="qarilist_gapless">连续的</string>
+  <string name="qarilist_gapped">非连续的</string>
+  <string name="qarilist_selected">精选</string>
+  <string name="qarilist_dismiss">解散</string>
+</resources>


### PR DESCRIPTION
Most of these are based on:
```
<?xml version="1.0" encoding="utf-8"?>
<resources>
  <string name="qarilist_select_qari">Select a Qari</string>
  <string name="qarilist_ready_to_play">Ready for listening</string>
  <string name="qarilist_qaris_with_downloads">Reciters with Downloads</string>
  <string name="qarilist_gapless">Continuous</string>
  <string name="qarilist_gapped">Non-Continuous</string>
  <string name="qarilist_selected">Selected</string>
  <string name="qarilist_dismiss">Dismiss</string>
</resources>

```
