### PR TITLE
Fix incorrect toolbar position

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/ui/PagerActivity.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/PagerActivity.kt
@@ -451,6 +451,10 @@ class PagerActivity : AppCompatActivity(), AudioBarListener, OnBookmarkTagsUpdat
     }
 
     val toolbar = findViewById<Toolbar>(R.id.toolbar)
+    if (quranSettings.isArabicNames || QuranUtils.isRtl()) {
+      // remove when we remove LTR from quran_page_activity's root
+      ViewCompat.setLayoutDirection(toolbar, ViewCompat.LAYOUT_DIRECTION_RTL)
+    }
     setSupportActionBar(toolbar)
 
     supportActionBar?.setDisplayShowHomeEnabled(true)

--- a/app/src/main/res/layout/quran_page_activity.xml
+++ b/app/src/main/res/layout/quran_page_activity.xml
@@ -5,6 +5,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:keepScreenOn="true"
+    android:layoutDirection="ltr"
     >
 
   <androidx.viewpager.widget.NonRestoringViewPager


### PR DESCRIPTION
This patch fixes a regression introduced during the migration to support
edge to edge in 8d7f9f749d34c078ff77af080e3bdcc55a09919a. This isn't an
ideal fix, but it's the same as the code has been before. In the future,
we should remove the forced LTR on the root RelativeLayout and the
corresponding switch back to RTL of the toolbar.

Note that the marker isn't ideal for some ayat, but this was also the
case before the update, so it should be fixed separately in sha' Allah.

Fixes #2985.
