### PR TITLE
Fix incorrect translation names after download

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/presenter/translation/InlineTranslationPresenter.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/presenter/translation/InlineTranslationPresenter.kt
@@ -10,9 +10,6 @@ import com.quran.labs.androidquran.util.QuranSettings
 import com.quran.labs.androidquran.util.TranslationUtil
 import com.quran.mobile.translation.model.LocalTranslation
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.MainScope
-import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
@@ -24,20 +21,10 @@ class InlineTranslationPresenter @Inject constructor(
   translationListPresenter: TranslationListPresenter,
   quranInfo: QuranInfo
 ) : BaseTranslationPresenter<InlineTranslationPresenter.TranslationScreen>(
-  translationModel, dbAdapter, translationUtil, quranInfo
+  translationModel, dbAdapter, translationUtil, quranInfo, translationListPresenter
 ) {
-  private val scope = MainScope()
   private var cachedTranslations = emptyList<LocalTranslation>()
   private var lastVerseRange: VerseRange? = null
-
-  init {
-    translationListPresenter.translations()
-      .onEach { translations ->
-        cachedTranslations = translations
-        translationScreen?.onTranslationsUpdated(translations)
-      }
-      .launchIn(scope)
-  }
 
   suspend fun refresh(verseRange: VerseRange) {
     val ayahHasBeenChanged = verseRange != lastVerseRange
@@ -52,6 +39,12 @@ class InlineTranslationPresenter @Inject constructor(
     super.bind(what)
     val translations = cachedTranslations
     what.onTranslationsUpdated(translations)
+  }
+
+  override fun onAvailableTranslationsChanged(localTranslations: List<LocalTranslation>) {
+    super.onAvailableTranslationsChanged(localTranslations)
+    cachedTranslations = localTranslations
+    translationScreen?.onTranslationsUpdated(localTranslations)
   }
 
   interface TranslationScreen {

--- a/app/src/main/java/com/quran/labs/androidquran/presenter/translation/TranslationPresenter.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/presenter/translation/TranslationPresenter.kt
@@ -5,6 +5,7 @@ import com.quran.data.di.QuranPageScope
 import com.quran.labs.androidquran.common.QuranAyahInfo
 import com.quran.labs.androidquran.database.TranslationsDBAdapter
 import com.quran.labs.androidquran.model.translation.TranslationModel
+import com.quran.labs.androidquran.presenter.translationlist.TranslationListPresenter
 import com.quran.labs.androidquran.util.QuranSettings
 import com.quran.labs.androidquran.util.TranslationUtil
 import com.quran.mobile.translation.model.LocalTranslation
@@ -18,11 +19,12 @@ class TranslationPresenter @Inject internal constructor(
   private val quranSettings: QuranSettings,
   translationsAdapter: TranslationsDBAdapter,
   translationUtil: TranslationUtil,
+  translationListPresenter: TranslationListPresenter,
   private val quranInfo: QuranInfo,
   private val pages: IntArray
 ) :
   BaseTranslationPresenter<TranslationPresenter.TranslationScreen>(
-    translationModel, translationsAdapter, translationUtil, quranInfo
+    translationModel, translationsAdapter, translationUtil, quranInfo, translationListPresenter
   ) {
 
   suspend fun refresh() {

--- a/app/src/test/java/com/quran/labs/androidquran/presenter/translation/BaseTranslationPresenterTest.kt
+++ b/app/src/test/java/com/quran/labs/androidquran/presenter/translation/BaseTranslationPresenterTest.kt
@@ -9,8 +9,14 @@ import com.quran.labs.androidquran.database.TranslationsDBAdapter
 import com.quran.labs.androidquran.model.translation.TranslationModel
 import com.quran.labs.androidquran.pages.data.madani.MadaniDataSource
 import com.quran.labs.androidquran.presenter.Presenter
+import com.quran.labs.androidquran.presenter.translationlist.TranslationListPresenter
 import com.quran.labs.androidquran.util.TranslationUtil
 import com.quran.mobile.translation.model.LocalTranslation
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mockito
@@ -19,8 +25,11 @@ class BaseTranslationPresenterTest {
 
   private lateinit var presenter: BaseTranslationPresenter<TestPresenter>
 
+  private val testDispatcher = UnconfinedTestDispatcher()
+
   @Before
   fun setupTest() {
+    Dispatchers.setMain(testDispatcher)
     presenter = BaseTranslationPresenter(
         Mockito.mock(TranslationModel::class.java),
         Mockito.mock(TranslationsDBAdapter::class.java),
@@ -29,8 +38,14 @@ class BaseTranslationPresenterTest {
             return TranslationMetadata(quranText.sura, quranText.ayah, quranText.text, translationId)
           }
         },
-        QuranInfo(MadaniDataSource())
+        QuranInfo(MadaniDataSource()),
+        Mockito.mock(TranslationListPresenter::class.java)
     )
+  }
+
+  @After
+  fun tearDown() {
+    Dispatchers.resetMain()
   }
 
   @Test


### PR DESCRIPTION
After downloading a fresh translation, the names typically show
something like x.db instead of the translation name. This fixes it by
updating the cache of translations when translations are updated.
