### PR TITLE
Remove right to left hack on root layout

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/ui/PagerActivity.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/PagerActivity.kt
@@ -455,10 +455,6 @@ class PagerActivity : AppCompatActivity(), AudioBarListener, OnBookmarkTagsUpdat
     }
 
     val toolbar = findViewById<Toolbar>(R.id.toolbar)
-    if (quranSettings.isArabicNames || QuranUtils.isRtl()) {
-      // remove when we remove LTR from quran_page_activity's root
-      ViewCompat.setLayoutDirection(toolbar, ViewCompat.LAYOUT_DIRECTION_RTL)
-    }
     setSupportActionBar(toolbar)
 
     supportActionBar?.setDisplayShowHomeEnabled(true)

--- a/app/src/main/java/com/quran/labs/androidquran/view/SlidingUpPanelLayout.java
+++ b/app/src/main/java/com/quran/labs/androidquran/view/SlidingUpPanelLayout.java
@@ -43,10 +43,6 @@ import android.graphics.drawable.Drawable;
 import android.os.Build;
 import android.os.Parcel;
 import android.os.Parcelable;
-import androidx.core.content.ContextCompat;
-import androidx.core.view.MotionEventCompat;
-import androidx.core.view.ViewCompat;
-import androidx.customview.widget.ViewDragHelper;
 import android.util.AttributeSet;
 import android.view.Gravity;
 import android.view.MotionEvent;
@@ -56,9 +52,12 @@ import android.view.ViewConfiguration;
 import android.view.ViewGroup;
 import android.view.accessibility.AccessibilityEvent;
 
-import com.quran.labs.androidquran.R;
+import androidx.core.content.ContextCompat;
+import androidx.core.view.MotionEventCompat;
+import androidx.core.view.ViewCompat;
+import androidx.customview.widget.ViewDragHelper;
 
-import timber.log.Timber;
+import com.quran.labs.androidquran.R;
 
 public class SlidingUpPanelLayout extends ViewGroup {
 
@@ -591,7 +590,7 @@ public class SlidingUpPanelLayout extends ViewGroup {
     final int childCount = getChildCount();
 
     if (childCount > 2) {
-      Timber.e("onMeasure: More than two child views are not supported.");
+      // Timber.e("onMeasure: More than two child views are not supported.");
     } else if (getChildAt(1).getVisibility() == GONE) {
       panelHeight = 0;
     }

--- a/app/src/main/res/layout/quran_page_activity.xml
+++ b/app/src/main/res/layout/quran_page_activity.xml
@@ -5,7 +5,6 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:keepScreenOn="true"
-    android:layoutDirection="ltr"
     >
 
   <androidx.viewpager.widget.NonRestoringViewPager


### PR DESCRIPTION
Previously, in order to ensure the ayah toolbar was set properly, a hack
was in place to always ensure that the root RelativeLayout is LTR.
Removing this hack broke the ayah toolbar position. Adding it back,
however, broke the proper directionality of the audio bar.

This patch finally removes this hack and properly calculates the
position in RTL. Consequently, it fixes the audio bar directionality.
