### PR TITLE
Don't trim search query

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/data/QuranDataProvider.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/data/QuranDataProvider.kt
@@ -200,7 +200,7 @@ class QuranDataProvider : ContentProvider() {
 
   private fun search(query: String, databaseName: String, wantSnippets: Boolean): Cursor? {
     val handler = getDatabaseHandler(context!!, databaseName, quranFileUtils)
-    return handler.search(query.trim(), wantSnippets, QURAN_ARABIC_DATABASE == databaseName)
+    return handler.search(query, wantSnippets, QURAN_ARABIC_DATABASE == databaseName)
   }
 
   override fun getType(uri: Uri): String? {


### PR DESCRIPTION
The search query wasn't being trimmed before, and it seems better since
it saves us from results in the middle of a word if a space is pressed.
