### PR TITLE
refactor: reorder step of build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,9 +27,6 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
 
-      - name: Build debug APK
-        run: ./gradlew assembleMadaniDebug
-
       - name: Run lint
         run: ./gradlew lintMadaniDebug
 
@@ -52,6 +49,9 @@ jobs:
         with:
           name: unit_test_report
           path: app/build/reports/tests/testMadaniDebugUnitTest/
+
+      - name: Build debug APK
+        run: ./gradlew assembleMadaniDebug
 
       - name: Download Previous Debug APK
         uses: dawidd6/action-download-artifact@v6


### PR DESCRIPTION
If PR has issues related to lint or test, so after fix we will run build step again with new push event, so I see we can postpone build step which take time and resources until we make sure PR is fine as code quality checks.