### PR TITLE
Properly set jvmToolchain for Kotlin

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -67,7 +67,6 @@ android {
   }
 
   kotlinOptions {
-    jvmTarget = "1.8"
     freeCompilerArgs += [ "-Xuse-experimental=kotlinx.coroutines.ExperimentalCoroutinesApi" ]
   }
 

--- a/build-logic/convention/src/main/kotlin/AndroidApplicationConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidApplicationConventionPlugin.kt
@@ -1,9 +1,11 @@
 import com.android.build.api.dsl.ApplicationExtension
 import com.quran.labs.androidquran.buildutil.applyAndroidCommon
 import com.quran.labs.androidquran.buildutil.applyBoms
+import com.quran.labs.androidquran.buildutil.applyKotlinCommon
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.configure
+import org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension
 
 class AndroidApplicationConventionPlugin : Plugin<Project> {
 
@@ -19,6 +21,7 @@ class AndroidApplicationConventionPlugin : Plugin<Project> {
         defaultConfig.targetSdk = 32
       }
 
+      applyKotlinCommon()
       applyBoms()
     }
   }

--- a/build-logic/convention/src/main/kotlin/AndroidLibraryComposeConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidLibraryComposeConventionPlugin.kt
@@ -1,4 +1,7 @@
 import com.android.build.gradle.LibraryExtension
+import com.quran.labs.androidquran.buildutil.applyAndroidCommon
+import com.quran.labs.androidquran.buildutil.applyBoms
+import com.quran.labs.androidquran.buildutil.applyKotlinCommon
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.configure
@@ -13,12 +16,15 @@ class AndroidLibraryComposeConventionPlugin : Plugin<Project> {
       }
 
       extensions.configure<LibraryExtension> {
+        applyAndroidCommon()
         buildFeatures.compose = true
         composeOptions.kotlinCompilerExtensionVersion = "1.4.1-dev-k1.8.10-c312d77f4cb"
       }
 
+      applyKotlinCommon()
+      applyBoms()
+
       dependencies {
-        add("implementation", platform("androidx.compose:compose-bom:2023.01.00"))
         // all compose projects need the runtime.
         // we can switch this to implementation instead of api once a fix is pushed for
         // https://issuetracker.google.com/issues/209688774.

--- a/build-logic/convention/src/main/kotlin/AndroidLibraryConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidLibraryConventionPlugin.kt
@@ -1,6 +1,7 @@
 import com.android.build.gradle.LibraryExtension
 import com.quran.labs.androidquran.buildutil.applyAndroidCommon
 import com.quran.labs.androidquran.buildutil.applyBoms
+import com.quran.labs.androidquran.buildutil.applyKotlinCommon
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.configure
@@ -19,6 +20,7 @@ class AndroidLibraryConventionPlugin : Plugin<Project> {
         defaultConfig.targetSdk = 32
       }
 
+      applyKotlinCommon()
       applyBoms()
     }
   }

--- a/build-logic/convention/src/main/kotlin/KotlinLibraryConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/KotlinLibraryConventionPlugin.kt
@@ -1,4 +1,5 @@
 import com.quran.labs.androidquran.buildutil.applyBoms
+import com.quran.labs.androidquran.buildutil.applyKotlinCommon
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 
@@ -10,6 +11,7 @@ class KotlinLibraryConventionPlugin : Plugin<Project> {
         apply("kotlin")
       }
 
+      applyKotlinCommon()
       applyBoms()
     }
   }

--- a/build-logic/convention/src/main/kotlin/com/quran/labs/androidquran/buildutil/AndroidCommon.kt
+++ b/build-logic/convention/src/main/kotlin/com/quran/labs/androidquran/buildutil/AndroidCommon.kt
@@ -10,11 +10,11 @@ fun CommonExtension<*, *, *, *>.applyAndroidCommon() {
   defaultConfig.minSdk = 21
 
   compileOptions {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
   }
 
   (this as ExtensionAware).extensions.configure<KotlinJvmOptions>("kotlinOptions") {
-    jvmTarget = JavaVersion.VERSION_1_8.toString()
+    jvmTarget = JavaVersion.VERSION_11.toString()
   }
 }

--- a/build-logic/convention/src/main/kotlin/com/quran/labs/androidquran/buildutil/KotlinCommon.kt
+++ b/build-logic/convention/src/main/kotlin/com/quran/labs/androidquran/buildutil/KotlinCommon.kt
@@ -1,0 +1,11 @@
+package com.quran.labs.androidquran.buildutil
+
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.configure
+import org.jetbrains.kotlin.gradle.dsl.KotlinProjectExtension
+
+fun Project.applyKotlinCommon() {
+  extensions.configure<KotlinProjectExtension> {
+    jvmToolchain(11)
+  }
+}

--- a/common/networking/build.gradle
+++ b/common/networking/build.gradle
@@ -3,11 +3,6 @@ plugins {
   id 'org.jetbrains.kotlin.kapt'
 }
 
-java {
-  sourceCompatibility JavaVersion.VERSION_1_8
-  targetCompatibility JavaVersion.VERSION_1_8
-}
-
 dependencies {
   kapt deps.dagger.apt
   implementation deps.dagger.runtime


### PR DESCRIPTION
This patch properly sets the jvmToolchain for Kotlin within the
convention plugins. This enables us to upgrade to Gradle 8.
