### PR TITLE
Fix many more toolbar issues

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/ui/PagerActivity.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/PagerActivity.kt
@@ -35,6 +35,7 @@ import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
+import androidx.core.view.marginEnd
 import androidx.core.view.updatePadding
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
@@ -481,6 +482,16 @@ class PagerActivity : AppCompatActivity(), AudioBarListener, OnBookmarkTagsUpdat
     ayahToolBar.flavor = BuildConfig.FLAVOR
     ayahToolBar.longPressLambda = { charSequence: CharSequence? ->
       makeText(this@PagerActivity, charSequence!!, Toast.LENGTH_SHORT).show()
+    }
+
+    ViewCompat.setOnApplyWindowInsetsListener(ayahToolBar) { view, windowInsets ->
+      val insets = windowInsets.getInsets(
+        WindowInsetsCompat.Type.statusBars() or
+            WindowInsetsCompat.Type.displayCutout() or
+            WindowInsetsCompat.Type.navigationBars()
+      )
+      ayahToolBar.insets = insets
+      windowInsets
     }
 
     val nonRestoringViewPager = findViewById<NonRestoringViewPager>(R.id.quran_pager)


### PR DESCRIPTION
After the last PR to fix some RTL toolbar issues, there were other
issues that were missed. For example, in landscape RTL, the toolbar was
broken. Moreover, it was broken for translations. This patch ensures
that the toolbar is well behaved in RTL and LTR in portrait and
landscape and in translation mode and normal mode (including on tablet
with dual screen and split screen modes).

The remaining issues not addressed by this PR are:

1. in landscape, when the toolbar is visible in translation mode and a
long press happens on an ayah, the y value is incorrectly lower than
the ayah box.

2. in tablet split screen mode, long pressing a translation and then
scrolling the translation down does not move the toolbar down.

Refs #2993.
