### PR TITLE
Use download streams for Quran reading

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/bridge/DownloadBridge.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/bridge/DownloadBridge.kt
@@ -1,0 +1,25 @@
+package com.quran.labs.androidquran.bridge
+
+import com.quran.mobile.common.download.DownloadInfo
+import com.quran.mobile.common.download.DownloadInfoStreams
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import javax.inject.Inject
+
+class DownloadBridge @Inject constructor(private val downloadInfoStreams: DownloadInfoStreams) {
+  private val scope = MainScope()
+
+  fun subscribeToDownloads(onDownloadSuccess: () -> Unit) {
+    downloadInfoStreams.downloadInfoStream()
+      .filter { it is DownloadInfo.DownloadBatchSuccess }
+      .onEach { onDownloadSuccess() }
+      .launchIn(scope)
+  }
+
+  fun unsubscribe() {
+    scope.cancel()
+  }
+}

--- a/app/src/main/java/com/quran/labs/androidquran/bridge/ReadingEventPresenterBridge.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/bridge/ReadingEventPresenterBridge.kt
@@ -10,7 +10,7 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 
-class ReadingEventPresenterBridge constructor(
+class ReadingEventPresenterBridge(
   private val readingEventPresenter: ReadingEventPresenter,
   private val handleClick: (() -> Unit),
   private val handleSelection: ((AyahSelection) -> Unit)


### PR DESCRIPTION
Instead of using the local broadcast manager, use the download streams
in order to refresh parts of the page, control playback, etc.
