### PR TITLE
Add padding at the bottom of the audio panel

### DIFF
--- a/app/src/main/res/layout-ar-land-v17/audio_panel.xml
+++ b/app/src/main/res/layout-ar-land-v17/audio_panel.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:paddingLeft="12dp"

--- a/app/src/main/res/layout-ar-land/audio_panel.xml
+++ b/app/src/main/res/layout-ar-land/audio_panel.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     >

--- a/app/src/main/res/layout-ar-v17/audio_panel.xml
+++ b/app/src/main/res/layout-ar-v17/audio_panel.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:fadeScrollbars="false"
@@ -80,6 +79,11 @@
         android:layout_height="wrap_content"
         android:text="@string/play_apply"
         android:layout_gravity="end"
+        />
+
+    <Space
+        android:layout_width="match_parent"
+        android:layout_height="56dp"
         />
   </LinearLayout>
 </ScrollView>

--- a/app/src/main/res/layout-ar/audio_panel.xml
+++ b/app/src/main/res/layout-ar/audio_panel.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:fadeScrollbars="false"
@@ -82,6 +81,11 @@
         android:layout_height="wrap_content"
         android:text="@string/play_apply"
         android:layout_gravity="start"
+        />
+
+    <Space
+        android:layout_width="match_parent"
+        android:layout_height="56dp"
         />
   </LinearLayout>
 </ScrollView>

--- a/app/src/main/res/layout-land/audio_panel.xml
+++ b/app/src/main/res/layout-land/audio_panel.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:paddingLeft="12dp"

--- a/app/src/main/res/layout/audio_panel.xml
+++ b/app/src/main/res/layout/audio_panel.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:fadeScrollbars="false"
@@ -80,6 +79,11 @@
         android:layout_height="wrap_content"
         android:text="@string/play_apply"
         android:layout_gravity="end"
+        />
+
+    <Space
+        android:layout_width="match_parent"
+        android:layout_height="56dp"
         />
   </LinearLayout>
 </ScrollView>


### PR DESCRIPTION
On devices using the older navigation bar, the "apply" button is often
obscured in portrait mode. This fixes it by adding padding underneath
it.
