### PR TITLE
Make some improvements to Arabic search

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/data/QuranDataProvider.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/data/QuranDataProvider.kt
@@ -200,7 +200,7 @@ class QuranDataProvider : ContentProvider() {
 
   private fun search(query: String, databaseName: String, wantSnippets: Boolean): Cursor? {
     val handler = getDatabaseHandler(context!!, databaseName, quranFileUtils)
-    return handler.search(query, wantSnippets, QURAN_ARABIC_DATABASE == databaseName)
+    return handler.search(query.trim(), wantSnippets, QURAN_ARABIC_DATABASE == databaseName)
   }
 
   override fun getType(uri: Uri): String? {

--- a/common/search/src/main/java/com/quran/common/search/arabic/ArabicCharacterHelper.kt
+++ b/common/search/src/main/java/com/quran/common/search/arabic/ArabicCharacterHelper.kt
@@ -13,11 +13,11 @@ object ArabicCharacterHelper {
 
       // given: ﺃ
       // match: ﺃﺀﺆﺋ
-      "\u0623" to "\u0621\u0623\u0624\u0626",
+      "\u0623" to "\u0621\u0623\u0624\u0626\u0627",
 
       // given: ﺀ
       // match: ﺀﺃﺆ
-      "\u0621" to "\u0621\u0623\u0624\u0626",
+      "\u0621" to "\u0621\u0623\u0624\u0626\u0627",
 
       // given: ﺕ
       // match: ﺕﺓ


### PR DESCRIPTION
This patch makes some improvements to Arabic search. It matches some
additional matches for alif and hamza, and, more importantly, it removes
the limit for suggestions (it used to only search the first 250 ayat
during suggestions mode) in order to give people results that are more
likely to be expected.
