### PR TITLE
Support skipping introductory pages

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/ui/fragment/QuranPageFragment.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/fragment/QuranPageFragment.java
@@ -97,7 +97,7 @@ public class QuranPageFragment extends Fragment implements PageController,
                            Bundle savedInstanceState) {
     final Context context = requireContext();
     quranPageLayout = new QuranImagePageLayout(context);
-    quranPageLayout.setPageController(this, pageNumber);
+    quranPageLayout.setPageController(this, pageNumber, quranInfo.getSkip());
     imageView = quranPageLayout.getImageView();
     return quranPageLayout;
   }

--- a/app/src/main/java/com/quran/labs/androidquran/ui/fragment/TabletFragment.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/fragment/TabletFragment.java
@@ -136,7 +136,7 @@ public class TabletFragment extends Fragment
         leftImageView = ((QuranImagePageLayout) mainView.getLeftPage()).getImageView();
         rightImageView = ((QuranImagePageLayout) mainView.getRightPage()).getImageView();
       }
-      mainView.setPageController(this, pageNumber, pageNumber - 1);
+      mainView.setPageController(this, pageNumber, pageNumber - 1, quranInfo.getSkip());
     } else if (mode == Mode.TRANSLATION) {
       if (!isSplitScreen) {
         mainView.init(TabletView.TRANSLATION_PAGE, TabletView.TRANSLATION_PAGE, pageViewFactory, pageNumber, pageNumber - 1);
@@ -148,7 +148,7 @@ public class TabletFragment extends Fragment
         PagerActivity pagerActivity = (PagerActivity) context;
         leftTranslation.setTranslationClickedListener(v -> pagerActivity.toggleActionBar());
         rightTranslation.setTranslationClickedListener(v -> pagerActivity.toggleActionBar());
-        mainView.setPageController(this, pageNumber, pageNumber - 1);
+        mainView.setPageController(this, pageNumber, pageNumber - 1, quranInfo.getSkip());
       } else {
         initSplitMode();
       }
@@ -157,7 +157,8 @@ public class TabletFragment extends Fragment
   }
 
   private void initSplitMode() {
-    isQuranOnRight = pageNumber % 2 == 1;
+    final int skip = quranInfo.getSkip();
+    isQuranOnRight = (pageNumber + skip) % 2 == 1;
 
     final int leftPageType = isQuranOnRight ? TabletView.TRANSLATION_PAGE : TabletView.QURAN_PAGE;
     final int rightPageType = isQuranOnRight ? TabletView.QURAN_PAGE : TabletView.TRANSLATION_PAGE;
@@ -186,7 +187,7 @@ public class TabletFragment extends Fragment
 
     PagerActivity pagerActivity = (PagerActivity) getActivity();
     splitTranslationView.setTranslationClickedListener(v -> pagerActivity.toggleActionBar());
-    mainView.setPageController(this, pageNumber);
+    mainView.setPageController(this, pageNumber, quranInfo.getSkip());
   }
 
   @Override

