### PR TITLE
Add a preference for drawing a pre-line divider

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/data/Constants.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/data/Constants.kt
@@ -99,4 +99,5 @@ object Constants {
   const val PREF_CURRENT_AUDIO_REVISION = "currentAudioRevision"
   const val PREF_SURA_TRANSLATED_NAME = "suraTranslatedName"
   const val PREF_SHOW_SIDELINES = "showSidelines"
+  const val PREF_SHOW_LINE_DIVIDERS = "showLineDividers"
 }

--- a/app/src/main/java/com/quran/labs/androidquran/util/QuranSettings.java
+++ b/app/src/main/java/com/quran/labs/androidquran/util/QuranSettings.java
@@ -162,8 +162,14 @@ public class QuranSettings {
     return prefs.getString(Constants.PREF_PAGE_TYPE, null);
   }
 
+  // only available for Naskh, should return false by default for non-Naskh pages
   public boolean isSidelines() {
     return prefs.getBoolean(Constants.PREF_SHOW_SIDELINES, false);
+  }
+
+  // only available for Naskh, should return false by default for non-Naskh pages
+  public boolean showLineDividers() {
+    return prefs.getBoolean(Constants.PREF_SHOW_LINE_DIVIDERS, false);
   }
 
   public void setPageType(String pageType) {

--- a/app/src/main/java/com/quran/labs/androidquran/util/SettingsImpl.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/util/SettingsImpl.kt
@@ -69,5 +69,9 @@ class SettingsImpl @Inject constructor(private val quranSettings: QuranSettings)
     return quranSettings.isSidelines
   }
 
+  override suspend fun showLineDividers(): Boolean {
+    return quranSettings.showLineDividers()
+  }
+
   override fun preferencesFlow(): Flow<String> = preferencesFlow
 }

--- a/common/data/src/main/java/com/quran/data/dao/Settings.kt
+++ b/common/data/src/main/java/com/quran/data/dao/Settings.kt
@@ -14,6 +14,7 @@ interface Settings {
   suspend fun shouldShowBookmarks(): Boolean
   suspend fun pageType(): String
   suspend fun showSidelines(): Boolean
+  suspend fun showLineDividers(): Boolean
 
   fun preferencesFlow(): Flow<String>
 }

--- a/common/preference/src/main/res/values/preferences_keys.xml
+++ b/common/preference/src/main/res/values/preferences_keys.xml
@@ -2,4 +2,5 @@
 <resources>
   <string translatable="false" name="prefs_reading_category_key">readingCategoryKey</string>
   <string translatable="false" name="prefs_show_sidelines">showSidelines</string>
+  <string translatable="false" name="prefs_show_line_dividers">showLineDividers</string>
 </resources>


### PR DESCRIPTION
Add a setting to allow drawing a line before each line of the Quran
text. This is mostly used for Naskh.
