### PR TITLE
Use dark mode as the default

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/QuranApplication.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/QuranApplication.kt
@@ -3,6 +3,7 @@ package com.quran.labs.androidquran
 import android.app.Application
 import android.content.Context
 import android.content.res.Resources
+import androidx.appcompat.app.AppCompatDelegate
 import androidx.work.Configuration
 import androidx.work.WorkManager
 import com.quran.labs.androidquran.core.worker.QuranWorkerFactory
@@ -34,6 +35,9 @@ open class QuranApplication : Application(), QuranApplicationComponentProvider {
     applicationComponent.inject(this)
     initializeWorkManager()
     bookmarksWidgetSubscriber.subscribeBookmarksWidgetIfNecessary()
+
+    // set dark mode as the default for now
+    AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_YES)
   }
 
   open fun setupTimber() {


### PR DESCRIPTION
For now, set the default mode to be dark mode. In the future, in sha'
Allah, there will be a setting for either day, night, or follow system.
For people who have the app installed, it will default to dark. For new
installations, it'll follow system by default. This will be in the
future though, in sha' Allah.