--- a/app/src/main/java/com/quran/labs/androidquran/ui/fragment/TranslationFragment.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/fragment/TranslationFragment.java
@@ -81,7 +81,7 @@ public class TranslationFragment extends Fragment implements
                            ViewGroup container, Bundle savedInstanceState) {
     Context context = getActivity();
     mainView = new QuranTranslationPageLayout(context);
-    mainView.setPageController(this, pageNumber);
+    mainView.setPageController(this, pageNumber, quranInfo.getSkip());
 
     translationView = mainView.getTranslationView();
     translationView.setTranslationClickedListener(v -> {

--- a/app/src/main/java/com/quran/labs/androidquran/ui/helpers/QuranPageAdapter.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/helpers/QuranPageAdapter.kt
@@ -21,7 +21,7 @@ class QuranPageAdapter(
   private val pageViewFactory: PageViewFactory? = null
 ) : FragmentStatePagerAdapter(fm, if (isDualPages) "dualPages" else "singlePage") {
   private var pageMode: PageMode = makePageMode()
-  private val totalPages: Int = quranInfo.numberOfPages
+  private val totalPages: Int = quranInfo.numberOfPagesConsideringSkipped
   private val totalPagesDual: Int = totalPages / 2 + (totalPages % 2)
 
   fun setTranslationMode() {

--- a/app/src/main/java/com/quran/labs/androidquran/util/QuranPageInfoImpl.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/util/QuranPageInfoImpl.kt
@@ -6,7 +6,7 @@ import com.quran.data.core.QuranPageInfo
 import com.quran.labs.androidquran.data.QuranDisplayData
 import com.quran.labs.androidquran.ui.helpers.QuranDisplayHelper
 
-class QuranPageInfoImpl constructor(
+class QuranPageInfoImpl(
   private val context: Context,
   private val quranInfo: QuranInfo,
   private val quranDisplayData: QuranDisplayData
@@ -35,4 +35,6 @@ class QuranPageInfoImpl constructor(
   override fun manzilForPage(page: Int): String {
     return quranDisplayData.getManzilForPage(context, page)
   }
+
+  override fun skippedPagesCount(): Int = quranInfo.skip
 }

--- a/app/src/main/java/com/quran/labs/androidquran/view/QuranImagePageLayout.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/view/QuranImagePageLayout.kt
@@ -36,8 +36,8 @@ open class QuranImagePageLayout(context: Context) : QuranPageLayout(context) {
     imageView.setNightMode(quranSettings.isNightMode, quranSettings.nightModeTextBrightness, quranSettings.nightModeBackgroundBrightness)
   }
 
-  override fun setPageController(controller: PageController?, pageNumber: Int) {
-    super.setPageController(controller, pageNumber)
+  override fun setPageController(controller: PageController?, pageNumber: Int, skips: Int) {
+    super.setPageController(controller, pageNumber, skips)
     val gestureDetector = GestureDetector(context, PageGestureDetector())
     val gestureListener = OnTouchListener { _, event ->
       gestureDetector.onTouchEvent(event)

--- a/app/src/main/java/com/quran/labs/androidquran/view/QuranPageLayout.java
+++ b/app/src/main/java/com/quran/labs/androidquran/view/QuranPageLayout.java
@@ -66,6 +66,7 @@ public abstract class QuranPageLayout extends QuranPageWrapperLayout
   protected int pageNumber;
   protected boolean shouldHideLine;
   protected boolean isFullWidth;
+  private int skippedPages;
 
   private ObservableScrollView scrollView;
   private @BorderMode int leftBorder;
@@ -205,9 +206,10 @@ public abstract class QuranPageLayout extends QuranPageWrapperLayout
     return scrollView != null ? scrollView : innerView;
   }
 
-  public void setPageController(PageController controller, int pageNumber) {
+  public void setPageController(PageController controller, int pageNumber, int skippedPages) {
     this.pageNumber = pageNumber;
     this.pageController = controller;
+    this.skippedPages = skippedPages;
   }
 
   protected int getPagesVisible() {
@@ -239,7 +241,7 @@ public abstract class QuranPageLayout extends QuranPageWrapperLayout
       lineColor = Color.argb(nightModeTextBrightness, 255, 255, 255);
     }
 
-    if (pageNumber % 2 == 0) {
+    if ((pageNumber + skippedPages) % 2 == 0) {
       leftBorder = nightMode ? BorderMode.DARK : BorderMode.LIGHT;
       rightBorder = BorderMode.HIDDEN;
     } else {

--- a/app/src/main/java/com/quran/labs/androidquran/view/QuranTranslationPageLayout.java
+++ b/app/src/main/java/com/quran/labs/androidquran/view/QuranTranslationPageLayout.java
@@ -26,8 +26,8 @@ public class QuranTranslationPageLayout extends QuranPageLayout {
   }
 
   @Override
-  public void setPageController(PageController controller, int pageNumber) {
-    super.setPageController(controller, pageNumber);
+  public void setPageController(PageController controller, int pageNumber, int skips) {
+    super.setPageController(controller, pageNumber, skips);
     translationView.setPageController(controller);
   }
 

--- a/app/src/main/java/com/quran/labs/androidquran/view/TabletView.java
+++ b/app/src/main/java/com/quran/labs/androidquran/view/TabletView.java
@@ -83,17 +83,17 @@ public class TabletView extends QuranPageWrapperLayout {
     }
   }
 
-  public void setPageController(PageController controller, int leftPage, int rightPage) {
+  public void setPageController(PageController controller, int leftPage, int rightPage, int skips) {
     this.pageController = controller;
-    this.leftPage.setPageController(controller, leftPage);
-    this.rightPage.setPageController(controller, rightPage);
+    this.leftPage.setPageController(controller, leftPage, skips);
+    this.rightPage.setPageController(controller, rightPage, skips);
   }
 
-  public void setPageController(PageController controller, int pageNumber) {
+  public void setPageController(PageController controller, int pageNumber, int skips) {
     this.pageController = controller;
 
-    this.rightPage.setPageController(controller, pageNumber);
-    this.leftPage.setPageController(controller, pageNumber);
+    this.rightPage.setPageController(controller, pageNumber, skips);
+    this.leftPage.setPageController(controller, pageNumber, skips);
   }
 
   @Override

--- a/app/src/test/java/com/quran/data/core/QuranInfoTest.kt
+++ b/app/src/test/java/com/quran/data/core/QuranInfoTest.kt
@@ -59,4 +59,54 @@ class QuranInfoTest {
     assertThat(quranInfo.getJuzForDisplayFromPage(201)).isEqualTo(10)
     assertThat(quranInfo.getJuzFromPage(201)).isEqualTo(11)
   }
+
+  @Test
+  fun testMapSinglePageToDualPage() {
+    val quranInfo = QuranInfo(MadaniDataSource())
+    assertThat(quranInfo.mapSinglePageToDualPage(1)).isEqualTo(2)
+    assertThat(quranInfo.mapSinglePageToDualPage(2)).isEqualTo(2)
+    assertThat(quranInfo.mapSinglePageToDualPage(3)).isEqualTo(4)
+    assertThat(quranInfo.mapSinglePageToDualPage(4)).isEqualTo(4)
+
+    // skipping a single page (ex naskh), so the first page is 2
+    val quranInfoThatSkips = QuranInfo(SkippingDataSource())
+    assertThat(quranInfoThatSkips.mapSinglePageToDualPage(2)).isEqualTo(3)
+    assertThat(quranInfoThatSkips.mapSinglePageToDualPage(3)).isEqualTo(3)
+    assertThat(quranInfoThatSkips.mapSinglePageToDualPage(4)).isEqualTo(5)
+    assertThat(quranInfoThatSkips.mapSinglePageToDualPage(5)).isEqualTo(5)
+
+    // hypothetical example where we skip 2 pages, so the first page is 3
+    val quranInfoThatSkipsExtra = QuranInfo(SkippingDataSource(2))
+    assertThat(quranInfoThatSkipsExtra.mapSinglePageToDualPage(3)).isEqualTo(4)
+    assertThat(quranInfoThatSkipsExtra.mapSinglePageToDualPage(4)).isEqualTo(4)
+    assertThat(quranInfoThatSkipsExtra.mapSinglePageToDualPage(5)).isEqualTo(6)
+    assertThat(quranInfoThatSkipsExtra.mapSinglePageToDualPage(6)).isEqualTo(6)
+  }
+
+  @Test
+  fun testMapDualPageToSinglePage() {
+    val quranInfo = QuranInfo(MadaniDataSource())
+    assertThat(quranInfo.mapDualPageToSinglePage(1)).isEqualTo(1)
+    assertThat(quranInfo.mapDualPageToSinglePage(2)).isEqualTo(1)
+    assertThat(quranInfo.mapDualPageToSinglePage(3)).isEqualTo(3)
+    assertThat(quranInfo.mapDualPageToSinglePage(4)).isEqualTo(3)
+
+    // skipping a single page (ex naskh), so the first page is 2
+    val quranInfoThatSkips = QuranInfo(SkippingDataSource())
+    assertThat(quranInfoThatSkips.mapDualPageToSinglePage(2)).isEqualTo(2)
+    assertThat(quranInfoThatSkips.mapDualPageToSinglePage(3)).isEqualTo(2)
+    assertThat(quranInfoThatSkips.mapDualPageToSinglePage(4)).isEqualTo(4)
+    assertThat(quranInfoThatSkips.mapDualPageToSinglePage(5)).isEqualTo(4)
+
+    // hypothetical example where we skip 2 pages, so the first page is 3
+    val quranInfoThatSkipsExtra = QuranInfo(SkippingDataSource(2))
+    assertThat(quranInfoThatSkipsExtra.mapDualPageToSinglePage(3)).isEqualTo(3)
+    assertThat(quranInfoThatSkipsExtra.mapDualPageToSinglePage(4)).isEqualTo(3)
+    assertThat(quranInfoThatSkipsExtra.mapDualPageToSinglePage(5)).isEqualTo(5)
+    assertThat(quranInfoThatSkipsExtra.mapDualPageToSinglePage(6)).isEqualTo(5)
+  }
+
+  private class SkippingDataSource(skipCount: Int = 1) : MadaniDataSource() {
+    override val pagesToSkip: Int = skipCount
+  }
 }

--- a/common/data/src/main/java/com/quran/data/core/QuranInfo.kt
+++ b/common/data/src/main/java/com/quran/data/core/QuranInfo.kt
@@ -23,8 +23,12 @@ class QuranInfo @Inject constructor(quranDataSource: QuranDataSource) {
   private val manazil = quranDataSource.manzilPageArray
   val quarters = quranDataSource.quartersArray
 
+  val skip = quranDataSource.pagesToSkip
+  private val firstPage = PAGES_FIRST + skip
+
   val numberOfPages = quranDataSource.numberOfPages
-  private val numberOfPagesDual = numberOfPages / 2 + numberOfPages % 2
+  val numberOfPagesConsideringSkipped = numberOfPages - skip
+  private val numberOfPagesDual = numberOfPagesConsideringSkipped / 2 + numberOfPagesConsideringSkipped % 2
 
   fun getStartingPageForJuz(juz: Int): Int {
     return juzPageStart[juz - 1]
@@ -44,7 +48,7 @@ class QuranInfo @Inject constructor(quranDataSource: QuranDataSource) {
   }
 
   fun isValidPage(page: Int): Boolean {
-    return page in PAGES_FIRST..numberOfPages
+    return page in firstPage..numberOfPages
   }
 
   fun getSuraNumberFromPage(page: Int): Int {
@@ -88,7 +92,7 @@ class QuranInfo @Inject constructor(quranDataSource: QuranDataSource) {
     val page =
       when {
         inputPage > numberOfPages -> numberOfPages
-        inputPage < 1 -> 1
+        inputPage < firstPage -> firstPage
         else -> inputPage
       }
 
@@ -188,9 +192,9 @@ class QuranInfo @Inject constructor(quranDataSource: QuranDataSource) {
     isDualPagesVisible: Boolean
   ): Int {
     return if (isDualPagesVisible) {
-      (numberOfPagesDual - position) * 2
+      ((numberOfPagesDual - position) * 2) + skip
     } else {
-      numberOfPages - position
+      (numberOfPagesConsideringSkipped - position) + skip
     }
   }
 
@@ -200,9 +204,32 @@ class QuranInfo @Inject constructor(quranDataSource: QuranDataSource) {
   ): Int {
     return if (isDualPagesVisible) {
       val pageToUse = if (page % 2 != 0) { page + 1 } else { page }
-      numberOfPagesDual - pageToUse / 2
+      val delta = if (page % 2 != 0) { skip } else 0
+      numberOfPagesDual - pageToUse / 2 + delta
     } else {
-      numberOfPages - page
+      (numberOfPagesConsideringSkipped - page) + skip
+    }
+  }
+
+  fun mapDualPageToSinglePage(page: Int): Int {
+    // selects the "first" page when mapping this dual page to a single page
+    // i.e. maps "left | right" => "right" (i.e. to first landscape page)
+    val amount = skip % 2
+    return if (page % 2 == amount) {
+      page - 1
+    } else {
+      page
+    }
+  }
+
+  fun mapSinglePageToDualPage(page: Int): Int {
+    // selects the "second" page when viewing this page by another
+    // i.e. "left | right" => "left" irrespective of which is chosen, left/right
+    val amount = skip % 2
+    return if (page % 2 != amount) {
+      page + 1
+    } else {
+      page
     }
   }
 

--- a/common/data/src/main/java/com/quran/data/core/QuranPageInfo.kt
+++ b/common/data/src/main/java/com/quran/data/core/QuranPageInfo.kt
@@ -7,4 +7,5 @@ interface QuranPageInfo {
   fun localizedPage(page: Int): String
   fun pageForSuraAyah(sura: Int, ayah: Int): Int
   fun manzilForPage(page: Int): String
+  fun skippedPagesCount(): Int
 }

--- a/common/data/src/main/java/com/quran/data/pageinfo/common/MadaniDataSource.kt
+++ b/common/data/src/main/java/com/quran/data/pageinfo/common/MadaniDataSource.kt
@@ -228,4 +228,5 @@ open class MadaniDataSource : QuranDataSource {
 
   override val manzilPageArray: Array<Int> = emptyArray()
   override val haveSidelines: Boolean = false
+  override val pagesToSkip: Int = 0
 }

--- a/common/data/src/main/java/com/quran/data/source/QuranDataSource.kt
+++ b/common/data/src/main/java/com/quran/data/source/QuranDataSource.kt
@@ -15,4 +15,5 @@ interface QuranDataSource {
   val quartersArray: Array<SuraAyah>
   val manzilPageArray: Array<Int>
   val haveSidelines: Boolean
+  val pagesToSkip: Int
 }


### PR DESCRIPTION
This is mostly added to support Naskh, where the first page is page 2,
but it is still on the right side. By setting skip to 1 here, we make
the first page (on the right), set to page 2.
