### PR TITLE
Batch database with ordered audio download batches

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/service/util/DownloadStarter.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/service/util/DownloadStarter.kt
@@ -25,10 +25,10 @@ class DownloadStarter @Inject constructor(
 ) : Downloader {
 
   override fun downloadSura(qari: Qari, sura: Int) {
-    downloadSuras(qari, sura, sura)
+    downloadSuras(qari, sura, sura, false)
   }
 
-  override fun downloadSuras(qari: Qari, startSura: Int, endSura: Int) {
+  override fun downloadSuras(qari: Qari, startSura: Int, endSura: Int, downloadDatabase: Boolean) {
     val basePath = fileManager.audioFileDirectory()
     val baseUri = basePath + qari.path
     val isGapless = qari.isGapless
@@ -46,6 +46,9 @@ class DownloadStarter @Inject constructor(
       putExtra(QuranDownloadService.EXTRA_END_VERSE, SuraAyah(endSura, quranInfo.getNumberOfAyahs(endSura)))
       putExtra(QuranDownloadService.EXTRA_IS_GAPLESS, isGapless)
       putExtra(QuranDownloadService.EXTRA_METADATA, AudioDownloadMetadata(qari.id))
+      if (downloadDatabase && isGapless) {
+        putExtra(QuranDownloadService.EXTRA_DOWNLOAD_DATABASE, fileManager.urlForDatabase(qari))
+      }
     }
     appContext.startService(intent)
   }
@@ -55,7 +58,7 @@ class DownloadStarter @Inject constructor(
     val intent = ServiceIntentHelper.getAudioDownloadIntent(
       appContext,
       databaseUri,
-      fileManager.audioFileDirectory() + File.separator + qari.path,
+      fileManager.audioFileDirectory() + qari.path,
       appContext.getString(com.quran.mobile.feature.downloadmanager.R.string.audio_manager_database)
     ).apply {
       putExtra(QuranDownloadService.EXTRA_METADATA, AudioDownloadMetadata(qari.id))

--- a/common/download/src/main/java/com/quran/mobile/common/download/Downloader.kt
+++ b/common/download/src/main/java/com/quran/mobile/common/download/Downloader.kt
@@ -4,7 +4,7 @@ import com.quran.data.model.audio.Qari
 
 interface Downloader {
   fun downloadSura(qari: Qari, sura: Int)
-  fun downloadSuras(qari: Qari, startSura: Int, endSura: Int)
+  fun downloadSuras(qari: Qari, startSura: Int, endSura: Int, downloadDatabase: Boolean)
   fun downloadAudioDatabase(qari: Qari)
   fun cancelDownloads()
 }

--- a/feature/downloadmanager/src/main/kotlin/com/quran/mobile/feature/downloadmanager/presenter/SheikhAudioPresenter.kt
+++ b/feature/downloadmanager/src/main/kotlin/com/quran/mobile/feature/downloadmanager/presenter/SheikhAudioPresenter.kt
@@ -152,19 +152,20 @@ class SheikhAudioPresenter @Inject constructor(
       val qariInfo = qariInfoForId(qariId)
       if (qariInfo != null) {
         val qari = qariInfo.qari
+        val qariDatabase = qari.databasePath()
         val alreadyDownloaded = qariInfo.fullyDownloadedSuras.toSet()
         val sorted = (suras - alreadyDownloaded).sorted()
         if (sorted.isNotEmpty()) {
           if (sorted.size == 1 || (1 + sorted.last() - sorted.first()) == sorted.size) {
-            downloader.downloadSuras(qari, sorted.first(), sorted.last())
+            downloader.downloadSuras(qari, sorted.first(), sorted.last(), downloadDatabase)
           } else {
             sorted.forEach { downloader.downloadSura(qari, it) }
+            if (downloadDatabase && qariDatabase != null && !qariDatabase.exists()) {
+              downloader.downloadAudioDatabase(qari)
+            }
           }
-        }
-
-        if (downloadDatabase) {
-          val path = qari.databasePath()
-          if (path?.exists() == false) {
+        } else if (downloadDatabase) {
+          if (qariDatabase != null && !qariDatabase.exists()) {
             downloader.downloadAudioDatabase(qari)
           }
         }


### PR DESCRIPTION
Today, the download of consecutive suras happens as a "batch," and the
database is a separate "batch," breaking the dialog and what not. This
fixes it by placing the database download within the consecutive suras
batch.

For non-consecutive suras, each sura is a download "batch," and the
database is also a separate "batch" today. This will change in a future
PR in sha' Allah.
