### PR TITLE
Fix an invalid url when downloading a single page

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/util/QuranFileUtils.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/util/QuranFileUtils.kt
@@ -368,7 +368,7 @@ class QuranFileUtils @Inject constructor(
     }
     return if (isRetry) Response(
         Response.ERROR_DOWNLOADING_ERROR
-    ) else getImageFromWeb(okHttpClient, context, filename, widthParam, true)
+    ) else getImageFromWeb(okHttpClient, context, widthParam, filename, true)
   }
 
   private fun decodeBitmapStream(`is`: InputStream): Bitmap? {


### PR DESCRIPTION
In certain cases, the url when downloading a single page is wrong. This
fixes it.