### PR TITLE
Fix audio not starting after required downloads

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/service/QuranDownloadService.java
+++ b/app/src/main/java/com/quran/labs/androidquran/service/QuranDownloadService.java
@@ -341,9 +341,12 @@ public class QuranDownloadService extends Service implements
     lastSentIntent = notifier.notifyProgress(details, 0, 0);
     boolean result = downloadFileWrapper(urlString, destination, outputFile, details);
     if (result) {
+      // first notify that the file was downloaded
+      notifier.notifyFileDownloaded(details, outputFile);
+      // then download that the batch (containing only one file in this case)
+      // was downloaded.
       lastSentIntent = notifier.notifyDownloadSuccessful(details);
     }
-    notifier.notifyFileDownloaded(details, outputFile);
     return result;
   }
 


### PR DESCRIPTION
Certain files, when downloaded, were not notifying the app that the
download is complete (due to an ordering bug of the "file download"
being sent after the "batch download done," when the batch should be
last). This caused required downloads to not continue to playing audio
when downloaded. This patch fixes this.
