### PR TITLE
Fix: Scroll state in retained in the partial translation mode

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/presenter/translation/InlineTranslationPresenter.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/presenter/translation/InlineTranslationPresenter.kt
@@ -28,6 +28,7 @@ class InlineTranslationPresenter @Inject constructor(
 ) {
   private val scope = MainScope()
   private var cachedTranslations = emptyList<LocalTranslation>()
+  private var lastVerseRange: VerseRange? = null
 
   init {
     translationListPresenter.translations()
@@ -39,10 +40,12 @@ class InlineTranslationPresenter @Inject constructor(
   }
 
   suspend fun refresh(verseRange: VerseRange) {
+    val ayahHasBeenChanged = verseRange != lastVerseRange
     val result = withContext(Dispatchers.IO) {
       getVerses(false, getTranslations(quranSettings), verseRange)
     }
-    translationScreen?.setVerses(result.translations, result.ayahInformation)
+    translationScreen?.setVerses(result.translations, result.ayahInformation, ayahHasBeenChanged)
+    lastVerseRange = verseRange
   }
 
   override fun bind(what: TranslationScreen) {
@@ -52,7 +55,7 @@ class InlineTranslationPresenter @Inject constructor(
   }
 
   interface TranslationScreen {
-    fun setVerses(translations: Array<LocalTranslation>, verses: List<QuranAyahInfo>)
+    fun setVerses(translations: Array<LocalTranslation>, verses: List<QuranAyahInfo>, ayahHasBeenChanged: Boolean)
     fun onTranslationsUpdated(translations: List<LocalTranslation>)
   }
 }

--- a/app/src/main/java/com/quran/labs/androidquran/ui/fragment/AyahTranslationFragment.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/fragment/AyahTranslationFragment.kt
@@ -163,7 +163,7 @@ class AyahTranslationFragment : AyahActionFragment(), TranslationScreen {
     }
   }
 
-  override fun setVerses(translations: Array<LocalTranslation>, verses: List<QuranAyahInfo>) {
+  override fun setVerses(translations: Array<LocalTranslation>, verses: List<QuranAyahInfo>, ayahHasBeenChanged: Boolean) {
     progressBar.visibility = View.GONE
     if (verses.isNotEmpty()) {
       emptyState.visibility = View.GONE
@@ -171,6 +171,9 @@ class AyahTranslationFragment : AyahActionFragment(), TranslationScreen {
       translator.visibility = View.VISIBLE
       translationView.visibility = View.VISIBLE
       translationView.setAyahs(translations, verses)
+      if (ayahHasBeenChanged) {
+        translationView.resetScroll()
+      }
     } else {
       emptyState.visibility = View.VISIBLE
     }

--- a/app/src/main/java/com/quran/labs/androidquran/view/InlineTranslationView.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/view/InlineTranslationView.kt
@@ -88,8 +88,11 @@ class InlineTranslationView @JvmOverloads constructor(
         i++
       }
       addFooterSpacer()
-      scrollTo(0, 0)
     }
+  }
+
+  fun resetScroll() {
+    scrollTo(0, 0)
   }
 
   private fun addFooterSpacer() {


### PR DESCRIPTION
Fixes #2598 [Retain scroll state in partial translation mode](https://github.com/quran/quran_android/issues/2598)

The issue was with the call to `scrollTo(0, 0)` within the `setAyahs()`, so basically when the Ayahs are set the scroll is rested to 0,0.

Removing `scrollTo(0, 0)` persists the scroll position since `InlineTranslationView` extends `ScrollView` and it saves the scroll state out of the box. but this introduce a new **problem** which is when you select a different ayah then the scroll will not be rested. to fix this I added a flag called `ayahHasBeenChanged` to reset the scroll to 0,0 when ayah is changed