### PR TITLE
Don't override material3 version anymore

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -102,7 +102,7 @@ androidx-window = { module = "androidx.window:window", version.ref = "androidxWi
 compose-foundation = { module = "androidx.compose.foundation:foundation" }
 compose-animation = { module = "androidx.compose.animation:animation" }
 compose-material = { module = "androidx.compose.material:material" }
-compose-material3 = { module = "androidx.compose.material3:material3", version = "1.2.1" }
+compose-material3 = { module = "androidx.compose.material3:material3" }
 compose-material-icons = { module = "androidx.compose.material:material-icons-extended" }
 compose-runtime = { module = "androidx.compose.runtime:runtime" }
 compose-ui = { module = "androidx.compose.ui:ui" }


### PR DESCRIPTION
The version in the BOM is the version we're using, so stop overriding
the version.
