### PR TITLE
Respect Arabic setting for Audio Manager

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/QuranApplication.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/QuranApplication.kt
@@ -6,6 +6,7 @@ import android.content.res.Resources
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.work.Configuration
 import androidx.work.WorkManager
+import com.quran.labs.androidquran.common.ui.LanguageEnforcer
 import com.quran.labs.androidquran.core.worker.QuranWorkerFactory
 import com.quran.labs.androidquran.di.component.application.ApplicationComponent
 import com.quran.labs.androidquran.di.component.application.DaggerApplicationComponent
@@ -18,7 +19,7 @@ import timber.log.Timber
 import java.util.Locale
 import javax.inject.Inject
 
-open class QuranApplication : Application(), QuranApplicationComponentProvider {
+open class QuranApplication : Application(), QuranApplicationComponentProvider, LanguageEnforcer {
   lateinit var applicationComponent: ApplicationComponent
 
   @Inject lateinit var quranWorkerFactory: QuranWorkerFactory
@@ -58,7 +59,7 @@ open class QuranApplication : Application(), QuranApplicationComponentProvider {
     )
   }
 
-  fun refreshLocale(
+  override fun refreshLocale(
     context: Context,
     force: Boolean
   ) {

--- a/common/ui/core/src/main/java/com/quran/labs/androidquran/common/ui/LanguageEnforcer.kt
+++ b/common/ui/core/src/main/java/com/quran/labs/androidquran/common/ui/LanguageEnforcer.kt
@@ -1,0 +1,7 @@
+package com.quran.labs.androidquran.common.ui
+
+import android.content.Context
+
+interface LanguageEnforcer {
+  fun refreshLocale(context: Context, force: Boolean)
+}

--- a/feature/downloadmanager/src/main/kotlin/com/quran/mobile/feature/downloadmanager/AudioManagerActivity.kt
+++ b/feature/downloadmanager/src/main/kotlin/com/quran/mobile/feature/downloadmanager/AudioManagerActivity.kt
@@ -20,6 +20,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import com.quran.labs.androidquran.common.audio.model.QariItem
+import com.quran.labs.androidquran.common.ui.LanguageEnforcer
 import com.quran.labs.androidquran.common.ui.core.QuranTheme
 import com.quran.mobile.di.QuranApplicationComponentProvider
 import com.quran.mobile.feature.downloadmanager.di.DownloadManagerComponentInterface
@@ -30,13 +31,14 @@ import com.quran.mobile.feature.downloadmanager.ui.common.DownloadManagerToolbar
 import kotlinx.collections.immutable.persistentListOf
 import javax.inject.Inject
 
-
 class AudioManagerActivity : ComponentActivity() {
 
   @Inject
   lateinit var audioManagerPresenter: AudioManagerPresenter
 
   override fun onCreate(savedInstanceState: Bundle?) {
+    (application as? LanguageEnforcer)?.refreshLocale(this, false)
+
     super.onCreate(savedInstanceState)
 
     val injector = (application as? QuranApplicationComponentProvider)

--- a/feature/downloadmanager/src/main/kotlin/com/quran/mobile/feature/downloadmanager/SheikhAudioDownloadsActivity.kt
+++ b/feature/downloadmanager/src/main/kotlin/com/quran/mobile/feature/downloadmanager/SheikhAudioDownloadsActivity.kt
@@ -24,6 +24,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
 import androidx.core.app.ActivityCompat
 import com.quran.common.search.SearchTextUtil
+import com.quran.labs.androidquran.common.ui.LanguageEnforcer
 import com.quran.labs.androidquran.common.ui.core.QuranTheme
 import com.quran.mobile.di.QuranApplicationComponentProvider
 import com.quran.mobile.feature.downloadmanager.di.DownloadManagerComponentInterface
@@ -66,6 +67,8 @@ class SheikhAudioDownloadsActivity : ComponentActivity() {
     }
 
   override fun onCreate(savedInstanceState: Bundle?) {
+    (application as? LanguageEnforcer)?.refreshLocale(this, false)
+
     super.onCreate(savedInstanceState)
     qariId = intent.getIntExtra(EXTRA_QARI_ID, -1)
     if (qariId < 0) {


### PR DESCRIPTION
This patch applies a temporary fix for the audio manager screen not
respecting the proper locale. The entire method of enforcing locale
within the app needs to be revisited in the near future in sha' Allah.
