### PR TITLE
Remove kapt in favor of only using Ksp

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -5,7 +5,6 @@ import java.util.Locale
 
 plugins {
   id("quran.android.application")
-  alias(libs.plugins.kotlin.kapt)
   alias(libs.plugins.kotlin.parcelize)
   alias(libs.plugins.ksp)
   alias(libs.plugins.errorprone)
@@ -70,12 +69,13 @@ android {
       proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard.cfg")
       signingConfig = signingConfigs.getByName("release")
       versionNameSuffix = "-beta"
-      matchingFallbacks += listOf("debug")
+      matchingFallbacks += listOf("debug", "release")
     }
 
     getByName("debug") {
       applicationIdSuffix = ".debug"
       versionNameSuffix = "-debug"
+      matchingFallbacks += "release"
     }
 
     getByName("release") {
@@ -186,8 +186,8 @@ dependencies {
   implementation(libs.rxandroid)
 
   // dagger
-  kapt(libs.dagger.compiler)
-  kaptTest(libs.dagger.compiler)
+  ksp(libs.dagger.compiler)
+  kspTest(libs.dagger.compiler)
   implementation(libs.dagger.runtime)
 
   // workmanager

--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -8,6 +8,8 @@ dependencies {
   compileOnly(libs.android.gradlePlugin)
   compileOnly(libs.kotlin.gradlePlugin)
   compileOnly(libs.compose.compiler.gradlePlugin)
+  compileOnly(libs.sqldelight.gradlePlugin)
+  compileOnly(libs.ksp.gradlePlugin)
   implementation(files(libs.javaClass.superclass.protectionDomain.codeSource.location))
 }
 

--- a/build-logic/convention/src/main/kotlin/AndroidLibraryComposeConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidLibraryComposeConventionPlugin.kt
@@ -2,8 +2,10 @@ import com.android.build.gradle.LibraryExtension
 import com.quran.labs.androidquran.buildutil.applyAndroidCommon
 import com.quran.labs.androidquran.buildutil.applyBoms
 import com.quran.labs.androidquran.buildutil.applyComposeCommon
+import com.quran.labs.androidquran.buildutil.applyDaggerAnvilCommon
 import com.quran.labs.androidquran.buildutil.applyJavaCommon
 import com.quran.labs.androidquran.buildutil.applyKotlinCommon
+import com.quran.labs.androidquran.buildutil.disableDebugVariant
 import com.quran.labs.androidquran.buildutil.withLibraries
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -24,11 +26,13 @@ class AndroidLibraryComposeConventionPlugin : Plugin<Project> {
       extensions.configure<LibraryExtension> {
         applyAndroidCommon(target)
         applyComposeCommon(target)
+        disableDebugVariant()
       }
 
       applyJavaCommon()
       applyKotlinCommon()
       applyBoms()
+      applyDaggerAnvilCommon()
     }
   }
 }

--- a/build-logic/convention/src/main/kotlin/AndroidLibraryConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidLibraryConventionPlugin.kt
@@ -1,8 +1,10 @@
 import com.android.build.gradle.LibraryExtension
 import com.quran.labs.androidquran.buildutil.applyAndroidCommon
 import com.quran.labs.androidquran.buildutil.applyBoms
+import com.quran.labs.androidquran.buildutil.applyDaggerAnvilCommon
 import com.quran.labs.androidquran.buildutil.applyJavaCommon
 import com.quran.labs.androidquran.buildutil.applyKotlinCommon
+import com.quran.labs.androidquran.buildutil.disableDebugVariant
 import com.quran.labs.androidquran.buildutil.withLibraries
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -21,11 +23,13 @@ class AndroidLibraryConventionPlugin : Plugin<Project> {
 
       extensions.configure<LibraryExtension> {
         applyAndroidCommon(target)
+        disableDebugVariant()
       }
 
       applyJavaCommon()
       applyKotlinCommon()
       applyBoms()
+      applyDaggerAnvilCommon()
     }
   }
 }

