### PR TITLE
Hide older gapped qaris from download manager

### DIFF
--- a/common/audio/src/main/java/com/quran/labs/androidquran/common/audio/cache/QariDownloadInfoManager.kt
+++ b/common/audio/src/main/java/com/quran/labs/androidquran/common/audio/cache/QariDownloadInfoManager.kt
@@ -42,6 +42,21 @@ class QariDownloadInfoManager @Inject constructor(
     return storageCache.flow()
   }
 
+  fun downloadQariInfoFilteringNonDownloadedGappedQaris(): Flow<List<QariDownloadInfo>> {
+    return downloadedQariInfo().map { list ->
+      list.filter { qariDownloadInfo ->
+        val qari = qariDownloadInfo.qari
+        val gappedItem = qariDownloadInfo as? QariDownloadInfo.GappedQariDownloadInfo
+        qari.isGapless ||
+            // gapped qaris are only shown if they don't have a gapless alternative or if
+            // some file for the qari is already downloaded.
+            (!qari.hasGaplessAlternative ||
+                qariDownloadInfo.fullyDownloadedSuras.isNotEmpty() ||
+                (gappedItem?.partiallyDownloadedSuras?.isNotEmpty() ?: false))
+      }
+    }
+  }
+
   private fun populateCache() {
     val audioDirectory = quranFileManager.audioFileDirectory() ?: return
     val qariDownloadInfo = audioInfoCommand.generateAllQariDownloadInfo(audioDirectory)

--- a/feature/downloadmanager/src/main/kotlin/com/quran/mobile/feature/downloadmanager/presenter/AudioManagerPresenter.kt
+++ b/feature/downloadmanager/src/main/kotlin/com/quran/mobile/feature/downloadmanager/presenter/AudioManagerPresenter.kt
@@ -17,7 +17,7 @@ class AudioManagerPresenter @Inject constructor(
   fun downloadedShuyookh(
     lambda: ((Qari) -> QariItem)
   ): Flow<List<DownloadedSheikhUiModel>> {
-    return qariDownloadInfoManager.downloadedQariInfo()
+    return qariDownloadInfoManager.downloadQariInfoFilteringNonDownloadedGappedQaris()
       .map { qariDownloadInfoList ->
         qariDownloadInfoList
           .map { qariDownloadInfo ->

--- a/feature/qarilist/src/main/kotlin/com/quran/mobile/feature/qarilist/presenter/QariListPresenter.kt
+++ b/feature/qarilist/src/main/kotlin/com/quran/mobile/feature/qarilist/presenter/QariListPresenter.kt
@@ -17,18 +17,7 @@ import kotlinx.coroutines.flow.map
 class QariListPresenter @Inject constructor(private val qariDownloadInfoManager: QariDownloadInfoManager) {
 
   fun qariList(start: SuraAyah, end: SuraAyah, qariTranslationLambda: ((Qari) -> QariItem)): Flow<List<QariUiModel>> {
-    return qariDownloadInfoManager.downloadedQariInfo().map { list ->
-        list.filter { qariDownloadInfo ->
-          val qari = qariDownloadInfo.qari
-          val gappedItem = qariDownloadInfo as? QariDownloadInfo.GappedQariDownloadInfo
-          qari.isGapless ||
-              // gapped qaris are only shown if they don't have a gapless alternative or if
-              // some file for the qari is already downloaded.
-              (!qari.hasGaplessAlternative ||
-                  qariDownloadInfo.fullyDownloadedSuras.isNotEmpty() ||
-                  (gappedItem?.partiallyDownloadedSuras?.isNotEmpty() ?: false))
-        }
-      }
+    return qariDownloadInfoManager.downloadQariInfoFilteringNonDownloadedGappedQaris()
       .map { unsortedQariList ->
         val readyToPlay = unsortedQariList.filter { it.isRangeDownloaded(start, end) }
           .toSortedQariItemList(qariTranslationLambda)


### PR DESCRIPTION
Like the shuyookh selection popup, only shuyookh who are gapless, gapped
without gapless alternatives, or gapped with downloads should show up in
the download manager. This shares the logic so both the shuyookh
selection and download manager reflect the same list of shuyookh.
