### PR TITLE
Add BatchDownloadStrategy

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/service/download/BatchDownloadStrategy.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/service/download/BatchDownloadStrategy.kt
@@ -1,0 +1,66 @@
+package com.quran.labs.androidquran.service.download
+
+import com.quran.data.core.QuranInfo
+import com.quran.data.model.SuraAyah
+import com.quran.labs.androidquran.service.util.QuranDownloadNotifier
+import com.quran.labs.androidquran.service.util.QuranDownloadNotifier.NotificationDetails
+
+class BatchDownloadStrategy(
+  private val audioUrlFormat: String,
+  private val destination: String,
+  private val isGapless: Boolean,
+  private val quranInfo: QuranInfo,
+  private val notifier: QuranDownloadNotifier,
+  private val details: NotificationDetails,
+  private val batch: IntArray,
+  private val databaseUrl: String?,
+  private val downloaderLambda: (String, String, String, NotificationDetails) -> Boolean
+) : DownloadStrategy {
+
+  private val listStrategies: List<DownloadStrategy> by lazy {
+    buildList {
+      batch.forEachIndexed { index, sura ->
+        add(strategyFor(sura, index == 0))
+      }
+    }
+  }
+
+  override fun fileCount(): Int {
+    // unfortunately, we'll try to download the basmallah for each sura
+    // when gapped, but the file check will stop us from actually hitting
+    // the server.
+    return listStrategies.sumOf { it.fileCount() }
+  }
+
+  override fun downloadFiles(): Boolean {
+    return listStrategies.all { it.downloadFiles() }
+  }
+
+  private fun strategyFor(sura: Int, isFirst: Boolean): DownloadStrategy {
+    val start = SuraAyah(sura, 1)
+    val end = SuraAyah(sura, quranInfo.getNumberOfAyahs(sura))
+    return if (isGapless) {
+      GaplessDownloadStrategy(
+        start,
+        end,
+        audioUrlFormat,
+        destination,
+        notifier,
+        details,
+        if (isFirst) databaseUrl else null,
+        downloaderLambda
+      )
+    } else {
+      GappedDownloadStrategy(
+        start,
+        end,
+        audioUrlFormat,
+        quranInfo,
+        destination,
+        notifier,
+        details,
+        downloaderLambda
+      )
+    }
+  }
+}

--- a/common/download/src/main/java/com/quran/mobile/common/download/Downloader.kt
+++ b/common/download/src/main/java/com/quran/mobile/common/download/Downloader.kt
@@ -3,7 +3,7 @@ package com.quran.mobile.common.download
 import com.quran.data.model.audio.Qari
 
 interface Downloader {
-  fun downloadSura(qari: Qari, sura: Int)
+  fun downloadBatchSuras(qari: Qari, suras: List<Int>, downloadDatabase: Boolean)
   fun downloadSuras(qari: Qari, startSura: Int, endSura: Int, downloadDatabase: Boolean)
   fun downloadAudioDatabase(qari: Qari)
   fun cancelDownloads()

--- a/feature/downloadmanager/src/main/kotlin/com/quran/mobile/feature/downloadmanager/presenter/SheikhAudioPresenter.kt
+++ b/feature/downloadmanager/src/main/kotlin/com/quran/mobile/feature/downloadmanager/presenter/SheikhAudioPresenter.kt
@@ -157,12 +157,10 @@ class SheikhAudioPresenter @Inject constructor(
         val sorted = (suras - alreadyDownloaded).sorted()
         if (sorted.isNotEmpty()) {
           if (sorted.size == 1 || (1 + sorted.last() - sorted.first()) == sorted.size) {
+            // if we're downloading "a consecutive range" this is slightly more efficient
             downloader.downloadSuras(qari, sorted.first(), sorted.last(), downloadDatabase)
           } else {
-            sorted.forEach { downloader.downloadSura(qari, it) }
-            if (downloadDatabase && qariDatabase != null && !qariDatabase.exists()) {
-              downloader.downloadAudioDatabase(qari)
-            }
+            downloader.downloadBatchSuras(qari, sorted, downloadDatabase)
           }
         } else if (downloadDatabase) {
           if (qariDatabase != null && !qariDatabase.exists()) {


### PR DESCRIPTION
This is a not very efficient download strategy to download a batch of
non-consecutive suras. It does many more allocations compared to the
consecutive downloaders, but is still significantly more efficient than
the previous version of n disparate download requests. In a future
commit, this will be improved in sha' Allah.
