### PR TITLE
Fix toolbar text getting cut in Arabic

### DIFF
--- a/app/src/main/res/layout/quran_page_activity.xml
+++ b/app/src/main/res/layout/quran_page_activity.xml
@@ -32,6 +32,8 @@
         android:layout_height="?attr/actionBarSize"
         android:theme="@style/ToolbarStyle"
         app:popupTheme="@style/ThemeOverlay.AppCompat.Dark"
+        app:titleTextAppearance="@style/ToolbarTitleText"
+        app:subtitleTextAppearance="@style/ToolbarSubtitleText"
         android:elevation="4dp"
         >
       <com.quran.labs.androidquran.view.QuranSpinner

--- a/app/src/main/res/values-ar-v35/styles.xml
+++ b/app/src/main/res/values-ar-v35/styles.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <style name="ToolbarTitleText" parent="TextAppearance.Widget.AppCompat.Toolbar.Title">
+    <!-- 22sp in m3 -->
+    <item name="android:textSize">18sp</item>
+  </style>
+
+  <style name="ToolbarSubtitleText" parent="TextAppearance.Widget.AppCompat.Toolbar.Subtitle">
+    <!-- 16sp in m3 -->
+    <item name="android:textSize">14sp</item>
+  </style>
+</resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -16,6 +16,9 @@
     <item name="android:textColorSecondary">@color/toolbar_secondary_text</item>
   </style>
 
+  <style name="ToolbarTitleText" parent="TextAppearance.Widget.AppCompat.Toolbar.Title" />
+  <style name="ToolbarSubtitleText" parent="TextAppearance.Widget.AppCompat.Toolbar.Subtitle" />
+
     <style name="NotificationText"
         parent="android:TextAppearance.StatusBar.EventContent" />
 


### PR DESCRIPTION
The toolbar text is too large on Android 35 and above, causing it to cut
the subtitle. This works fine in English, and works fine in Arabic on
Android 34 and below, so modify it only for 35 and above to use
smaller title and subtitle sizes.
