### PR TITLE
Allow setting a default qari id for each page type

### DIFF
--- a/common/audio/src/main/java/com/quran/labs/androidquran/common/audio/repository/CurrentQariManager.kt
+++ b/common/audio/src/main/java/com/quran/labs/androidquran/common/audio/repository/CurrentQariManager.kt
@@ -13,11 +13,14 @@ import kotlinx.coroutines.flow.map
 @Singleton
 class CurrentQariManager @Inject constructor(appContext: Context, private val qariUtil: QariUtil) {
   private val prefs = PreferenceManager.getDefaultSharedPreferences(appContext)
-  private val currentQariFlow = MutableStateFlow(prefs.getInt(PREF_DEFAULT_QARI, 0))
+  private val currentQariFlow =
+    MutableStateFlow(prefs.getInt(PREF_DEFAULT_QARI, qariUtil.getDefaultQariId()))
   private val qaris by lazy { qariUtil.getQariList() }
 
   fun flow(): Flow<Qari> = currentQariFlow
     .map { qariId -> qaris.firstOrNull { it.id == qariId } ?: qaris.first() }
+
+  fun currentQariId(): Int = currentQariFlow.value
 
   fun setCurrentQari(qariId: Int) {
     prefs.edit().putInt(PREF_DEFAULT_QARI, qariId).apply()

--- a/common/audio/src/main/java/com/quran/labs/androidquran/common/audio/util/QariUtil.kt
+++ b/common/audio/src/main/java/com/quran/labs/androidquran/common/audio/util/QariUtil.kt
@@ -19,6 +19,13 @@ class QariUtil @Inject constructor(private val pageProvider: PageProvider) {
   }
 
   /**
+   * Get the default qari id when no qari is selected.
+    */
+  fun getDefaultQariId(): Int {
+    return pageProvider.getDefaultQariId()
+  }
+
+  /**
    * Get a list of all available qaris as [QariItem]s
    *
    * @param context the current context

--- a/common/data/src/main/java/com/quran/data/source/PageProvider.kt
+++ b/common/data/src/main/java/com/quran/data/source/PageProvider.kt
@@ -29,5 +29,6 @@ interface PageProvider {
   fun getPageContentType(): PageContentType = PageContentType.Image
   fun getFallbackPageType(): String? = null
   fun getQaris(): List<Qari>
+  fun getDefaultQariId(): Int
   fun pageType(): String = ""
 }

--- a/pages/madani/src/main/java/com/quran/data/page/provider/madani/MadaniPageProvider.kt
+++ b/pages/madani/src/main/java/com/quran/data/page/provider/madani/MadaniPageProvider.kt
@@ -42,6 +42,8 @@ class MadaniPageProvider : PageProvider {
 
   override fun getPreviewDescription() = R.string.madani_description
 
+  override fun getDefaultQariId(): Int = 0
+
   override fun getQaris(): List<Qari> {
     return listOf(
       Qari(


### PR DESCRIPTION
Currently, all qaris default to qari id 0. This makes sense for all the
Hafs masa7if, where sheikh Minshawi has qari id 0. For other qira'at,
however, this might not be the best default. This allows us to set it
per page type. Fixes #2414.
