### PR TITLE
Allow removing a certain page from bookmarks

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/database/BookmarksDaoImpl.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/database/BookmarksDaoImpl.kt
@@ -23,6 +23,12 @@ class BookmarksDaoImpl @Inject constructor(
     }
   }
 
+  override suspend fun removeBookmarksForPage(page: Int) {
+    withContext(Dispatchers.IO) {
+      bookmarksDBAdapter.removeBookmarksForPage(page)
+    }
+  }
+
   override suspend fun recentPages(): List<RecentPage> {
     return withContext(Dispatchers.IO) {
       bookmarksDBAdapter.getRecentPages()
@@ -38,6 +44,12 @@ class BookmarksDaoImpl @Inject constructor(
   override suspend fun removeRecentPages() {
     withContext(Dispatchers.IO) {
       bookmarksDBAdapter.removeRecentPages()
+    }
+  }
+
+  override suspend fun removeRecentsForPage(page: Int) {
+    withContext(Dispatchers.IO) {
+      bookmarksDBAdapter.removeRecentsForPage(page)
     }
   }
 }

--- a/common/data/src/main/java/com/quran/data/dao/BookmarksDao.kt
+++ b/common/data/src/main/java/com/quran/data/dao/BookmarksDao.kt
@@ -6,9 +6,11 @@ import com.quran.data.model.bookmark.RecentPage
 interface BookmarksDao {
   suspend fun bookmarks(): List<Bookmark>
   suspend fun replaceBookmarks(bookmarks: List<Bookmark>)
+  suspend fun removeBookmarksForPage(page: Int)
 
   // recent pages
   suspend fun recentPages(): List<RecentPage>
   suspend fun removeRecentPages()
   suspend fun replaceRecentPages(pages: List<RecentPage>)
+  suspend fun removeRecentsForPage(page: Int)
 }


### PR DESCRIPTION
In some cases, when we swap out pages, we might get rid of extra pages
that are no longer there. This allows removing bookmarks for such pages.
This is really meant for pages like 612 (the du3a page) in Naskh, in
preparation for replacing this set with the King Fahd images, which do
not have this page.