--- a/build-logic/convention/src/main/kotlin/com/quran/labs/androidquran/buildutil/AndroidLibraryCommon.kt
+++ b/build-logic/convention/src/main/kotlin/com/quran/labs/androidquran/buildutil/AndroidLibraryCommon.kt
@@ -1,0 +1,14 @@
+package com.quran.labs.androidquran.buildutil
+
+import com.android.build.api.variant.AndroidComponentsExtension
+import org.gradle.api.Project
+
+// Disable the debug build type for libraries
+fun Project.disableDebugVariant() {
+  val androidComponents = project.extensions.getByType(AndroidComponentsExtension::class.java)
+  androidComponents.beforeVariants {
+    if (it.buildType == "debug") {
+      it.enable = false
+    }
+  }
+}

--- a/build-logic/convention/src/main/kotlin/com/quran/labs/androidquran/buildutil/ComposeCommon.kt
+++ b/build-logic/convention/src/main/kotlin/com/quran/labs/androidquran/buildutil/ComposeCommon.kt
@@ -16,8 +16,10 @@ fun CommonExtension<*, *, *, *, *, *>.applyComposeCommon(project: Project) {
   }
 
   project.extensions.configure<ComposeCompilerGradlePluginExtension> {
-    // https://issuetracker.google.com/issues/338842143
+    // manually enable source info until this is fixed:
+    // https://issuetracker.google.com/issues/362780328
     includeSourceInformation.set(true)
+
     if (project.findProperty("composeCompilerReports") == "true") {
       reportsDestination.set(project.layout.buildDirectory.get().asFile.resolve("compose_compiler"))
       metricsDestination.set(project.layout.buildDirectory.get().asFile.resolve("compose_compiler"))

--- a/build-logic/convention/src/main/kotlin/com/quran/labs/androidquran/buildutil/DaggerAnvilCommon.kt
+++ b/build-logic/convention/src/main/kotlin/com/quran/labs/androidquran/buildutil/DaggerAnvilCommon.kt
@@ -1,0 +1,59 @@
+package com.quran.labs.androidquran.buildutil
+
+import app.cash.sqldelight.gradle.SqlDelightExtension
+import app.cash.sqldelight.gradle.SqlDelightTask
+import com.google.devtools.ksp.gradle.KspAATask
+import com.google.devtools.ksp.gradle.KspExtension
+import com.google.devtools.ksp.gradle.KspTaskJvm
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.getByType
+import org.gradle.kotlin.dsl.named
+
+fun Project.applyDaggerAnvilCommon() {
+  kspAfterSqlDelight()
+  if (pluginManager.hasPlugin("com.google.devtools.ksp")) {
+    extensions.getByType<KspExtension>().apply {
+      arg("dagger.ignoreProvisionKeyWildcards", "enabled")
+      arg("dagger.experimentalDaggerErrorMessages", "enabled")
+      arg("dagger.warnIfInjectionFactoryNotGeneratedUpstream", "enabled")
+      arg("dagger.fastInit", "enabled")
+    }
+  }
+}
+
+private fun Project.kspAfterSqlDelight() {
+  // make KSP depend on SqlDelight task
+  // https://github.com/slackhq/slack-gradle-plugin/blob/a69a630e2971c98eb5db29ea800c87ae167eb9fb/slack-plugin/src/main/kotlin/slack/gradle/SlackExtension.kt#L238
+  project.afterEvaluate {
+    afterEvaluate {
+      if (pluginManager.hasPlugin("app.cash.sqldelight")) {
+        val dbNames =
+          extensions.getByType<SqlDelightExtension>().databases.names
+
+        val sourceSet = "Release" // "CommonMain" if using KMP some day
+        val sourceSetKspName = "Release" // "CommonMainMetadata" if using KMP some day
+        for (dbName in dbNames) {
+          val sqlDelightTask =
+            tasks.named<SqlDelightTask>("generate${sourceSet}${dbName}Interface")
+          val outputProvider = sqlDelightTask.flatMap { it.outputDirectory }
+
+          tasks
+            .named { it == "ksp${sourceSetKspName}Kotlin" }
+            .configureEach {
+              when (this) {
+                is KspTaskJvm -> {
+                  source(outputProvider)
+                  dependsOn(sqlDelightTask)
+                }
+
+                is KspAATask -> {
+                  kspConfig.javaSourceRoots.from(outputProvider)
+                  dependsOn(sqlDelightTask)
+                }
+              }
+            }
+        }
+      }
+    }
+  }
+}

--- a/build-logic/convention/src/main/kotlin/com/quran/labs/androidquran/buildutil/KotlinCommon.kt
+++ b/build-logic/convention/src/main/kotlin/com/quran/labs/androidquran/buildutil/KotlinCommon.kt
@@ -1,10 +1,8 @@
 package com.quran.labs.androidquran.buildutil
 
 import org.gradle.api.Project
-import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.withType
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-import org.jetbrains.kotlin.gradle.plugin.KaptExtension
 
 fun Project.applyKotlinCommon() {
 
@@ -15,17 +13,6 @@ fun Project.applyKotlinCommon() {
         "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi",
         "-Xjvm-default=all"
       )
-    }
-  }
-
-  pluginManager.withPlugin("org.jetbrains.kotlin.kapt") {
-    extensions.configure<KaptExtension> {
-      arguments {
-        arg("dagger.ignoreProvisionKeyWildcards", "enabled")
-        arg("dagger.experimentalDaggerErrorMessages", "enabled")
-        arg("dagger.warnIfInjectionFactoryNotGeneratedUpstream", "enabled")
-        arg("dagger.fastInit", "enabled")
-      }
     }
   }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,6 @@ plugins {
   alias(libs.plugins.android.library) apply false
   alias(libs.plugins.crashlytics) apply false
   alias(libs.plugins.kotlin.android) apply false
-  alias(libs.plugins.kotlin.kapt) apply false
   alias(libs.plugins.kotlin.parcelize) apply false
   alias(libs.plugins.compose.compiler) apply false
   alias(libs.plugins.ksp) apply false

--- a/common/bookmark/build.gradle.kts
+++ b/common/bookmark/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
   id("quran.android.library.android")
-  id("app.cash.sqldelight")
+  alias(libs.plugins.sqldelight)
   alias(libs.plugins.anvil)
 }
 

--- a/common/mapper/build.gradle.kts
+++ b/common/mapper/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
   id("quran.android.library.android")
-  id("com.squareup.anvil")
+  alias(libs.plugins.anvil)
 }
 
 anvil {

--- a/common/translation/build.gradle.kts
+++ b/common/translation/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
-   id("quran.android.library.android")
-   id("app.cash.sqldelight")
-   id("com.squareup.anvil")
+  id("quran.android.library.android")
+  alias(libs.plugins.sqldelight)
+  alias(libs.plugins.anvil)
 }
 
 anvil {

--- a/feature/audio/build.gradle
+++ b/feature/audio/build.gradle
@@ -7,11 +7,6 @@ android {
   namespace 'com.quran.labs.androidquran.feature.audio'
 
   buildTypes {
-     beta {
-       consumerProguardFiles 'proguard.cfg'
-       matchingFallbacks = ['debug']
-     }
-
      release {
        consumerProguardFiles 'proguard.cfg'
      }

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,8 +7,7 @@ org.gradle.caching=true
 android.useAndroidX=true
 
 # kotlin 2.0
-kapt.use.k2=true
-ksp.useKSP2=true
+ksp.useKSP2=false
 android.lint.useK2Uast=true
 
 # optimize resources

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,7 +8,7 @@ composeBomVersion = "2024.08.00"
 okhttpBomVersion = "4.12.0"
 
 # dependencies
-anvil = "0.2.6"
+anvil = "0.3.0"
 coroutinesVersion = "1.8.1"
 crashlytics = "3.0.2"
 daggerVersion = "2.52"
@@ -181,12 +181,14 @@ kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-t
 android-gradlePlugin = { group = "com.android.tools.build", name = "gradle", version.ref = "agp" }
 kotlin-gradlePlugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin" }
 compose-compiler-gradlePlugin = { module = "org.jetbrains.kotlin:compose-compiler-gradle-plugin", version.ref = "kotlin" }
+sqldelight-gradlePlugin = { module = "app.cash.sqldelight:gradle-plugin", version.ref = "sqldelight" }
+ksp-gradlePlugin = { module = "com.google.devtools.ksp:symbol-processing-gradle-plugin", version.ref = "ksp" }
+
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 android-library = { id = "com.android.library", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
-kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
 kotlin-parcelize = { id = "org.jetbrains.kotlin.plugin.parcelize", version.ref = "kotlin" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }


### PR DESCRIPTION
Use Ksp for Dagger (therefore using ksp1). This requires wiring up
KSP to depend on SqlDelight tasks, since, otherwise, it won't work.
