### PR TITLE
Remove lint workaround

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -12,6 +12,3 @@ android.enableResourceOptimizations=true
 android.uniquePackageNames=true
 android.enableAppCompileTimeRClass=true
 android.experimental.enableNewResourceShrinker=true
-
-# temporarily use updated lint to work around issues
-android.experimental.lint.version=8.0.0-alpha10


### PR DESCRIPTION
Since we're now compiling against AGP 7.4.0, this workaround for lint is
no longer needed.
