### PR TITLE
Update the height of the header and footer

### DIFF
--- a/common/linebyline/ui/src/main/java/com/quran/mobile/linebyline/ui/renderer/calculator/QuranPageCalculator.kt
+++ b/common/linebyline/ui/src/main/java/com/quran/mobile/linebyline/ui/renderer/calculator/QuranPageCalculator.kt
@@ -35,7 +35,7 @@ class QuranPageCalculator : PageCalculator {
   }
 
   companion object {
-    private const val headerFooterHeightRatio = 0.03f
+    private const val headerFooterHeightRatio = 0.04f
     private const val quranImageMinWidthToHeightRatio = 1 / 1.60f
     private const val quranImageMaxWidthToHeightRatio = 1 / 1.84f
     private const val headerFooterMarginRatio = 0.027f


### PR DESCRIPTION
This patch updates the height of the header and footer for line by line
pages since the text ends up being cut on some devices.
