### PR TITLE
Persist non-audio data on internal storage

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/QuranDataActivity.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/QuranDataActivity.kt
@@ -343,7 +343,7 @@ class QuranDataActivity : Activity(), SimpleDownloadListener, OnRequestPermissio
     if (location != null) {
       try {
         if (File(location).exists() ||
-            quranFileUtils.makeQuranDirectory(this, quranScreenInfo.widthParam)
+            quranFileUtils.makeQuranImagesDirectory(quranScreenInfo.widthParam)
         ) {
           val f = File(location, "" + System.currentTimeMillis())
           if (f.createNewFile()) {
@@ -461,8 +461,11 @@ class QuranDataActivity : Activity(), SimpleDownloadListener, OnRequestPermissio
       try {
         // try to write a directory to distinguish between the entire Quran directory
         // being removed versus just the images being somehow removed.
-        File(baseDirectory, QURAN_DIRECTORY_MARKER_FILE).createNewFile()
-        File(baseDirectory, QURAN_HIDDEN_DIRECTORY_MARKER_FILE).createNewFile()
+        if (baseDirectory != null) {
+          File(baseDirectory).mkdirs()
+          File(baseDirectory, QURAN_DIRECTORY_MARKER_FILE).createNewFile()
+          File(baseDirectory, QURAN_HIDDEN_DIRECTORY_MARKER_FILE).createNewFile()
+        }
 
         // try writing a file to the app's internal no_backup directory
         File(noBackupFilesDir, QURAN_HIDDEN_DIRECTORY_MARKER_FILE).createNewFile()
@@ -663,12 +666,12 @@ class QuranDataActivity : Activity(), SimpleDownloadListener, OnRequestPermissio
     if (!TextUtils.isEmpty(patchParam)) {
       url = quranFileUtils.getPatchFileUrl(patchParam!!, quranDataPresenter.imagesVersion())
     }
-    val destination = quranFileUtils.getQuranImagesBaseDirectory(this@QuranDataActivity)
+    val destination = quranFileUtils.getQuranImagesBaseDirectory()
 
     // start service
     val intent = ServiceIntentHelper.getDownloadIntent(
         this, url,
-        destination, getString(R.string.app_name), PAGES_DOWNLOAD_KEY,
+        destination.absolutePath, getString(R.string.app_name), PAGES_DOWNLOAD_KEY,
         QuranDownloadService.DOWNLOAD_TYPE_PAGES
     )
     if (!force) {

--- a/app/src/main/java/com/quran/labs/androidquran/SearchActivity.java
+++ b/app/src/main/java/com/quran/labs/androidquran/SearchActivity.java
@@ -130,7 +130,7 @@ public class SearchActivity extends AppCompatActivity
     String url = quranFileUtils.getArabicSearchDatabaseUrl();
     String notificationTitle = getString(R.string.search_data);
     Intent intent = ServiceIntentHelper.getDownloadIntent(this, url,
-        quranFileUtils.getQuranDatabaseDirectory(this),
+        quranFileUtils.getQuranDatabaseDirectory().getAbsolutePath(),
         notificationTitle, SEARCH_INFO_DOWNLOAD_KEY,
         QuranDownloadService.DOWNLOAD_TYPE_ARABIC_SEARCH_DB);
     final String extension = url.endsWith(".zip") ? ".zip" : "";

--- a/app/src/main/java/com/quran/labs/androidquran/data/AyahInfoDatabaseProvider.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/data/AyahInfoDatabaseProvider.kt
@@ -18,7 +18,7 @@ class AyahInfoDatabaseProvider @Inject constructor(
     if (databaseHandler == null) {
       val filename = quranFileUtils.getAyaPositionFileName(widthParameter)
       databaseHandler = AyahInfoDatabaseHandler.getAyahInfoDatabaseHandler(
-        context, filename,
+        filename,
         quranFileUtils
       )
     }

--- a/app/src/main/java/com/quran/labs/androidquran/data/QuranDataProvider.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/data/QuranDataProvider.kt
@@ -19,7 +19,6 @@ import com.quran.labs.androidquran.database.TranslationsDBAdapter
 import com.quran.labs.androidquran.util.QuranFileUtils
 import com.quran.labs.androidquran.util.QuranUtils
 import com.quran.mobile.translation.model.LocalTranslation
-import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import timber.log.Timber
@@ -80,7 +79,7 @@ class QuranDataProvider : ContentProvider() {
     }
     val queryIsArabic = QuranUtils.doesStringContainArabic(query)
     val haveArabic = queryIsArabic &&
-        quranFileUtils.hasTranslation(context!!, QURAN_ARABIC_DATABASE)
+        quranFileUtils.hasTranslation(QURAN_ARABIC_DATABASE)
     val translations = availableTranslations()
     if (translations.isEmpty() && queryIsArabic && !haveArabic) {
       return null
@@ -170,10 +169,9 @@ class QuranDataProvider : ContentProvider() {
     translations: List<LocalTranslation> = availableTranslations()
   ): Cursor? {
     Timber.d("query: %s", query)
-    val context = context
     val queryIsArabic = QuranUtils.doesStringContainArabic(query)
     val haveArabic = queryIsArabic &&
-        quranFileUtils.hasTranslation(context!!, QURAN_ARABIC_DATABASE)
+        quranFileUtils.hasTranslation(QURAN_ARABIC_DATABASE)
     if (translations.isEmpty() && queryIsArabic && !haveArabic) {
       return null
     }

--- a/app/src/main/java/com/quran/labs/androidquran/database/DatabaseHandler.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/database/DatabaseHandler.kt
@@ -87,9 +87,9 @@ class DatabaseHandler private constructor(
     arabicSearcher = ArabicSearcher(defaultSearcher, matchString, MATCH_END)
 
     // if there's no Quran base directory, there are no databases
-    val base = quranFileUtils.getQuranDatabaseDirectory(context)
-    base?.let {
-      val path = base + File.separator + databaseName
+    val base = quranFileUtils.getQuranDatabaseDirectory()
+    base.let {
+      val path = File(base, databaseName).absolutePath
       Timber.d("opening database file: %s", path)
       database = try {
         SQLiteDatabase.openDatabase(path, null,

--- a/app/src/main/java/com/quran/labs/androidquran/database/TranslationsDBAdapter.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/database/TranslationsDBAdapter.kt
@@ -27,7 +27,7 @@ class TranslationsDBAdapter @Inject constructor(
     return dataSource.translations()
       .filterNotNull()
       .map { translations ->
-        translations.filter { quranFileUtils.hasTranslation(context, it.filename) }
+        translations.filter { quranFileUtils.hasTranslation(it.filename) }
       }
   }
 

--- a/app/src/main/java/com/quran/labs/androidquran/feature/reading/presenter/AudioPresenter.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/feature/reading/presenter/AudioPresenter.kt
@@ -109,10 +109,10 @@ constructor(private val quranDisplayData: QuranDisplayData,
     val path = audioPathInfo.localDirectory
     val gaplessDb = audioPathInfo.gaplessDatabase
 
-    return if (!quranFileUtils.haveAyaPositionFile(context)) {
+    return if (!quranFileUtils.haveAyaPositionFile()) {
       getDownloadIntent(context,
           quranFileUtils.ayaPositionFileUrl,
-          quranFileUtils.getQuranAyahDatabaseDirectory(context)!!,
+          quranFileUtils.quranAyahDatabaseDirectory.absolutePath,
           context.getString(R.string.highlighting_database))
     } else if (gaplessDb != null && !File(gaplessDb).exists()) {
       getDownloadIntent(context,

--- a/app/src/main/java/com/quran/labs/androidquran/pageselect/PageSelectPresenter.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/pageselect/PageSelectPresenter.kt
@@ -35,45 +35,43 @@ constructor(
   private var currentView: PageSelectActivity? = null
 
   private fun generateData() {
-    val base = quranFileUtils.quranBaseDirectory
-    if (base != null) {
-      val outputPath = File(File(base, "pagetypes"), "snips")
-      if (!outputPath.exists()) {
-        outputPath.mkdirs()
-        File(outputPath, ".nomedia").createNewFile()
-      }
-
-      val data = pageTypes.map {
-        val provider = it.value
-        val previewImage = File(outputPath, "${it.key}.png")
-        val downloadedImage = if (previewImage.exists()) {
-          previewImage
-        } else if (!downloadingSet.contains(it.key)) {
-          downloadingSet.add(it.key)
-          val url = "$baseUrl/${it.key}.png"
-          compositeDisposable.add(
-            imageUtil.downloadImage(url, previewImage)
-              .onErrorResumeWith(
-                imageUtil.downloadImage(url, previewImage)
-              )
-              .subscribeOn(Schedulers.io())
-              .observeOn(mainThreadScheduler)
-              .subscribe({ generateData() }, { e -> Timber.e(e) })
-          )
-          null
-        } else {
-          // already downloading
-          null
-        }
-        PageTypeItem(
-          it.key,
-          downloadedImage,
-          provider.getPreviewTitle(),
-          provider.getPreviewDescription()
-        )
-      }
-      currentView?.onUpdatedData(data)
+    val base = quranFileUtils.quranInternalStorage
+    val outputPath = File(File(base, "pagetypes"), "snips")
+    if (!outputPath.exists()) {
+      outputPath.mkdirs()
+      File(outputPath, ".nomedia").createNewFile()
     }
+
+    val data = pageTypes.map {
+      val provider = it.value
+      val previewImage = File(outputPath, "${it.key}.png")
+      val downloadedImage = if (previewImage.exists()) {
+        previewImage
+      } else if (!downloadingSet.contains(it.key)) {
+        downloadingSet.add(it.key)
+        val url = "$baseUrl/${it.key}.png"
+        compositeDisposable.add(
+          imageUtil.downloadImage(url, previewImage)
+            .onErrorResumeWith(
+              imageUtil.downloadImage(url, previewImage)
+            )
+            .subscribeOn(Schedulers.io())
+            .observeOn(mainThreadScheduler)
+            .subscribe({ generateData() }, { e -> Timber.e(e) })
+        )
+        null
+      } else {
+        // already downloading
+        null
+      }
+      PageTypeItem(
+        it.key,
+        downloadedImage,
+        provider.getPreviewTitle(),
+        provider.getPreviewDescription()
+      )
+    }
+    currentView?.onUpdatedData(data)
   }
 
   /**

--- a/app/src/main/java/com/quran/labs/androidquran/presenter/data/QuranDataPresenter.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/presenter/data/QuranDataPresenter.kt
@@ -132,8 +132,7 @@ class QuranDataPresenter @Inject internal constructor(
     directory?.let {
       val log = StringBuilder()
 
-      val quranImagesDirectoryName = quranFileUtils.getQuranImagesBaseDirectory(appContext)
-      val quranImagesDirectory = File(quranImagesDirectoryName)
+      val quranImagesDirectory = quranFileUtils.getQuranImagesBaseDirectory()
       val quranImagesDirectoryFiles = quranImagesDirectory.listFiles()
       quranImagesDirectoryFiles?.let { files ->
         val imageSubdirectories = files.filter { it.name.contains("width_") }
@@ -161,7 +160,7 @@ class QuranDataPresenter @Inject internal constructor(
       }
 
       if (quranImagesDirectoryFiles == null) {
-        log.append("null list of files in images directory: $quranImagesDirectoryName - ${quranImagesDirectory.isDirectory}")
+        log.append("null list of files in images directory: ${quranImagesDirectory.name}- ${quranImagesDirectory.isDirectory}")
       }
 
       val audioDirectory = quranFileUtils.getQuranAudioDirectory(appContext)
@@ -202,7 +201,7 @@ class QuranDataPresenter @Inject internal constructor(
          * folder of 1920 images, in which case it sets that in the pref
          * so we load those instead of 1260s.
          */
-        val fallback = quranFileUtils.getPotentialFallbackDirectory(appContext, totalPages)
+        val fallback = quranFileUtils.getPotentialFallbackDirectory(totalPages)
         if (fallback != null) {
           Timber.d("setting fallback pages to %s", fallback)
           quranSettings.setDefaultImagesDirectory(fallback)
@@ -247,11 +246,11 @@ class QuranDataPresenter @Inject internal constructor(
   private fun actuallyCheckPages(totalPages: Int): Single<QuranDataStatus> {
     return Single.fromCallable {
       val width = quranScreenInfo.widthParam
-      val havePortrait = quranFileUtils.haveAllImages(appContext, width, totalPages, true)
+      val havePortrait = quranFileUtils.haveAllImages(width, totalPages, true)
 
       val tabletWidth = quranScreenInfo.tabletWidthParam
       val needLandscapeImages = if (quranScreenInfo.isDualPageMode && width != tabletWidth) {
-        val haveLandscape = quranFileUtils.haveAllImages(appContext, tabletWidth, totalPages, true)
+        val haveLandscape = quranFileUtils.haveAllImages(tabletWidth, totalPages, true)
         Timber.d("checkPages: have portrait images: %s, have landscape images: %s",
             if (havePortrait) "yes" else "no", if (haveLandscape) "yes" else "no")
         !haveLandscape
@@ -261,7 +260,7 @@ class QuranDataPresenter @Inject internal constructor(
         false
       }
 
-      QuranDataStatus(width, tabletWidth, havePortrait, !needLandscapeImages, null)
+      QuranDataStatus(width, tabletWidth, havePortrait, !needLandscapeImages, null, totalPages)
     }
   }
 

--- a/app/src/main/java/com/quran/labs/androidquran/presenter/quran/ayahtracker/AyahTrackerPresenter.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/presenter/quran/ayahtracker/AyahTrackerPresenter.kt
@@ -364,7 +364,7 @@ class AyahTrackerPresenter @Inject constructor(
 
   private fun checkCoordinateData(activity: Activity) {
     if (activity is PagerActivity &&
-      (!quranFileUtils.haveAyaPositionFile(activity) ||
+      (!quranFileUtils.haveAyaPositionFile() ||
           !quranFileUtils.hasArabicSearchDatabase())
     ) {
       activity.showGetRequiredFilesDialog()

--- a/app/src/main/java/com/quran/labs/androidquran/presenter/translation/TranslationManagerPresenter.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/presenter/translation/TranslationManagerPresenter.kt
@@ -160,13 +160,13 @@ open class TranslationManagerPresenter @Inject internal constructor(
 
   internal open val cachedFile: File
     get() {
-      val dir = quranFileUtils.getQuranDatabaseDirectory(appContext)
-      return File(dir + File.separator + CACHED_RESPONSE_FILE_NAME)
+      val dir = quranFileUtils.getQuranDatabaseDirectory()
+      return File(dir, CACHED_RESPONSE_FILE_NAME)
     }
 
   internal open suspend fun mergeWithServerTranslations(serverTranslations: List<Translation>): List<TranslationItem> {
     val localTranslations = translationsDBAdapter.translationsHash()
-    val databaseDir = quranFileUtils.getQuranDatabaseDirectory(appContext)
+    val databaseDir = quranFileUtils.getQuranDatabaseDirectory()
     val updates: MutableList<TranslationItem> = ArrayList()
 
     val results = serverTranslations.mapIndexed { _, translation ->

--- a/app/src/main/java/com/quran/labs/androidquran/service/QuranDownloadService.java
+++ b/app/src/main/java/com/quran/labs/androidquran/service/QuranDownloadService.java
@@ -540,8 +540,7 @@ public class QuranDownloadService extends Service implements
     if (result == DOWNLOAD_SUCCESS) {
       if (filename.endsWith("zip")) {
         final File actualFile = new File(path, filename);
-        if (!ZipUtils.unzipFile(actualFile.getAbsolutePath(),
-            path, notificationInfo, this)) {
+        if (!ZipUtils.unzipFile(actualFile, new File(path), notificationInfo, this)) {
           return !actualFile.delete() ?
               QuranDownloadNotifier.ERROR_PERMISSIONS :
               QuranDownloadNotifier.ERROR_INVALID_DOWNLOAD;

--- a/app/src/main/java/com/quran/labs/androidquran/ui/PagerActivity.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/PagerActivity.kt
@@ -863,19 +863,19 @@ class PagerActivity : AppCompatActivity(), AudioBarListener, OnBookmarkTagsUpdat
     }
 
     var haveDownload = false
-    if (!quranFileUtils.haveAyaPositionFile(this)) {
+    if (!quranFileUtils.haveAyaPositionFile()) {
       var url = quranFileUtils.ayaPositionFileUrl
       if (isDualPages) {
         url = quranFileUtils.getAyaPositionFileUrl(
           quranScreenInfo.tabletWidthParam
         )
       }
-      val destination = quranFileUtils.getQuranAyahDatabaseDirectory(this)
+      val destination = quranFileUtils.quranAyahDatabaseDirectory
       // start the download
       val notificationTitle = getString(R.string.highlighting_database)
       val intent = getDownloadIntent(
         this, url,
-        destination, notificationTitle, AUDIO_DOWNLOAD_KEY,
+        destination.absolutePath, notificationTitle, AUDIO_DOWNLOAD_KEY,
         downloadType
       )
       Timber.d("starting service to download ayah position file")
@@ -897,7 +897,7 @@ class PagerActivity : AppCompatActivity(), AudioBarListener, OnBookmarkTagsUpdat
       val extension = if (url.endsWith(".zip")) ".zip" else ""
       val intent = getDownloadIntent(
         this, url,
-        quranFileUtils.getQuranDatabaseDirectory(this), notificationTitle,
+        quranFileUtils.getQuranDatabaseDirectory().absolutePath, notificationTitle,
         AUDIO_DOWNLOAD_KEY, downloadType
       )
       intent.putExtra(

--- a/app/src/main/java/com/quran/labs/androidquran/ui/TranslationManagerActivity.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/TranslationManagerActivity.kt
@@ -50,7 +50,7 @@ class TranslationManagerActivity : AppCompatActivity(), SimpleDownloadListener,
   private var originalSortedDownloads: List<TranslationItem> = emptyList()
   private var translationPositions: SparseIntArray = SparseIntArray()
   private var downloadingItem: TranslationItem? = null
-  private var databaseDirectory: String? = null
+  private var databaseDirectory: File? = null
   private var downloadReceiver: DefaultDownloadReceiver? = null
   private var actionMode: ActionMode? = null
   private var downloadedItemActionListener: DownloadedItemActionListener? = null
@@ -87,7 +87,7 @@ class TranslationManagerActivity : AppCompatActivity(), SimpleDownloadListener,
     adapter = TranslationsAdapter(this)
     translationRecycler.setAdapter(adapter)
     selectionListener = TranslationSelectionListener(adapter)
-    databaseDirectory = quranFileUtils.getQuranDatabaseDirectory(this)
+    databaseDirectory = quranFileUtils.getQuranDatabaseDirectory()
     val actionBar = supportActionBar
     if (actionBar != null) {
       actionBar.setDisplayHomeAsUpEnabled(true)
@@ -332,7 +332,7 @@ class TranslationManagerActivity : AppCompatActivity(), SimpleDownloadListener,
     val notificationTitle = selectedItem.name()
     val intent = getDownloadIntent(
       this, url,
-      destination, notificationTitle, TRANSLATION_DOWNLOAD_KEY,
+      destination?.absolutePath ?: "", notificationTitle, TRANSLATION_DOWNLOAD_KEY,
       QuranDownloadService.DOWNLOAD_TYPE_TRANSLATION
     )
     var filename = selectedItem.translation.fileName
@@ -422,13 +422,9 @@ class TranslationManagerActivity : AppCompatActivity(), SimpleDownloadListener,
   }
 
   private fun removeTranslation(fileName: String): Boolean {
-    var path = quranFileUtils.getQuranDatabaseDirectory(this@TranslationManagerActivity)
-    if (path != null) {
-      path += File.separator + fileName
-      val f = File(path)
-      return f.delete()
-    }
-    return false
+    var path = quranFileUtils.getQuranDatabaseDirectory()
+    val f = File(path, fileName)
+    return f.delete()
   }
 
   override fun startMenuAction(

--- a/app/src/main/java/com/quran/labs/androidquran/ui/helpers/QuranDisplayHelper.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/helpers/QuranDisplayHelper.java
@@ -33,7 +33,7 @@ public class QuranDisplayHelper {
                                QuranFileUtils quranFileUtils) {
     Response response;
     String filename = QuranFileUtils.getPageFileName(page);
-    response = quranFileUtils.getImageFromSD(context, widthParam, filename);
+    response = quranFileUtils.getImageFromSD(widthParam, filename);
     if (!response.isSuccessful()) {
       // let's only try if an sdcard is found... otherwise, let's tell
       // the user to mount their sdcard and try again.

--- a/app/src/main/java/com/quran/labs/androidquran/util/QuranPartialPageChecker.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/util/QuranPartialPageChecker.kt
@@ -10,7 +10,7 @@ class QuranPartialPageChecker @Inject constructor() {
   /**
    * Checks all the pages to find partially downloaded images.
    */
-  fun checkPages(directory: String, numberOfPages: Int, width: String): List<Int> {
+  fun checkPages(directory: File, numberOfPages: Int, width: String): List<Int> {
     // past versions of the partial page checker didn't run the checker
     // whenever any .vX file exists. this was noted as a "works sometimes"
     // solution because not all zip files contain .vX files (ex naskh and
@@ -33,7 +33,7 @@ class QuranPartialPageChecker @Inject constructor() {
    * If the last few rows are blank, the image is assumed to be partial and
    * the image is returned.
    */
-  private fun checkPartialImages(directoryName: String,
+  private fun checkPartialImages(directory: File,
                                  width: String,
                                  numberOfPages: Int): List<Int> {
     val result = mutableListOf<Int>()
@@ -44,7 +44,6 @@ class QuranPartialPageChecker @Inject constructor() {
           inSampleSize = 16
         }
 
-    val directory = File(directoryName)
     // optimization to avoid re-generating the pixel array every time
     var pixelArray: IntArray? = null
 
@@ -53,7 +52,7 @@ class QuranPartialPageChecker @Inject constructor() {
       val filename = QuranFileUtils.getPageFileName(page)
       if (File(directory, filename).exists()) {
         val bitmap = BitmapFactory.decodeFile(
-            directoryName + File.separator + filename, options
+            File(directory, filename).absolutePath, options
         )
 
         // this is an optimization to avoid allocating 8 * width of memory

--- a/app/src/main/java/com/quran/labs/androidquran/util/ZipUtils.java
+++ b/app/src/main/java/com/quran/labs/androidquran/util/ZipUtils.java
@@ -31,17 +31,16 @@ public class ZipUtils {
    * @param <T> the type of the item passed in
    * @return a boolean representing whether we succeeded to unzip the file or not
    */
-  public static <T> boolean unzipFile(String zipFile,
-      String destDirectory, T item, ZipListener<T> listener){
+  public static <T> boolean unzipFile(File zipFile,
+      File destDirectory, T item, ZipListener<T> listener){
     try {
-      File file = new File(zipFile);
-      Timber.d("unzipping %s, size: %d", zipFile, file.length());
+      Timber.d("unzipping %s, size: %d", zipFile, zipFile.length());
 
-      try (ZipFile zip = new ZipFile(file, ZipFile.OPEN_READ)) {
+      try (ZipFile zip = new ZipFile(zipFile, ZipFile.OPEN_READ)) {
         int numberOfFiles = zip.size();
         Enumeration<? extends ZipEntry> entries = zip.entries();
 
-        String canonicalPath = new File(destDirectory).getCanonicalPath();
+        String canonicalPath = destDirectory.getCanonicalPath();
 
         long total = 0;
         int processedFiles = 0;

--- a/app/src/main/java/com/quran/labs/androidquran/worker/MissingPageDownloadWorker.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/worker/MissingPageDownloadWorker.kt
@@ -62,7 +62,7 @@ class MissingPageDownloadWorker(private val context: Context,
 
   private fun findMissingPagesForWidth(width: String): List<PageToDownload> {
     val result = mutableListOf<PageToDownload>()
-    val pagesDirectory = File(quranFileUtils.getQuranImagesDirectory(context, width))
+    val pagesDirectory = quranFileUtils.getQuranImagesDirectory(width)
     for (page in 1..quranInfo.numberOfPages) {
       val pageFile = QuranFileUtils.getPageFileName(page)
       if (!File(pagesDirectory, pageFile).exists()) {

--- a/app/src/main/java/com/quran/labs/androidquran/worker/PartialPageCheckingWorker.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/worker/PartialPageCheckingWorker.kt
@@ -37,9 +37,9 @@ class PartialPageCheckingWorker(private val context: Context,
 
       // prepare page widths and paths
       val width = quranScreenInfo.widthParam
-      val pagesDirectory = quranFileUtils.getQuranImagesDirectory(context, width)!!
+      val pagesDirectory = quranFileUtils.getQuranImagesDirectory(width)
       val tabletWidth = quranScreenInfo.tabletWidthParam
-      val tabletPagesDirectory = quranFileUtils.getQuranImagesDirectory(context, tabletWidth)!!
+      val tabletPagesDirectory = quranFileUtils.getQuranImagesDirectory(tabletWidth)
 
       // compute the partial page sets
       val partialPages =
@@ -88,7 +88,7 @@ class PartialPageCheckingWorker(private val context: Context,
 
   data class PartialPage(val width: String, val page: Int)
 
-  private fun deletePage(directory: String, page: Int): Boolean {
+  private fun deletePage(directory: File, page: Int): Boolean {
     val pageName = QuranFileUtils.getPageFileName(page)
     return File(directory, pageName).let { file ->
       if (file.exists()) {

--- a/app/src/test/java/com/quran/labs/androidquran/util/ZipUtilsTest.kt
+++ b/app/src/test/java/com/quran/labs/androidquran/util/ZipUtilsTest.kt
@@ -13,19 +13,19 @@ class ZipUtilsTest {
     private const val CLI_ROOT_DIRECTORY = "src/test/resources"
   }
 
-  private lateinit var destinationDirectory: String
+  private lateinit var destinationDirectory: File
   private val listener =
     ZipUtils.ZipListener { _: Any?, _: Int, _: Int -> }
 
   @Before
   fun setup() {
-    destinationDirectory = "$CLI_ROOT_DIRECTORY/tmp"
-    File(destinationDirectory).mkdir()
+    destinationDirectory = File(CLI_ROOT_DIRECTORY, "tmp")
+    destinationDirectory.mkdir()
   }
 
   @After
   fun cleanup() {
-    removeDirectory(File(destinationDirectory))
+    removeDirectory(destinationDirectory)
   }
 
   private fun removeDirectory(file: File) {
@@ -46,7 +46,7 @@ class ZipUtilsTest {
     var e: RuntimeException? = null
     try {
       // thanks to https://github.com/commonsguy/cwac-security for this zip file
-      ZipUtils.unzipFile("$CLI_ROOT_DIRECTORY/zip_file_100mb.zip",
+      ZipUtils.unzipFile(File(CLI_ROOT_DIRECTORY, "zip_file_100mb.zip"),
         destinationDirectory, null, listener)
     } catch (ise: IllegalStateException) {
       e = ise
@@ -60,7 +60,7 @@ class ZipUtilsTest {
     var e: RuntimeException? = null
     try {
       // thanks to https://github.com/commonsguy/cwac-security for this zip file
-      ZipUtils.unzipFile("$CLI_ROOT_DIRECTORY/zip_file_100mb.zip",
+      ZipUtils.unzipFile(File(CLI_ROOT_DIRECTORY, "zip_file_100mb.zip"),
         destinationDirectory, null, listener)
     } catch (ise: IllegalStateException) {
       e = ise
@@ -74,7 +74,7 @@ class ZipUtilsTest {
     var e: RuntimeException? = null
     try {
       // thanks to https://github.com/commonsguy/cwac-security for this zip file
-      ZipUtils.unzipFile("$CLI_ROOT_DIRECTORY/zip_file_writes_outside.zip",
+      ZipUtils.unzipFile(File(CLI_ROOT_DIRECTORY, "zip_file_writes_outside.zip"),
         destinationDirectory, null, listener)
     } catch (ise: IllegalStateException) {
       e = ise

--- a/common/data/src/main/java/com/quran/data/core/QuranFileManager.kt
+++ b/common/data/src/main/java/com/quran/data/core/QuranFileManager.kt
@@ -1,10 +1,11 @@
 package com.quran.data.core
 
 import androidx.annotation.WorkerThread
+import java.io.File
 
 interface QuranFileManager {
-  fun quranImagesDirectory(): String?
-  fun ayahInfoFileDirectory(): String?
+  fun quranImagesDirectory(): File
+  fun ayahInfoFileDirectory(): File
   fun audioFileDirectory(): String?
 
   fun recitationSessionsDirectory(): String
@@ -33,4 +34,7 @@ interface QuranFileManager {
 
   @WorkerThread
   fun writeNoMediaFileRelative(widthParam: String)
+
+  @WorkerThread
+  fun upgradeNonAudioFiles(portraitWidth: String, landscapeWidth: String, totalPages: Int): Boolean
 }

--- a/common/data/src/main/java/com/quran/data/model/QuranDataStatus.kt
+++ b/common/data/src/main/java/com/quran/data/model/QuranDataStatus.kt
@@ -5,7 +5,8 @@ data class QuranDataStatus(
   val landscapeWidth: String,
   val havePortrait: Boolean,
   val haveLandscape: Boolean,
-  val patchParam: String?
+  val patchParam: String?,
+  val totalPages: Int
 ) {
   fun needPortrait() = !havePortrait
   fun needLandscape() = !haveLandscape


### PR DESCRIPTION
This patch changes the location of all images and databases to be
internal storage. Audio will remain on the directory set by the person
using the application. Migrations of data will only move audio moving
forward.
