### PR TITLE
Minor clean up to build scripts

### DIFF
--- a/build-logic/convention/src/main/kotlin/AndroidLibraryComposeConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidLibraryComposeConventionPlugin.kt
@@ -18,7 +18,6 @@ class AndroidLibraryComposeConventionPlugin : Plugin<Project> {
 
       extensions.configure<LibraryExtension> {
         applyAndroidCommon(target)
-        defaultConfig.targetSdk = 32
         buildFeatures.compose = true
         composeOptions.kotlinCompilerExtensionVersion = "1.5.0-dev-k1.9.0-6a60475e07f"
       }

--- a/build-logic/convention/src/main/kotlin/AndroidLibraryConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidLibraryConventionPlugin.kt
@@ -17,7 +17,6 @@ class AndroidLibraryConventionPlugin : Plugin<Project> {
 
       extensions.configure<LibraryExtension> {
         applyAndroidCommon(target)
-        defaultConfig.targetSdk = 32
       }
 
       applyKotlinCommon()

--- a/build.gradle
+++ b/build.gradle
@@ -33,13 +33,6 @@ buildscript {
     androidxJunitExtVersion = '1.1.5'
 
     deps = [
-        android: [
-            build: [
-                minSdkVersion    : 21,
-                targetSdkVersion : 32,
-                compileSdkVersion: 33
-            ]
-        ],
         dagger: [
             apt: "com.google.dagger:dagger-compiler:${daggerVersion}",
             runtime: "com.google.dagger:dagger:${daggerVersion}"


### PR DESCRIPTION
Android libraries no longer need a target sdk, since that really only
makes sense on applications.
