### PR TITLE
Fix: Ensure bookmarked ayahs respect translation mode (#3130)

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/ui/QuranActivity.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/QuranActivity.kt
@@ -425,6 +425,7 @@ class QuranActivity : AppCompatActivity(),
     i.putExtra("page", page)
     i.putExtra(PagerActivity.EXTRA_HIGHLIGHT_SURA, sura)
     i.putExtra(PagerActivity.EXTRA_HIGHLIGHT_AYAH, ayah)
+    i.putExtra(PagerActivity.EXTRA_JUMP_TO_TRANSLATION, settings.wasShowingTranslation)
     startActivity(i)
   }
 


### PR DESCRIPTION
### Fix: Ensure bookmarked ayahs respect translation mode

#### Description
This PR fixes an inconsistency where bookmarked ayahs always open in Quran mode, regardless of whether the user was in translation mode. The `EXTRA_JUMP_TO_TRANSLATION` flag is now passed in the `jumpToAndHighlight` method to ensure the correct mode is respected.

#### Related Issue
Fixes #3130 

#### Changes Made
- Updated `jumpToAndHighlight` in `QuranActivity` to include the `EXTRA_JUMP_TO_TRANSLATION` flag.

#### Testing
- Verified that bookmarked pages and ayahs now respect the current mode (translation or Quran mode).