### PR TITLE
Use namespace instead of one line manifests

### DIFF
--- a/common/audio/build.gradle
+++ b/common/audio/build.gradle
@@ -6,6 +6,7 @@ apply plugin: 'com.squareup.anvil'
 anvil { generateDaggerFactories = true }
 
 android {
+  namespace 'com.quran.labs.androidquran.common.audio'
   compileSdkVersion deps.android.build.compileSdkVersion
   defaultConfig {
     minSdkVersion deps.android.build.minSdkVersion

--- a/common/audio/src/main/AndroidManifest.xml
+++ b/common/audio/src/main/AndroidManifest.xml
@@ -1,1 +1,0 @@
-<manifest package="com.quran.labs.androidquran.common.audio"/>

--- a/common/bookmark/build.gradle
+++ b/common/bookmark/build.gradle
@@ -6,6 +6,7 @@ apply plugin: 'com.squareup.anvil'
 anvil { generateDaggerFactories = true }
 
 android {
+  namespace 'com.quran.mobile.bookmark'
   compileSdkVersion deps.android.build.compileSdkVersion
   defaultConfig {
     minSdkVersion deps.android.build.minSdkVersion

--- a/common/bookmark/src/main/AndroidManifest.xml
+++ b/common/bookmark/src/main/AndroidManifest.xml
@@ -1,1 +1,0 @@
-<manifest package="com.quran.mobile.bookmark"/>

--- a/common/di/build.gradle
+++ b/common/di/build.gradle
@@ -5,6 +5,7 @@ plugins {
 }
 
 android {
+  namespace 'com.quran.mobile.di'
   compileSdkVersion deps.android.build.compileSdkVersion
   defaultConfig {
     minSdkVersion deps.android.build.minSdkVersion

--- a/common/di/src/main/AndroidManifest.xml
+++ b/common/di/src/main/AndroidManifest.xml
@@ -1,1 +1,0 @@
-<manifest package="com.quran.mobile.di"/>

--- a/common/download/build.gradle
+++ b/common/download/build.gradle
@@ -5,6 +5,7 @@ apply plugin: 'com.squareup.anvil'
 anvil { generateDaggerFactories = true }
 
 android {
+  namespace 'com.quran.mobile.common.download'
   compileSdkVersion deps.android.build.compileSdkVersion
   defaultConfig {
     minSdkVersion deps.android.build.minSdkVersion

--- a/common/download/src/main/AndroidManifest.xml
+++ b/common/download/src/main/AndroidManifest.xml
@@ -1,1 +1,0 @@
-<manifest package="com.quran.mobile.common.download"/>

--- a/common/pages/build.gradle
+++ b/common/pages/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
 
 android {
+  namespace 'com.quran.labs.androidquran.common.pages'
   compileSdkVersion deps.android.build.compileSdkVersion
   defaultConfig {
     minSdkVersion deps.android.build.minSdkVersion

--- a/common/pages/src/main/AndroidManifest.xml
+++ b/common/pages/src/main/AndroidManifest.xml
@@ -1,1 +1,0 @@
-<manifest package="com.quran.labs.androidquran.common.pages"/>

--- a/common/recitation/build.gradle
+++ b/common/recitation/build.gradle
@@ -5,6 +5,7 @@ plugins {
 }
 
 android {
+  namespace 'com.quran.recitation.common'
   compileSdkVersion deps.android.build.compileSdkVersion
   defaultConfig {
     minSdkVersion deps.android.build.minSdkVersion

--- a/common/recitation/src/main/AndroidManifest.xml
+++ b/common/recitation/src/main/AndroidManifest.xml
@@ -1,1 +1,0 @@
-<manifest package="com.quran.recitation.common"/>

--- a/common/search/build.gradle
+++ b/common/search/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
 
 android {
+  namespace 'com.quran.labs.androidquran.common.search'
   compileSdkVersion deps.android.build.compileSdkVersion
   defaultConfig {
     minSdkVersion deps.android.build.minSdkVersion

--- a/common/search/src/main/AndroidManifest.xml
+++ b/common/search/src/main/AndroidManifest.xml
@@ -1,1 +1,0 @@
-<manifest package="com.quran.labs.androidquran.common.search"/>

--- a/common/toolbar/build.gradle
+++ b/common/toolbar/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'com.squareup.anvil'
 
 android {
+  namespace 'com.quran.labs.androidquran.common.toolbar'
   compileSdkVersion deps.android.build.compileSdkVersion
   defaultConfig {
     minSdkVersion deps.android.build.minSdkVersion

--- a/common/toolbar/src/main/AndroidManifest.xml
+++ b/common/toolbar/src/main/AndroidManifest.xml
@@ -1,1 +1,0 @@
-<manifest package="com.quran.labs.androidquran.common.toolbar"/>

--- a/common/ui/core/build.gradle
+++ b/common/ui/core/build.gradle
@@ -2,6 +2,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+  namespace 'com.quran.mobile.common.ui.core'
   compileSdkVersion deps.android.build.compileSdkVersion
   defaultConfig {
     minSdkVersion deps.android.build.minSdkVersion

--- a/common/ui/core/src/main/AndroidManifest.xml
+++ b/common/ui/core/src/main/AndroidManifest.xml
@@ -1,1 +1,0 @@
-<manifest package="com.quran.mobile.common.ui.core"/>

--- a/common/upgrade/build.gradle
+++ b/common/upgrade/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
 
 android {
+  namespace 'com.quran.labs.androidquran.common.upgrade'
   compileSdkVersion deps.android.build.compileSdkVersion
   defaultConfig {
     minSdkVersion deps.android.build.minSdkVersion

--- a/common/upgrade/src/main/AndroidManifest.xml
+++ b/common/upgrade/src/main/AndroidManifest.xml
@@ -1,1 +1,0 @@
-<manifest package="com.quran.labs.androidquran.common.upgrade"/>

--- a/feature/audio/build.gradle
+++ b/feature/audio/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
 
 android {
+  namespace 'com.quran.labs.androidquran.feature.audio'
   compileSdkVersion deps.android.build.compileSdkVersion
   defaultConfig {
     minSdkVersion deps.android.build.minSdkVersion

--- a/feature/audio/src/main/AndroidManifest.xml
+++ b/feature/audio/src/main/AndroidManifest.xml
@@ -1,1 +1,0 @@
-<manifest package="com.quran.labs.androidquran.feature.audio"/>

--- a/feature/qarilist/build.gradle
+++ b/feature/qarilist/build.gradle
@@ -5,6 +5,7 @@ plugins {
 }
 
 android {
+  namespace 'com.quran.mobile.feature.qarilist'
   compileSdkVersion deps.android.build.compileSdkVersion
   defaultConfig {
     minSdkVersion deps.android.build.minSdkVersion

--- a/feature/qarilist/src/main/AndroidManifest.xml
+++ b/feature/qarilist/src/main/AndroidManifest.xml
@@ -1,1 +1,0 @@
-<manifest package="com.quran.mobile.feature.qarilist"/>

--- a/feature/recitation/build.gradle
+++ b/feature/recitation/build.gradle
@@ -5,6 +5,7 @@ plugins {
 }
 
 android {
+  namespace 'com.quran.mobile.recitation'
   compileSdkVersion deps.android.build.compileSdkVersion
   defaultConfig {
     minSdkVersion deps.android.build.minSdkVersion

--- a/feature/recitation/src/main/AndroidManifest.xml
+++ b/feature/recitation/src/main/AndroidManifest.xml
@@ -1,1 +1,0 @@
-<manifest package="com.quran.mobile.recitation"/>

--- a/pages/madani/build.gradle
+++ b/pages/madani/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
 
 android {
+  namespace 'com.quran.labs.androidquran.pages.madani'
   compileSdkVersion deps.android.build.compileSdkVersion
   defaultConfig {
     minSdkVersion deps.android.build.minSdkVersion

--- a/pages/madani/src/main/AndroidManifest.xml
+++ b/pages/madani/src/main/AndroidManifest.xml
@@ -1,1 +1,0 @@
-<manifest package="com.quran.labs.androidquran.pages.madani"/>


### PR DESCRIPTION
In AGP 7.3.0, android.namespace can be set instead of having an
AndroidManifest.xml for the sole purpose of setting a package name.
This does this for the relevant build files.
