### PR TITLE
Minor clean up of Arabic search

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/database/DatabaseHandler.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/database/DatabaseHandler.kt
@@ -84,7 +84,7 @@ class DatabaseHandler private constructor(
         ContextCompat.getColor(context, R.color.translation_highlight) +
         "\">"
     defaultSearcher = DefaultSearcher(matchString, MATCH_END, ELLIPSES)
-    arabicSearcher = ArabicSearcher(defaultSearcher, matchString, MATCH_END, QuranFileConstants.SEARCH_EXTRA_REPLACEMENTS)
+    arabicSearcher = ArabicSearcher(defaultSearcher, matchString, MATCH_END)
 
     // if there's no Quran base directory, there are no databases
     val base = quranFileUtils.getQuranDatabaseDirectory(context)

--- a/app/src/warsh/java/com/quran/labs/androidquran/data/QuranFileConstants.kt
+++ b/app/src/warsh/java/com/quran/labs/androidquran/data/QuranFileConstants.kt
@@ -14,7 +14,6 @@ object QuranFileConstants {
   const val FETCH_QUARTER_NAMES_FROM_DATABASE = true
 
   const val FALLBACK_PAGE_TYPE = "warsh"
-  const val SEARCH_EXTRA_REPLACEMENTS = "\u0626"
 
   var ICON_RESOURCE_ID = com.quran.labs.androidquran.pages.warsh.R.drawable.icon
 }

--- a/common/search/src/main/java/com/quran/common/search/ArabicSearcher.kt
+++ b/common/search/src/main/java/com/quran/common/search/ArabicSearcher.kt
@@ -8,9 +8,8 @@ import java.util.regex.Pattern
 
 class ArabicSearcher(private val defaultSearcher: Searcher,
                      private val matchStart: String,
-                     private val matchEnd: String,
-                     extraReplacements: String = "") : Searcher {
-  private val arabicRegex = "[$arabicRegexChars$extraReplacements]".toRegex()
+                     private val matchEnd: String) : Searcher {
+  private val arabicRegex = "[$arabicRegexChars]".toRegex()
 
   override fun getQuery(withSnippets: Boolean,
                         hasFTS: Boolean,
@@ -79,6 +78,6 @@ class ArabicSearcher(private val defaultSearcher: Searcher,
   }
 
   companion object {
-    private const val arabicRegexChars =  "\u0627\u0623\u0621\u062a\u0629\u0647\u0648\u0649"
+    private const val arabicRegexChars =  "\u0627\u0623\u0621\u062a\u0629\u0647\u0648\u0649\u0626"
   }
 }

--- a/common/search/src/main/java/com/quran/common/search/arabic/ArabicCharacterHelper.kt
+++ b/common/search/src/main/java/com/quran/common/search/arabic/ArabicCharacterHelper.kt
@@ -37,7 +37,7 @@ object ArabicCharacterHelper {
 
       // given: ئ
       // match: ئﻯي
-      // this is helpful for rewayat Warsh, and thus only enabled on it
+      // this is especially helpful for rewayat Warsh
       "\u0626" to "\u0626\u0649\u064a",
   )
 


### PR DESCRIPTION
We can use the same replacement characters for all the riwayat, since
the special cased one just for Warsh is actually useful for Hafs as
well.
