### PR TITLE
Do not crash when building without Firebase

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -169,7 +169,6 @@ dependencies {
   implementation "dev.chrisbanes.insetter:insetter:0.6.1"
   implementation 'com.jakewharton.timber:timber:5.0.1'
   debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.10'
-  implementation 'com.google.firebase:firebase-crashlytics:18.3.6'
 
   testImplementation "junit:junit:${junitVersion}"
   testImplementation "com.google.truth:truth:${truthVersion}"

--- a/app/src/main/java/com/quran/labs/androidquran/util/RecordingLogTree.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/util/RecordingLogTree.kt
@@ -1,9 +1,8 @@
 package com.quran.labs.androidquran.util
 
 import android.util.Log
-import com.google.firebase.crashlytics.FirebaseCrashlytics
+import com.quran.analytics.provider.SystemCrashReporter
 import timber.log.Timber
-import java.lang.StringBuilder
 import java.util.ArrayDeque
 import java.util.Deque
 
@@ -30,7 +29,7 @@ class RecordingLogTree : Timber.Tree() {
     }
   }
 
-  private val crashlytics = FirebaseCrashlytics.getInstance()
+  private val crashlytics = SystemCrashReporter.crashReporter()
 
   // Adding one to the initial size accounts for the add before remove.
   private val buffer: Deque<String> = ArrayDeque(BUFFER_SIZE + 1)

--- a/common/analytics/src/main/java/com/quran/analytics/CrashReporter.kt
+++ b/common/analytics/src/main/java/com/quran/analytics/CrashReporter.kt
@@ -1,0 +1,6 @@
+package com.quran.analytics
+
+interface CrashReporter {
+  fun log(message: String)
+  fun recordException(throwable: Throwable)
+}

--- a/feature/analytics-noop/src/main/java/com/quran/analytics/provider/AnalyticsModule.kt
+++ b/feature/analytics-noop/src/main/java/com/quran/analytics/provider/AnalyticsModule.kt
@@ -1,11 +1,14 @@
 package com.quran.analytics.provider
 
 import com.quran.analytics.AnalyticsProvider
+import com.quran.analytics.CrashReporter
 import dagger.Binds
 import dagger.Module
 
 @Module
 interface AnalyticsModule {
+  @Binds
+  fun provideCrashReporter(noopCrashReporter: NoopCrashReporter): CrashReporter
 
   @Binds
   fun provideAnalyticsProvider(noopAnalyticsProvider: NoopAnalyticsProvider): AnalyticsProvider

--- a/feature/analytics-noop/src/main/java/com/quran/analytics/provider/NoopCrashReporter.kt
+++ b/feature/analytics-noop/src/main/java/com/quran/analytics/provider/NoopCrashReporter.kt
@@ -1,0 +1,12 @@
+package com.quran.analytics.provider
+
+import com.quran.analytics.CrashReporter
+import javax.inject.Inject
+
+class NoopCrashReporter @Inject constructor() : CrashReporter {
+  override fun log(message: String) {
+  }
+
+  override fun recordException(throwable: Throwable) {
+  }
+}

--- a/feature/analytics-noop/src/main/java/com/quran/analytics/provider/SystemCrashReporter.kt
+++ b/feature/analytics-noop/src/main/java/com/quran/analytics/provider/SystemCrashReporter.kt
@@ -1,0 +1,9 @@
+package com.quran.analytics.provider
+
+import com.quran.analytics.CrashReporter
+
+object SystemCrashReporter {
+  private val noopCrashReporter by lazy { NoopCrashReporter() }
+
+  fun crashReporter(): CrashReporter = noopCrashReporter
+}


### PR DESCRIPTION
The Gradle flag for disabling Firebase was causing a crash due to us
explicitly depending on Firebase for Crashlytics in app. This patch
fixes it by making it behind our own CrashReporter interface and
returning the real one if we're building with Firebase, or the noop one
otherwise.
