### PR TITLE
Fix required downloads for audio

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/feature/reading/bridge/DownloadBridge.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/feature/reading/bridge/DownloadBridge.kt
@@ -14,7 +14,7 @@ class DownloadBridge @Inject constructor(private val downloadInfoStreams: Downlo
 
   fun subscribeToDownloads(onDownloadSuccess: () -> Unit) {
     downloadInfoStreams.downloadInfoStream()
-      .filter { it is DownloadInfo.DownloadBatchSuccess }
+      .filter { it is DownloadInfo.DownloadBatchSuccess || it is DownloadInfo.FileDownloaded }
       .onEach { onDownloadSuccess() }
       .launchIn(scope)
   }


### PR DESCRIPTION
After some of the required downloads complete, the audio was not
starting, due to needing more required downloads. This is because the
download bridge missed the FileDownloaded event and only was handling
the batch download success event.
