### PR TITLE
Fix widget bookmarks always going to last page

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/widget/BookmarksWidget.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/widget/BookmarksWidget.kt
@@ -64,7 +64,7 @@ class BookmarksWidget : AppWidgetProvider() {
         .getActivity(
           context, 0,
           clickIntent,
-          PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+          PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE
         )
       widget.setPendingIntentTemplate(R.id.list_view_widget, clickPendingIntent)
       widget.setEmptyView(R.id.list_view_widget, R.id.empty_view)


### PR DESCRIPTION
Widgets need to have the mutable flag since the pending intent template
needs to be mutated per row.
