### PR TITLE
Use ksp for Moshi and avoid kapt for Dagger

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,9 +1,10 @@
 plugins {
-  id 'quran.android.application'
+  id "quran.android.application"
   id 'org.jetbrains.kotlin.kapt'
   id 'org.jetbrains.kotlin.plugin.parcelize'
-  id 'net.ltgt.errorprone'
-  id 'com.squareup.anvil'
+  alias libs.plugins.ksp
+  alias libs.plugins.errorprone
+  alias libs.plugins.anvil
 }
 
 if (getGradle().getStartParameter().getTaskRequests().toString().contains("Release") &&
@@ -160,7 +161,7 @@ dependencies {
   implementation libs.okhttp
 
   implementation libs.moshi
-  kapt(libs.moshi.codegen)
+  ksp(libs.moshi.codegen)
 
   implementation libs.insetter
   implementation libs.timber

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
   alias(libs.plugins.android.library) apply false
   alias(libs.plugins.crashlytics) apply false
   alias(libs.plugins.kotlin.android) apply false
+  alias(libs.plugins.ksp) apply false
   alias(libs.plugins.errorprone) apply false
   alias(libs.plugins.google.services) apply false
   alias(libs.plugins.sqldelight) apply false

--- a/common/analytics/build.gradle
+++ b/common/analytics/build.gradle
@@ -1,12 +1,13 @@
 plugins {
   id 'quran.android.library'
-  id 'org.jetbrains.kotlin.kapt'
+  alias libs.plugins.anvil
 }
+
+anvil { generateDaggerFactories = true }
 
 dependencies {
   implementation libs.androidx.annotation
 
   // dagger
-  kapt libs.dagger.compiler
   implementation libs.dagger.runtime
 }

--- a/common/data/build.gradle
+++ b/common/data/build.gradle
@@ -1,7 +1,10 @@
 plugins {
   id 'quran.android.library'
-  id 'org.jetbrains.kotlin.kapt'
+  alias libs.plugins.anvil
+  alias libs.plugins.ksp
 }
+
+anvil { generateDaggerFactories = true }
 
 dependencies {
   implementation libs.androidx.annotation
@@ -10,9 +13,8 @@ dependencies {
   implementation libs.kotlinx.coroutines.android
 
   // dagger
-  kapt libs.dagger.compiler
   implementation libs.dagger.runtime
 
   implementation libs.moshi
-  kapt(libs.moshi.codegen)
+  ksp(libs.moshi.codegen)
 }

--- a/common/networking/build.gradle
+++ b/common/networking/build.gradle
@@ -1,10 +1,11 @@
 plugins {
   id 'quran.android.library'
-  id 'org.jetbrains.kotlin.kapt'
+  alias libs.plugins.anvil
 }
 
+anvil { generateDaggerFactories = true }
+
 dependencies {
-  kapt libs.dagger.compiler
   implementation libs.dagger.runtime
 
   implementation libs.dnsjava

--- a/common/pages/build.gradle
+++ b/common/pages/build.gradle
@@ -1,7 +1,9 @@
 plugins {
   id 'quran.android.library.android'
-  id 'org.jetbrains.kotlin.kapt'
+  alias libs.plugins.anvil
 }
+
+anvil { generateDaggerFactories = true }
 
 android.namespace 'com.quran.labs.androidquran.common.pages'
 
@@ -9,6 +11,5 @@ dependencies {
   implementation project(path: ':common:data')
   implementation libs.androidx.fragment.ktx
 
-  kapt libs.dagger.compiler
   implementation libs.dagger.runtime
 }

--- a/common/search/build.gradle
+++ b/common/search/build.gradle
@@ -1,6 +1,5 @@
 plugins {
   id 'quran.android.library.android'
-  id 'org.jetbrains.kotlin.kapt'
 }
 
 android.namespace 'com.quran.labs.androidquran.common.search'

--- a/common/upgrade/build.gradle
+++ b/common/upgrade/build.gradle
@@ -1,14 +1,15 @@
 plugins {
   id 'quran.android.library.android'
-  id 'org.jetbrains.kotlin.kapt'
+  alias libs.plugins.anvil
 }
+
+anvil { generateDaggerFactories = true }
 
 android.namespace 'com.quran.labs.androidquran.common.upgrade'
 
 dependencies {
   implementation project(":common:data")
 
-  kapt libs.dagger.compiler
   implementation libs.dagger.runtime
 
   implementation libs.androidx.annotation

--- a/feature/analytics-noop/build.gradle
+++ b/feature/analytics-noop/build.gradle
@@ -1,13 +1,14 @@
 plugins {
   id 'quran.android.library'
-  id 'org.jetbrains.kotlin.kapt'
+  alias libs.plugins.anvil
 }
+
+anvil { generateDaggerFactories = true }
 
 dependencies {
   implementation project(":common:analytics")
   implementation libs.androidx.annotation
 
   // dagger
-  kapt libs.dagger.compiler
   implementation libs.dagger.runtime
 }

--- a/feature/audio/build.gradle
+++ b/feature/audio/build.gradle
@@ -1,6 +1,6 @@
 plugins {
   id 'quran.android.library.android'
-  id 'org.jetbrains.kotlin.kapt'
+  alias libs.plugins.ksp
 }
 
 android {
@@ -27,7 +27,7 @@ dependencies {
   implementation libs.okio
 
   implementation libs.moshi
-  kapt(libs.moshi.codegen)
+  ksp(libs.moshi.codegen)
 
   implementation libs.retrofit
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,7 @@
 [versions]
 agp = "8.1.2"
 kotlin = "1.9.10"
+ksp = "1.9.10-1.0.13"
 
 anvil = "2.4.8"
 coroutinesVersion = "1.7.3"
@@ -162,6 +163,7 @@ truth = { module = "com.google.truth:truth", version.ref = "truthVersion" }
 android-application = { id = "com.android.application", version.ref = "agp" }
 android-library = { id = "com.android.library", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 sqldelight = { id = "app.cash.sqldelight", version.ref = "sqldelight" }
 anvil = { id = "com.squareup.anvil", version.ref = "anvil"}
 crashlytics = { id = "com.google.firebase.crashlytics", version.ref = "crashlytics" }

--- a/pages/madani/build.gradle
+++ b/pages/madani/build.gradle
@@ -1,7 +1,9 @@
 plugins {
   id 'quran.android.library.android'
-  id 'org.jetbrains.kotlin.kapt'
+  alias libs.plugins.anvil
 }
+
+anvil { generateDaggerFactories = true }
 
 android.namespace 'com.quran.labs.androidquran.pages.madani'
 
@@ -11,6 +13,5 @@ dependencies {
   implementation project(path: ':common:audio')
   implementation project(path: ':common:upgrade')
 
-  kapt libs.dagger.compiler
   implementation libs.dagger.runtime
 }


### PR DESCRIPTION
We only need kapt for Dagger for the app module (and, as of today, we
can't yet use ksp Dagger here due to the interop with Anvil). This at
least limits kapt usage only to the app module.
