### PR TITLE
Fix GitHub workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
     branches:
       - main
+  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -12,6 +13,7 @@ jobs:
   build:
     name: Validate PR
     runs-on: ubuntu-latest
+    if: github.event_name != 'merge_group'
     steps:
       - name: Checkout the Code
         uses: actions/checkout@v4

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -1,11 +1,13 @@
 name: Merge Queue
 on:
+  pull_request:
   merge_group:
 
 jobs:
   build:
     name: Merge
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request'
     steps:
       - name: Checkout the Code
         uses: actions/checkout@v4


### PR DESCRIPTION
There are no merge queue specific checks today, which means that both
merge queue checks and pr checks need to be run on all types of things
in order to make them required.

See https://github.com/orgs/community/discussions/103114 for details.
