### PR TITLE
Cap ui tests workflow at 25 minutes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,6 +102,7 @@ jobs:
   ui_test:
     name: Instrumentation tests
     runs-on: macos-latest
+    timeout-minutes: 25
     steps:
       - name: Checkout the Code
         uses: actions/checkout@v2


### PR DESCRIPTION
Sometimes, the ui test workflow gets stuck. This makes sure it never
goes beyond 25 minutes, otherwise it is canceled. In the future, will
likely consider replacing this ui test with something else.
