### PR TITLE
Gracefully handle audio updates api returning 204

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/worker/AudioUpdateWorker.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/worker/AudioUpdateWorker.kt
@@ -41,9 +41,10 @@ class AudioUpdateWorker(
       val currentVersion = quranSettings.currentAudioRevision
       val updates = audioUpdateService.getUpdates(currentVersion)
 
-      Timber.d("local version: %d - server version: %d",
+      if (updates != null && currentVersion != updates.currentRevision) {
+        Timber.d("local version: %d - server version: %d",
           currentVersion, updates.currentRevision)
-      if (currentVersion != updates.currentRevision) {
+
         val localFilesToDelete = AudioUpdater.computeUpdates(
             updates.updates, audioUtils.getQariList(context),
             AudioFileCheckerImpl(MD5Calculator, audioPathRoot),
@@ -84,6 +85,8 @@ class AudioUpdateWorker(
         }
         Timber.d("updating audio to revision: %d", updates.currentRevision)
         quranSettings.currentAudioRevision = updates.currentRevision
+      } else {
+        Timber.d("no audio updates found")
       }
     }
     Result.success()

--- a/feature/audio/src/main/java/com/quran/labs/androidquran/feature/audio/api/AudioUpdateService.kt
+++ b/feature/audio/src/main/java/com/quran/labs/androidquran/feature/audio/api/AudioUpdateService.kt
@@ -5,5 +5,5 @@ import retrofit2.http.Query
 
 interface AudioUpdateService {
   @GET("/data/audio_updates.php")
-  suspend fun getUpdates(@Query("revision") revision: Int): AudioUpdates
+  suspend fun getUpdates(@Query("revision") revision: Int): AudioUpdates?
 }


### PR DESCRIPTION
When there are no updates, the audio updates api returns 204. Gracefully
handle this by treating null as no data.
