### PR TITLE
Update compile and target sdk to 35

### DIFF
--- a/app/src/test/java/com/quran/labs/androidquran/ui/QuranActivityTest.kt
+++ b/app/src/test/java/com/quran/labs/androidquran/ui/QuranActivityTest.kt
@@ -18,7 +18,7 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 
 
-@Config(application = TestApplication::class)
+@Config(application = TestApplication::class, sdk = [33])
 @RunWith(RobolectricTestRunner::class)
 class QuranActivityTest {
   @get:Rule

--- a/app/src/test/java/com/quran/labs/androidquran/ui/ShortcutsActivityTest.kt
+++ b/app/src/test/java/com/quran/labs/androidquran/ui/ShortcutsActivityTest.kt
@@ -17,7 +17,7 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 
-@Config(application = TestApplication::class)
+@Config(application = TestApplication::class, sdk = [33])
 @RunWith(RobolectricTestRunner::class)
 class ShortcutsActivityTest {
 

--- a/build-logic/convention/src/main/kotlin/AndroidApplicationConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidApplicationConventionPlugin.kt
@@ -24,7 +24,7 @@ class AndroidApplicationConventionPlugin : Plugin<Project> {
       extensions.configure<ApplicationExtension> {
         applyAndroidCommon(target)
         applyComposeCommon(target)
-        defaultConfig.targetSdk = 34
+        defaultConfig.targetSdk = 35
       }
 
       applyJavaCommon()

--- a/build-logic/convention/src/main/kotlin/com/quran/labs/androidquran/buildutil/AndroidCommon.kt
+++ b/build-logic/convention/src/main/kotlin/com/quran/labs/androidquran/buildutil/AndroidCommon.kt
@@ -5,7 +5,7 @@ import org.gradle.api.JavaVersion
 import org.gradle.api.Project
 
 fun CommonExtension<*, *, *, *, *, *>.applyAndroidCommon(project: Project) {
-  compileSdk = 34
+  compileSdk = 35
   defaultConfig.minSdk = 21
 
   compileOptions {


### PR DESCRIPTION
The app now supports edge to edge, and, after a walkthrough of the
changes in Android 15, it seems like it is safe to target Android 35
now.
