### PR TITLE
Support recursively copying from assets

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/util/QuranFileUtils.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/util/QuranFileUtils.kt
@@ -250,6 +250,30 @@ class QuranFileUtils @Inject constructor(
     copyFromAssets(assetsPath, filename, actualDestination)
   }
 
+  override fun copyFromAssetsRelativeRecursive(
+    assetsPath: String,
+    directory: String,
+    destination: String
+  ) {
+    val destinationPath = File(getQuranBaseDirectory(appContext) + destination)
+    val directoryDestinationPath = File(destinationPath, directory)
+    if (!directoryDestinationPath.exists()) {
+      directoryDestinationPath.mkdirs()
+    }
+
+    val assets = appContext.assets
+    val files = assets.list(assetsPath) ?: emptyArray()
+    val destinationDirectory = "$destination${File.separator}$directory"
+    files.forEach {
+      val path = "$assetsPath${File.separator}$it"
+      if (assets.list(path)?.isNotEmpty() == true) {
+        copyFromAssetsRelativeRecursive(path, it, destinationDirectory)
+      } else {
+        copyFromAssetsRelative(path, it, destinationDirectory)
+      }
+    }
+  }
+
   @WorkerThread
   override fun removeOldArabicDatabase(): Boolean {
     val databaseQuranArabicDatabase = File(

--- a/app/src/main/java/com/quran/labs/androidquran/util/ZipUtils.java
+++ b/app/src/main/java/com/quran/labs/androidquran/util/ZipUtils.java
@@ -15,7 +15,7 @@ import timber.log.Timber;
 public class ZipUtils {
 
   private static final int BUFFER_SIZE = 512;
-  private static final int MAX_FILES = 10000; // Max number of files
+  private static final int MAX_FILES = 12000; // Max number of files
 
   @VisibleForTesting
   static int MAX_UNZIPPED_SIZE = 0x1f400000; // Max size of unzipped data, 500MB

--- a/common/data/src/main/java/com/quran/data/core/QuranFileManager.kt
+++ b/common/data/src/main/java/com/quran/data/core/QuranFileManager.kt
@@ -17,6 +17,9 @@ interface QuranFileManager {
   fun copyFromAssetsRelative(assetsPath: String, filename: String, destination: String)
 
   @WorkerThread
+  fun copyFromAssetsRelativeRecursive(assetsPath: String, directory: String, destination: String)
+
+  @WorkerThread
   fun removeOldArabicDatabase(): Boolean
 
   @WorkerThread


### PR DESCRIPTION
In order to support bundled line by line images, support recursively
copying data from assets, and increase the limit on the number of files.
