### PR TITLE
Fix the toolbar y position in landscape

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/ui/translation/SpacerDecoration.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/translation/SpacerDecoration.kt
@@ -1,0 +1,35 @@
+package com.quran.labs.androidquran.ui.translation
+
+import android.graphics.Rect
+import android.view.View
+import androidx.recyclerview.widget.RecyclerView
+
+class SpacerDecoration(
+  private var top: Int,
+  private var bottom: Int
+) : RecyclerView.ItemDecoration() {
+
+  fun setOffsets(top: Int, bottom: Int): Boolean {
+    return if (this.top != top || this.bottom != bottom) {
+      this.top = top
+      this.bottom = bottom
+      true
+    } else {
+      false
+    }
+  }
+
+  override fun getItemOffsets(
+    outRect: Rect,
+    view: View,
+    parent: RecyclerView,
+    state: RecyclerView.State
+  ) {
+    val adapter = parent.adapter ?: return
+    when (parent.getChildAdapterPosition(view)) {
+      0 -> outRect.top = top
+      adapter.itemCount - 1 -> outRect.bottom = bottom
+      else -> outRect.set(0, 0, 0, 0)
+    }
+  }
+}

--- a/app/src/main/java/com/quran/labs/androidquran/ui/translation/TranslationView.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/translation/TranslationView.java
@@ -9,12 +9,14 @@ import android.text.TextUtils;
 import android.util.AttributeSet;
 import android.view.View;
 import android.widget.FrameLayout;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.view.DisplayCutoutCompat;
 import androidx.recyclerview.widget.DefaultItemAnimator;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
+
 import com.quran.data.model.SuraAyah;
 import com.quran.data.model.highlight.HighlightType;
 import com.quran.data.model.selection.SelectionIndicator;
@@ -28,11 +30,12 @@ import com.quran.labs.androidquran.ui.util.PageController;
 import com.quran.labs.androidquran.util.QuranSettings;
 import com.quran.mobile.translation.model.LocalTranslation;
 
-import dev.chrisbanes.insetter.Insetter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+
+import dev.chrisbanes.insetter.Insetter;
 
 public class TranslationView extends FrameLayout implements View.OnClickListener,
     TranslationAdapter.OnVerseSelectedListener, TranslationAdapter.OnJumpToAyahListener {
@@ -44,6 +47,7 @@ public class TranslationView extends FrameLayout implements View.OnClickListener
   private final LinearLayoutManager layoutManager;
   private PageController pageController;
   private LocalTranslation[] localTranslations;
+  private SpacerDecoration spacerDecoration;
 
   public TranslationView(Context context) {
     this(context, null);
@@ -95,10 +99,17 @@ public class TranslationView extends FrameLayout implements View.OnClickListener
             final int bottomSafeOffset = cutout.getSafeInsetBottom();
             final int horizontalSafeOffset =
                 Math.max(cutout.getSafeInsetLeft(), cutout.getSafeInsetRight());
-            setPadding(horizontalSafeOffset,
-                topSafeOffset,
-                horizontalSafeOffset,
-                bottomSafeOffset);
+
+            if (spacerDecoration == null) {
+              spacerDecoration = new SpacerDecoration(topSafeOffset, bottomSafeOffset);
+              translationRecycler.addItemDecoration(spacerDecoration);
+            } else {
+              if (spacerDecoration.setOffsets(topSafeOffset, bottomSafeOffset)) {
+                translationRecycler.invalidateItemDecorations();
+              }
+            }
+
+            setPadding(horizontalSafeOffset, 0, horizontalSafeOffset, 0);
           }
         })
         .applyToView(this);

--- a/app/src/main/res/layout/quran_page_activity.xml
+++ b/app/src/main/res/layout/quran_page_activity.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout
+<FrameLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
@@ -49,7 +49,7 @@
       android:id="@+id/audio_area"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
-      android:layout_alignParentBottom="true"
+      android:layout_gravity="bottom"
       android:visibility="gone"
       />
-</RelativeLayout>
+</FrameLayout>

--- a/common/toolbar/src/main/java/com/quran/page/common/toolbar/AyahToolBar.kt
+++ b/common/toolbar/src/main/java/com/quran/page/common/toolbar/AyahToolBar.kt
@@ -21,6 +21,7 @@ import com.quran.page.common.toolbar.dao.SelectedAyahPlacementType
 import com.quran.page.common.toolbar.di.AyahToolBarInjector
 import com.quran.page.common.toolbar.extension.toInternalPosition
 import javax.inject.Inject
+import kotlin.math.max
 
 class AyahToolBar @JvmOverloads constructor(
   context: Context,
@@ -123,7 +124,7 @@ class AyahToolBar @JvmOverloads constructor(
     if (lastMeasuredWidth != totalWidth && lastMeasuredWidth == 0) {
       // whenever we're RTL, we need to adjust the translationX
       if (layoutDirection == LAYOUT_DIRECTION_RTL) {
-        val insetToAdd = if (lastSelectionShouldPadForCutout) insets.left + insets.right else 0
+        val insetToAdd = if (lastSelectionShouldPadForCutout) max(insets.left, insets.right) else 0
         translationX = translationX - (parentWidth - measuredWidth) + insetToAdd
       }
       lastMeasuredWidth = totalWidth
@@ -235,7 +236,7 @@ class AyahToolBar @JvmOverloads constructor(
       lastMeasuredWidth = measuredWidth
       val leftInset = if (position is SelectionIndicator.SelectedPointPosition) {
         lastSelectionShouldPadForCutout = true
-        insets.left + insets.right
+        max(insets.left, insets.right)
       } else {
         lastSelectionShouldPadForCutout = false
         0
@@ -258,13 +259,7 @@ class AyahToolBar @JvmOverloads constructor(
         x + leftInset
       }
 
-      val actualY = if (position is SelectionIndicator.SelectedPointPosition) {
-        y + insets.top
-      } else {
-        y
-      }
-
-      setPosition(actualX, actualY)
+      setPosition(actualX, y)
       if (needsLayout) {
         requestLayout()
       }


### PR DESCRIPTION
This fixes an issue where, in landscape translation mode, if the toolbar
is visible when a long press occurs, the y would be incorrect. Also make
the root a FrameLayout instead of a RelativeLayout.

Refs #2993.
