### PR TITLE
Fix audio playback bugs due to setting speed

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/service/AudioService.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/service/AudioService.kt
@@ -39,6 +39,7 @@ import android.media.MediaPlayer
 import android.media.MediaPlayer.OnCompletionListener
 import android.media.MediaPlayer.OnPreparedListener
 import android.media.MediaPlayer.OnSeekCompleteListener
+import android.media.PlaybackParams
 import android.net.wifi.WifiManager
 import android.net.wifi.WifiManager.WifiLock
 import android.os.Build
@@ -661,10 +662,7 @@ class AudioService : Service(), OnCompletionListener, OnPreparedListener,
   private fun processUpdatePlaybackSpeed(speed: Float) {
     if (State.Playing === state && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
       try {
-        player?.playbackParams?.let { params ->
-          params.setSpeed(speed)
-          player?.playbackParams = params
-        }
+        player?.playbackParams = PlaybackParams().allowDefaults().setSpeed(speed)
       } catch (e: Exception) {
         // catch an Android 6 crash [IllegalStateException], and report the speed since some
         // non-Android 6 devices also crash here, but with [IllegalArgumentException]
@@ -1070,12 +1068,13 @@ class AudioService : Service(), OnCompletionListener, OnPreparedListener,
       "seek complete! %d vs %d",
       mediaPlayer.currentPosition, player.currentPosition
     )
-    player.start()
-    state = State.Playing
-    updateAudioPlaybackStatus()
+
     audioRequest?.playbackSpeed?.let { speed ->
       processUpdatePlaybackSpeed(speed)
     }
+    player.start()
+    state = State.Playing
+    updateAudioPlaybackStatus()
     serviceHandler.sendEmptyMessageDelayed(MSG_UPDATE_AUDIO_POS, 200)
   }
 


### PR DESCRIPTION
This patch fixes bugs due to setting the playback speed on certain
devices, even if the person does not try to change the playback speed at
all. For example, on a Pixel 8, pausing the audio and resuming causes
the playback to stop ui wise without stopping service wise due to a
silent exception from setting the playback params.

The fix here, as suggested by Claude, is not re-using the playback
params, and, instead, setting a new one, irrespective of the current
values.
