### PR TITLE
Use -PdisableFirebase to build a non-Firebase build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
         run: ./gradlew verifySqlDelightMigration
 
       - name: Run tests
-        run: ./gradlew testMadaniDebug -PdisableCrashlytics -PdisableFirebase
+        run: ./gradlew testMadaniDebug -PdisableFirebase
 
       - name: Upload test report
         uses: actions/upload-artifact@v4

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -11,8 +11,7 @@ plugins {
 
 // whether or not to use Firebase - Firebase is enabled by default, and is only disabled for
 // providing apks for open source distribution stores.
-val useFirebase = !project.hasProperty("disableFirebase") &&
-    !project.hasProperty("disableCrashlytics")
+val useFirebase = !project.hasProperty("disableFirebase")
 
 // only want to apply the Firebase plugin if we're building a release build. moving this to the
 // release build type won't work, since debug builds would also implicitly get the plugin.


### PR DESCRIPTION
The two flags, -PdisableCrashlytics and -PdisableFirebase are the same,
so consolidate to one flag to avoid confusion.
