### PR TITLE
Refactor some of QuranDownloadService

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/service/download/DownloadStrategy.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/service/download/DownloadStrategy.kt
@@ -1,0 +1,6 @@
+package com.quran.labs.androidquran.service.download
+
+interface DownloadStrategy {
+  fun fileCount(): Int
+  fun downloadFiles(): Boolean
+}

--- a/app/src/main/java/com/quran/labs/androidquran/service/download/GaplessDownloadStrategy.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/service/download/GaplessDownloadStrategy.kt
@@ -1,0 +1,62 @@
+package com.quran.labs.androidquran.service.download
+
+import com.quran.data.model.SuraAyah
+import com.quran.labs.androidquran.service.util.QuranDownloadNotifier
+import com.quran.labs.androidquran.service.util.QuranDownloadNotifier.NotificationDetails
+import timber.log.Timber
+import java.io.File
+import java.util.Locale
+
+class GaplessDownloadStrategy(
+  private val startAyah: SuraAyah,
+  private val endAyah: SuraAyah,
+  private val audioUrlFormat: String,
+  private val destination: String,
+  private val notifier: QuranDownloadNotifier,
+  private val details: NotificationDetails,
+  private val databaseUrl: String?,
+  private val downloaderLambda: (String, String, String, NotificationDetails) -> Boolean
+) : DownloadStrategy {
+
+  override fun fileCount(): Int {
+    val lastSura = if (endAyah.ayah == 0) endAyah.sura - 1 else endAyah.sura
+    return (lastSura - startAyah.sura) + if (databaseUrl == null) 0 else 1
+  }
+
+  override fun downloadFiles(): Boolean {
+    val destDir = destination + File.separator
+    File(destDir).mkdirs()
+
+    for (sura in startAyah.sura..endAyah.sura) {
+      details.sura = sura
+      if (sura == endAyah.sura && endAyah.ayah == 0) {
+        continue
+      }
+
+      val url = String.format(Locale.US, audioUrlFormat, sura)
+      Timber.d("gapless asking to download %s to %s", url, destDir)
+      val filename = url.substringAfterLast("/")
+      val file = File(destDir, filename)
+      if (file.exists() || downloaderLambda(url, destDir, filename, details)) {
+        notifier.notifyFileDownloaded(details, filename)
+        details.currentFile++
+      } else {
+        return false
+      }
+    }
+
+    // download the database if requested
+    if (databaseUrl != null) {
+      Timber.d("gapless downloading database %s to %s", databaseUrl, destDir);
+      val filename = databaseUrl.substringAfterLast("/")
+      val file = File(destDir, filename)
+      return if (file.exists() || downloaderLambda(databaseUrl, destDir, filename, details)) {
+        notifier.notifyFileDownloaded(details, filename)
+        true
+      } else {
+        false
+      }
+    }
+    return true
+  }
+}

--- a/app/src/main/java/com/quran/labs/androidquran/service/download/GappedDownloadStrategy.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/service/download/GappedDownloadStrategy.kt
@@ -1,0 +1,70 @@
+package com.quran.labs.androidquran.service.download
+
+import com.quran.data.core.QuranInfo
+import com.quran.data.model.SuraAyah
+import com.quran.labs.androidquran.service.util.QuranDownloadNotifier
+import com.quran.labs.androidquran.service.util.QuranDownloadNotifier.NotificationDetails
+import java.io.File
+import java.util.Locale
+
+class GappedDownloadStrategy(
+  private val startAyah: SuraAyah,
+  private val endAyah: SuraAyah,
+  private val audioUrlFormat: String,
+  private val quranInfo: QuranInfo,
+  private val destination: String,
+  private val notifier: QuranDownloadNotifier,
+  private val details: NotificationDetails,
+  private val downloaderLambda: (String, String, String, NotificationDetails) -> Boolean
+) : DownloadStrategy {
+
+  override fun fileCount(): Int {
+    return if (startAyah.sura == endAyah.sura) {
+      endAyah.ayah - startAyah.ayah + 1
+    } else {
+      val ayatInMiddleSuras = ((startAyah.sura + 1)..<endAyah.sura)
+        .sumOf { quranInfo.getNumberOfAyahs(it) }
+      val ayatInStartAyah = quranInfo.getNumberOfAyahs(startAyah.sura) - startAyah.ayah + 1
+      ayatInStartAyah + ayatInMiddleSuras + endAyah.ayah
+    } + 1 // always add 1 for basmallah, even if we don't need it for this play range
+  }
+
+  override fun downloadFiles(): Boolean {
+    val extension = audioUrlFormat.substringAfterLast(".")
+    for (sura in startAyah.sura..endAyah.sura) {
+      details.sura = sura
+      val ayahStart = if (sura == startAyah.sura) startAyah.ayah else 1
+      val ayahEnd = if (sura == endAyah.sura) endAyah.ayah else quranInfo.getNumberOfAyahs(sura)
+
+      val destDir = destination + File.separator + sura + File.separator
+      File(destDir).mkdirs()
+      for (ayah in ayahStart..ayahEnd) {
+        details.ayah = ayah
+        val url = audioUrlFormat.format(Locale.US, sura, ayah)
+        val filename = "$ayah$extension"
+        val file = File(destDir, filename)
+        if (file.exists() || downloaderLambda(url, destDir, filename, details)) {
+          notifier.notifyFileDownloaded(details, filename)
+          details.currentFile++
+        } else {
+          return false
+        }
+      }
+    }
+
+
+    // attempt to download basmallah if it doesn't exist
+    val destDir = destination + File.separator + 1 + File.separator
+    File(destDir).mkdirs()
+    val basmallah = File(destDir, "1$extension")
+    val url = audioUrlFormat.format(Locale.US, 1, 1)
+    val destFile = "1$extension"
+    return if (basmallah.exists() || downloaderLambda(url, destDir, destFile, details)) {
+      notifier.notifyFileDownloaded(details, "1$extension")
+      details.currentFile++
+      true
+    } else {
+      false
+    }
+  }
+}

--- a/app/src/main/java/com/quran/labs/androidquran/service/download/SingleFileDownloadStrategy.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/service/download/SingleFileDownloadStrategy.kt
@@ -1,0 +1,30 @@
+package com.quran.labs.androidquran.service.download
+
+import com.quran.labs.androidquran.service.util.QuranDownloadNotifier
+import com.quran.labs.androidquran.service.util.QuranDownloadNotifier.NotificationDetails
+import timber.log.Timber
+import java.io.File
+
+class SingleFileDownloadStrategy(
+  private val urlString: String,
+  private val destination: String,
+  private val outputFile: String,
+  private val details: NotificationDetails,
+  private val notifier: QuranDownloadNotifier,
+  private val downloaderLambda: (String, String, String, NotificationDetails) -> Boolean
+) : DownloadStrategy {
+  override fun fileCount(): Int = 1
+
+  override fun downloadFiles(): Boolean {
+    File(destination).mkdirs()
+    Timber.d("made directory %s", destination)
+    return if (File(destination, outputFile).exists() ||
+      downloaderLambda(urlString, destination, outputFile, details)
+    ) {
+      notifier.notifyFileDownloaded(details, outputFile);
+      true
+    } else {
+      false
+    }
+  }
+}


### PR DESCRIPTION
Replace code within the service with code in a separate class, split by
the type. This will make it easier to add "batches" to replace the
current way download manager downloads non-ranged downloads in the
future. It can also enable some testing of this logic in the future
as well in sha' Allah.
