### PR TITLE
Fix wrong page when switching foldable state

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/ui/PagerActivity.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/PagerActivity.kt
@@ -349,9 +349,15 @@ class PagerActivity : AppCompatActivity(), AudioBarListener, OnBookmarkTagsUpdat
 
   private fun updateDualPageMode() {
     val lastIsDualPages = isDualPages
-    isDualPages = QuranUtils.isDualPages(this, quranScreenInfo, isFoldableDeviceOpenAndVertical)
-    if (lastIsDualPages != isDualPages) {
+    val nextIsDualPages = QuranUtils.isDualPages(this, quranScreenInfo, isFoldableDeviceOpenAndVertical)
+    if (lastIsDualPages != nextIsDualPages) {
+      // due to the conversion after setting the adapter, we need this page to be
+      // the page _before_ we switched from dual to single or vice versa. otherwise,
+      // we end up double-converting the page.
+      //
+      // might be worth trying later to undo this and just remove the conversion below.
       val page = currentPage
+      isDualPages = nextIsDualPages
 
       pagerAdapter = QuranPageAdapter(
         supportFragmentManager,


### PR DESCRIPTION
When switching between folded and open states, the page would often
reset (ex from sura Nur ayah 35 in closed mode would become sura Nisa'
in open mode). This is because there are two conversions happening. By
setting isDualPages, the currentPage read is the new position, but the
code would then re-convert that page, thus breaking it. This updates it
by reading currentPage before updating isDualPages.

In the future, this code can likely be simplified (i.e. removing the
mapping in favor of just reading the most up to date page).
