### PR TITLE
Provide fallback page via Dagger

### DIFF
--- a/app/src/madani/java/com/quran/labs/androidquran/data/QuranFileConstants.kt
+++ b/app/src/madani/java/com/quran/labs/androidquran/data/QuranFileConstants.kt
@@ -16,8 +16,5 @@ object QuranFileConstants {
   const val ARABIC_SHARE_TEXT_HAS_BASMALLAH = true
   const val FETCH_QUARTER_NAMES_FROM_DATABASE = false
 
-  const val FALLBACK_PAGE_TYPE = "madani"
-  const val SEARCH_EXTRA_REPLACEMENTS = ""
-
   var ICON_RESOURCE_ID = com.quran.labs.androidquran.R.drawable.icon
 }

--- a/app/src/main/java/com/quran/labs/androidquran/di/module/application/ApplicationModule.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/di/module/application/ApplicationModule.kt
@@ -10,13 +10,12 @@ import com.quran.data.dao.Settings
 import com.quran.data.source.DisplaySize
 import com.quran.data.source.PageProvider
 import com.quran.data.source.PageSizeCalculator
-import com.quran.labs.androidquran.data.QuranFileConstants
 import com.quran.labs.androidquran.util.QuranFileUtils
 import com.quran.labs.androidquran.util.QuranSettings
 import com.quran.labs.androidquran.util.SettingsImpl
-import com.quran.mobile.di.qualifier.ApplicationContext
 import com.quran.mobile.di.ExtraPreferencesProvider
 import com.quran.mobile.di.ExtraScreenProvider
+import com.quran.mobile.di.qualifier.ApplicationContext
 import dagger.Module
 import dagger.Provides
 import dagger.multibindings.ElementsIntoSet
@@ -65,9 +64,12 @@ object ApplicationModule {
 
   @Named(DependencyInjectionConstants.CURRENT_PAGE_TYPE)
   @Provides
-  fun provideCurrentPageType(quranSettings: QuranSettings): String {
+  fun provideCurrentPageType(
+    quranSettings: QuranSettings,
+    @Named(DependencyInjectionConstants.FALLBACK_PAGE_TYPE) fallbackPageType: String
+  ): String {
     val currentKey = quranSettings.pageType
-    val result = currentKey ?: QuranFileConstants.FALLBACK_PAGE_TYPE
+    val result = currentKey ?: fallbackPageType
     if (currentKey == null) {
       quranSettings.pageType = result
     }

--- a/app/src/naskh/java/com/quran/labs/androidquran/data/QuranFileConstants.kt
+++ b/app/src/naskh/java/com/quran/labs/androidquran/data/QuranFileConstants.kt
@@ -13,8 +13,6 @@ object QuranFileConstants {
   const val ARABIC_SHARE_TABLE = DatabaseHandler.ARABIC_TEXT_TABLE
   const val ARABIC_SHARE_TEXT_HAS_BASMALLAH = false
   const val FETCH_QUARTER_NAMES_FROM_DATABASE = false
-  const val FALLBACK_PAGE_TYPE = "naskh"
-  const val SEARCH_EXTRA_REPLACEMENTS = ""
 
   var ICON_RESOURCE_ID = com.quran.labs.androidquran.pages.naskh.R.drawable.icon
 }

--- a/app/src/qaloon/java/com/quran/labs/androidquran/data/QuranFileConstants.kt
+++ b/app/src/qaloon/java/com/quran/labs/androidquran/data/QuranFileConstants.kt
@@ -13,8 +13,5 @@ object QuranFileConstants {
   const val ARABIC_SHARE_TEXT_HAS_BASMALLAH = true
   const val FETCH_QUARTER_NAMES_FROM_DATABASE = false
 
-  const val FALLBACK_PAGE_TYPE = "qaloon"
-  const val SEARCH_EXTRA_REPLACEMENTS = ""
-
   var ICON_RESOURCE_ID = com.quran.labs.androidquran.pages.qaloon.R.drawable.icon
 }

--- a/app/src/warsh/java/com/quran/labs/androidquran/data/QuranFileConstants.kt
+++ b/app/src/warsh/java/com/quran/labs/androidquran/data/QuranFileConstants.kt
@@ -13,7 +13,5 @@ object QuranFileConstants {
   const val ARABIC_SHARE_TEXT_HAS_BASMALLAH = true
   const val FETCH_QUARTER_NAMES_FROM_DATABASE = true
 
-  const val FALLBACK_PAGE_TYPE = "warsh"
-
   var ICON_RESOURCE_ID = com.quran.labs.androidquran.pages.warsh.R.drawable.icon
 }

--- a/common/data/src/main/java/com/quran/data/constant/DependencyInjectionConstants.kt
+++ b/common/data/src/main/java/com/quran/data/constant/DependencyInjectionConstants.kt
@@ -2,4 +2,5 @@ package com.quran.data.constant
 
 object DependencyInjectionConstants {
   const val CURRENT_PAGE_TYPE = "CURRENT_PAGE_TYPE"
+  const val FALLBACK_PAGE_TYPE = "FALLBACK_PAGE_TYPE"
 }

--- a/pages/madani/src/main/java/com/quran/data/page/provider/QuranDataModule.kt
+++ b/pages/madani/src/main/java/com/quran/data/page/provider/QuranDataModule.kt
@@ -2,6 +2,7 @@ package com.quran.data.page.provider
 
 import com.quran.common.upgrade.LocalDataUpgrade
 import com.quran.common.upgrade.PreferencesUpgrade
+import com.quran.data.constant.DependencyInjectionConstants
 import com.quran.data.page.provider.madani.MadaniPageProvider
 import com.quran.data.pageinfo.mapper.AyahMapper
 import com.quran.data.pageinfo.mapper.IdentityAyahMapper
@@ -14,6 +15,7 @@ import dagger.Reusable
 import dagger.multibindings.ElementsIntoSet
 import dagger.multibindings.IntoMap
 import dagger.multibindings.StringKey
+import javax.inject.Named
 
 @Module
 object QuranDataModule {
@@ -22,6 +24,11 @@ object QuranDataModule {
   fun providePageViewFactoryProvider(): PageViewFactoryProvider {
     return PageViewFactoryProvider { null }
   }
+
+  @Named(DependencyInjectionConstants.FALLBACK_PAGE_TYPE)
+  @JvmStatic
+  @Provides
+  fun provideFallbackPageType(): String = "madani"
 
   @JvmStatic
   @Provides


### PR DESCRIPTION
Previously, the fallback page was hardcoded within each flavor. This
patch changes it to be provided with Dagger.

Note that this also makes the line by line 1441 images the default for
new installations.
