### PR TITLE
Fix last page not appearing for Shemerly on tablet

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/presenter/quran/QuranPagePresenter.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/presenter/quran/QuranPagePresenter.kt
@@ -1,5 +1,6 @@
 package com.quran.labs.androidquran.presenter.quran
 
+import com.quran.data.core.QuranInfo
 import com.quran.data.di.QuranPageScope
 import com.quran.labs.androidquran.R
 import com.quran.labs.androidquran.common.Response
@@ -22,6 +23,7 @@ class QuranPagePresenter @Inject constructor(
   private val coordinatesModel: CoordinatesModel,
   private val quranSettings: QuranSettings,
   private val quranPageLoader: QuranPageLoader,
+  private val quranInfo: QuranInfo,
   private val pages: IntArray,
 ) : Presenter<QuranPageScreen> {
 
@@ -85,8 +87,12 @@ class QuranPagePresenter @Inject constructor(
 
   fun downloadImages() {
     screen?.hidePageDownloadError()
+    // drop empty pages - this happens in Shemerly, for example, where there are an odd number of
+    // pages. in dual page mode, we have an empty page at the end, so we don't want to try to load
+    // the empty page.
+    val actualPages = pages.filter { it <= quranInfo.numberOfPages }
     compositeDisposable.add(
-      quranPageLoader.loadPages(pages.toTypedArray())
+      quranPageLoader.loadPages(actualPages.toTypedArray())
         .observeOn(AndroidSchedulers.mainThread())
         .subscribeWith(object : DisposableObserver<Response>() {
           override fun onNext(response: Response) {

--- a/app/src/main/java/com/quran/labs/androidquran/presenter/quran/ayahtracker/NoOpImageTrackerItem.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/presenter/quran/ayahtracker/NoOpImageTrackerItem.kt
@@ -1,0 +1,11 @@
+package com.quran.labs.androidquran.presenter.quran.ayahtracker
+
+import com.quran.data.model.AyahGlyph
+import com.quran.data.model.AyahWord
+import com.quran.data.model.selection.SelectionIndicator
+
+class NoOpImageTrackerItem(pageNumber: Int) : AyahTrackerItem(pageNumber) {
+  override fun getToolBarPosition(page: Int, sura: Int, ayah: Int): SelectionIndicator = SelectionIndicator.None
+  override fun getToolBarPosition(page: Int, word: AyahWord): SelectionIndicator = SelectionIndicator.None
+  override fun getToolBarPosition(page: Int, glyph: AyahGlyph): SelectionIndicator = SelectionIndicator.None
+}

--- a/app/src/main/java/com/quran/labs/androidquran/ui/PagerActivity.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/PagerActivity.java
@@ -437,7 +437,18 @@ public class PagerActivity extends AppCompatActivity implements
       @Override
       public void onPageSelected(int position) {
         Timber.d("onPageSelected(): %d", position);
-        final int page = quranInfo.getPageFromPosition(position, isDualPageVisible());
+        final int potentialPage = quranInfo.getPageFromPosition(position, isDualPageVisible());
+
+        // work around for empty pages at the end of the mushaf in dual screen mode
+        // Shemerly has an odd number of pages (521), so when showing in tablet mode,
+        // the last page is empty. default to the previous page title in those cases.
+        final int page;
+        if (isDualPages && !showingTranslation && potentialPage == quranInfo.getNumberOfPages() + 1) {
+          page = quranInfo.getNumberOfPages();
+        } else {
+          page = potentialPage;
+        }
+
         if (quranSettings.shouldDisplayMarkerPopup()) {
           lastPopupTime = QuranDisplayHelper.displayMarkerPopup(
               PagerActivity.this, quranInfo, page, lastPopupTime);

--- a/app/src/main/java/com/quran/labs/androidquran/ui/fragment/TabletFragment.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/fragment/TabletFragment.java
@@ -27,6 +27,7 @@ import com.quran.labs.androidquran.presenter.quran.ayahtracker.AyahSplitConsolid
 import com.quran.labs.androidquran.presenter.quran.ayahtracker.AyahTrackerItem;
 import com.quran.labs.androidquran.presenter.quran.ayahtracker.AyahTrackerPresenter;
 import com.quran.labs.androidquran.presenter.quran.ayahtracker.AyahTranslationTrackerItem;
+import com.quran.labs.androidquran.presenter.quran.ayahtracker.NoOpImageTrackerItem;
 import com.quran.labs.androidquran.presenter.translation.TranslationPresenter;
 import com.quran.labs.androidquran.ui.PagerActivity;
 import com.quran.labs.androidquran.ui.helpers.AyahSelectedListener;
@@ -286,12 +287,16 @@ public class TabletFragment extends Fragment
       AyahTrackerItem right;
       if (mode == Mode.ARABIC) {
         if (leftImageView != null && rightImageView != null) {
-          left = new AyahImageTrackerItem(pageNumber,
-              quranInfo,
-              quranDisplayData,
-              false,
-              imageDrawHelpers,
-              leftImageView);
+          if (quranInfo.getNumberOfPages() >= pageNumber) {
+            left = new AyahImageTrackerItem(pageNumber,
+                quranInfo,
+                quranDisplayData,
+                false,
+                imageDrawHelpers,
+                leftImageView);
+          } else {
+            left = new NoOpImageTrackerItem(pageNumber);
+          }
           right = new AyahImageTrackerItem(
               pageNumber - 1, quranInfo, quranDisplayData, true, imageDrawHelpers,
               rightImageView);

--- a/app/src/main/java/com/quran/labs/androidquran/ui/helpers/QuranPageAdapter.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/helpers/QuranPageAdapter.kt
@@ -22,7 +22,7 @@ class QuranPageAdapter(
 ) : FragmentStatePagerAdapter(fm, if (isDualPages) "dualPages" else "singlePage") {
   private var pageMode: PageMode = makePageMode()
   private val totalPages: Int = quranInfo.numberOfPages
-  private val totalPagesDual: Int = totalPages / 2
+  private val totalPagesDual: Int = totalPages / 2 + (totalPages % 2)
 
   fun setTranslationMode() {
     if (!isShowingTranslation) {

--- a/app/src/main/java/com/quran/labs/androidquran/util/AudioUtils.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/util/AudioUtils.kt
@@ -109,7 +109,7 @@ class AudioUtils @Inject constructor(
     mode: Int,
     isDualPageVisible: Boolean
   ): SuraAyah? {
-    val page =
+    val potentialPage =
       if (isDualPageVisible &&
         mode == LookAheadAmount.PAGE &&
         currentPage % 2 == 1
@@ -121,13 +121,21 @@ class AudioUtils @Inject constructor(
         currentPage
       }
 
+    // in cases like Shermerly in dual screen where the last page is empty, use
+    // the page prior to the last page.
+    val page = if (isDualPageVisible && potentialPage == (totalPages + 1)) {
+      totalPages
+    } else {
+      potentialPage
+    }
+
     var pageLastSura = 114
     var pageLastAyah = 6
+
     // page < 0 - intentional, because nextPageAyah looks up the ayah on the next page
     if (page > totalPages || page < 0) {
       return null
     }
-
 
     if (mode == LookAheadAmount.SURA) {
       val sura = startAyah.sura

--- a/common/data/src/main/java/com/quran/data/core/QuranInfo.kt
+++ b/common/data/src/main/java/com/quran/data/core/QuranInfo.kt
@@ -22,7 +22,7 @@ class QuranInfo @Inject constructor(quranDataSource: QuranDataSource) {
   val quarters = quranDataSource.quartersArray
 
   val numberOfPages = quranDataSource.numberOfPages
-  val numberOfPagesDual = numberOfPages / 2
+  val numberOfPagesDual = numberOfPages / 2 + numberOfPages % 2
 
   fun getStartingPageForJuz(juz: Int): Int {
     return juzPageStart[juz - 1]


### PR DESCRIPTION
The Shemerly mushaf has an odd number of pages. In dual screen mode when
translations are turned off (i.e. 2 mushaf pages), the last page was not
appearing due to it being out of bounds. This patch allows the last page
to be empty.
