### PR TITLE
Add support for opus files

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/data/QuranAudioExtensionDecider.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/data/QuranAudioExtensionDecider.kt
@@ -1,0 +1,49 @@
+package com.quran.labs.androidquran.data
+
+import com.quran.data.di.AppScope
+import com.quran.data.model.audio.Qari
+import com.quran.labs.androidquran.common.audio.model.QariItem
+import com.quran.labs.androidquran.common.audio.util.AudioExtensionDecider
+import com.squareup.anvil.annotations.ContributesBinding
+import javax.inject.Inject
+
+@ContributesBinding(AppScope::class)
+class QuranAudioExtensionDecider @Inject constructor() : AudioExtensionDecider {
+
+  /**
+   * Returns the audio file extension for a given Qari.
+   * For today, if the Qari has an opus URL, it returns "opus", otherwise it returns "mp3". In
+   * the future, this might depend on more issues, such as a global preference, or the presence
+   * of a specific audio file type for the qari already downloaded.
+   */
+  override fun audioExtensionForQari(qari: Qari): String {
+    return if (qari.opusUrl != null) "opus" else "mp3"
+  }
+
+  /**
+   * Returns the audio file extension for a given Qari.
+   * For today, if the Qari has an opus URL, it returns "opus", otherwise it returns "mp3". In
+   * the future, this might depend on more issues, such as a global preference, or the presence
+   * of a specific audio file type for the qari already downloaded.
+   */
+  override fun audioExtensionForQari(qariItem: QariItem): String {
+    return if (qariItem.opusUrl != null) "opus" else "mp3"
+  }
+
+  /**
+   * For today, a Qari can either have mp3s or opus files, but not both.
+   * In the future, this constraint may be relaxed, and this method allows this possibility.
+   */
+  override fun allowedAudioExtensions(qari: Qari): List<String> {
+    return listOf(audioExtensionForQari(qari))
+  }
+
+  /**
+   * For today, a Qari can either have mp3s or opus files, but not both.
+   * In the future, this constraint may be relaxed, and this method allows this possibility.
+   */
+  override fun allowedAudioExtensions(qariItem: QariItem): List<String> {
+    return listOf(audioExtensionForQari(qariItem))
+  }
+
+}

--- a/app/src/main/java/com/quran/labs/androidquran/service/util/DownloadStarter.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/service/util/DownloadStarter.kt
@@ -3,10 +3,10 @@ package com.quran.labs.androidquran.service.util
 import android.content.Context
 import android.content.Intent
 import com.quran.data.core.QuranFileManager
-import com.quran.data.core.QuranInfo
 import com.quran.data.di.AppScope
 import com.quran.data.model.audio.Qari
 import com.quran.labs.androidquran.common.audio.model.download.AudioDownloadMetadata
+import com.quran.labs.androidquran.common.audio.util.AudioExtensionDecider
 import com.quran.labs.androidquran.service.QuranDownloadService
 import com.quran.labs.androidquran.util.AudioUtils
 import com.quran.mobile.common.download.Downloader
@@ -17,9 +17,9 @@ import javax.inject.Inject
 @ContributesBinding(AppScope::class)
 class DownloadStarter @Inject constructor(
   @ApplicationContext private val appContext: Context,
-  private val quranInfo: QuranInfo,
   private val fileManager: QuranFileManager,
-  private val audioUtils: AudioUtils
+  private val audioUtils: AudioUtils,
+  private val audioExtensionDecider: AudioExtensionDecider
 ) : Downloader {
 
   /**
@@ -32,10 +32,11 @@ class DownloadStarter @Inject constructor(
     val baseUri = basePath + qari.path
     val isGapless = qari.isGapless
     val sheikhName = appContext.getString(qari.nameResource)
+    val extension = audioExtensionDecider.audioExtensionForQari(qari)
 
     val intent = ServiceIntentHelper.getDownloadIntent(
       appContext,
-      audioUtils.getQariUrl(qari),
+      audioUtils.getQariUrl(qari, extension),
       baseUri,
       sheikhName,
       AUDIO_DOWNLOAD_KEY + qari.id + suras.first(),

--- a/app/src/main/java/com/quran/labs/androidquran/worker/AudioUpdateWorker.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/worker/AudioUpdateWorker.kt
@@ -57,9 +57,11 @@ class AudioUpdateWorker(
             if (localUpdate.needsDatabaseUpgrade) {
               // delete the database
               val dbPath = audioUtils.getQariDatabasePathIfGapless(localUpdate.qari)
-              dbPath?.let { SuraTimingDatabaseHandler.clearDatabaseHandlerIfExists(it) }
-              Timber.d("would remove %s", dbPath)
-              File(dbPath).delete()
+              if (dbPath != null) {
+                SuraTimingDatabaseHandler.clearDatabaseHandlerIfExists(dbPath)
+                Timber.d("would remove %s", dbPath)
+                File(dbPath).delete()
+              }
             }
 
             val qari = localUpdate.qari
@@ -72,7 +74,8 @@ class AudioUpdateWorker(
                 // this is a hack to drop the leading 0s in the file name
                 val sura = it.substring(0, 3).toInt().toString()
                 val ayah = it.substring(3, 6).toInt().toString()
-                path + File.separator + sura + File.separator + ayah + ".mp3"
+                val extension = it.substringAfterLast(".")
+                path + File.separator + sura + File.separator + ayah + ".$extension"
               }
               Timber.d("would remove %s", filePath)
               File(filePath).delete()

--- a/app/src/test/java/com/quran/labs/androidquran/common/audio/extension/QariDownloadInfoExtensionTest.kt
+++ b/app/src/test/java/com/quran/labs/androidquran/common/audio/extension/QariDownloadInfoExtensionTest.kt
@@ -12,7 +12,7 @@ class QariDownloadInfoExtensionTest {
 
   @Test
   fun checkDownloadedGaplessFiles() {
-    val qari = Qari(1, 0, "url", "path", false, "database")
+    val qari = Qari(1, 0, "url", null, "path", false, "database")
     val qariDownloadInfo = QariDownloadInfo.GaplessQariDownloadInfo(qari, listOf(1, 2), listOf(3))
     assertTrue(qariDownloadInfo.isRangeDownloaded(SuraAyah(1, 1), SuraAyah(2, 286)))
     // ranges are inclusive, and there are no partial files
@@ -22,7 +22,7 @@ class QariDownloadInfoExtensionTest {
 
   @Test
   fun checkDownloadedGappedFiles() {
-    val qari = Qari(1, 0, "url", "path", false, null)
+    val qari = Qari(1, 0, "url", null, "path", false, null)
     val qariDownloadInfo = QariDownloadInfo.GappedQariDownloadInfo(
       qari,
       listOf(1, 2),

--- a/common/audio/src/main/java/com/quran/labs/androidquran/common/audio/cache/command/GaplessAudioInfoCommand.kt
+++ b/common/audio/src/main/java/com/quran/labs/androidquran/common/audio/cache/command/GaplessAudioInfoCommand.kt
@@ -7,23 +7,31 @@ import javax.inject.Inject
 
 class GaplessAudioInfoCommand @Inject constructor(private val fileSystem: FileSystem) {
 
-  fun gaplessDownloads(path: Path): Pair<List<Int>, List<Int>> {
-    return fullGaplessDownloads(path) to partialGaplessDownloads(path)
+  fun gaplessDownloads(path: Path, allowedExtensions: List<String>): Pair<List<Int>, List<Int>> {
+    return fullGaplessDownloads(path, allowedExtensions) to partialGaplessDownloads(path, allowedExtensions)
   }
 
-  private fun fullGaplessDownloads(path: Path): List<Int> {
-    val paths = AudioFileUtil.filesMatchingSuffixWithSuffixRemoved(fileSystem, path, ".mp3")
+  private fun fullGaplessDownloads(path: Path, allowedExtensions: List<String>): List<Int> {
+    val paths = allowedExtensions.flatMap { extension ->
+      AudioFileUtil.filesMatchingSuffixWithSuffixRemoved(fileSystem, path, ".$extension")
+    }
+
     return paths
       .filter { it.length == 3 }
       .mapNotNull { it.toIntOrNull() }
       .filter { it in 1..114 }
+      .distinct()
   }
 
-  private fun partialGaplessDownloads(path: Path): List<Int> {
-    val paths = AudioFileUtil.filesMatchingSuffixWithSuffixRemoved(fileSystem, path, ".mp3.part")
+  private fun partialGaplessDownloads(path: Path, allowedExtensions: List<String>): List<Int> {
+    val paths = allowedExtensions.flatMap { extension ->
+      AudioFileUtil.filesMatchingSuffixWithSuffixRemoved(fileSystem, path, ".$extension.part")
+    }
+
     return paths
       .filter { it.length == 3 }
       .mapNotNull { it.toIntOrNull() }
       .filter { it in 1..114 }
+      .distinct()
   }
 }

--- a/common/audio/src/main/java/com/quran/labs/androidquran/common/audio/cache/command/GappedAudioInfoCommand.kt
+++ b/common/audio/src/main/java/com/quran/labs/androidquran/common/audio/cache/command/GappedAudioInfoCommand.kt
@@ -12,14 +12,14 @@ class GappedAudioInfoCommand @Inject constructor(
   private val fileSystem: FileSystem
 ) {
 
-  fun gappedDownloads(path: Path): Pair<List<Int>, List<PartiallyDownloadedSura>> {
+  fun gappedDownloads(path: Path, allowedExtensions: List<String>): Pair<List<Int>, List<PartiallyDownloadedSura>> {
     val gappedSuras = fileSystem.list(path)
       .filter { it.name.toIntOrNull() in 1..114 }
       .associate { directory ->
-        val gappedDownloads =
-          AudioFileUtil.filesMatchingSuffixWithSuffixRemoved(fileSystem, directory, ".mp3")
-            .mapNotNull { it.toIntOrNull() }
-            .filter { it in 1..286 }
+        val gappedDownloads = allowedExtensions.flatMap { extension ->
+          AudioFileUtil.filesMatchingSuffixWithSuffixRemoved(fileSystem, directory, ".$extension")
+        }.mapNotNull { it.toIntOrNull() }
+         .filter { it in 1..286 }
         directory.toFile().nameWithoutExtension.toInt() to gappedDownloads
       }
 

--- a/common/audio/src/main/java/com/quran/labs/androidquran/common/audio/model/QariItem.kt
+++ b/common/audio/src/main/java/com/quran/labs/androidquran/common/audio/model/QariItem.kt
@@ -11,6 +11,7 @@ data class QariItem(
   val id: Int,
   val name: String,
   val url: String,
+  val opusUrl: String? = null,
   val path: String,
   val hasGaplessAlternative: Boolean,
   val db: String? = null
@@ -21,12 +22,23 @@ data class QariItem(
   val isGapless: Boolean
     get() = databaseName != null
 
+  fun hasOpus() = opusUrl != null && opusUrl.isNotEmpty()
+
+  fun url(extension: String): String {
+    return when (extension) {
+      "opus" -> opusUrl ?: throw IllegalArgumentException("Opus is not available for qari $id")
+      "mp3" -> url
+      else -> throw IllegalArgumentException("Unsupported audio format: $extension")
+    }
+  }
+
   companion object {
     fun fromQari(context: Context, qari: Qari): QariItem {
       return QariItem(
         id = qari.id,
         name = context.getString(qari.nameResource),
         url = qari.url,
+        opusUrl = qari.opusUrl,
         path = qari.path,
         hasGaplessAlternative = qari.hasGaplessAlternative,
         db = qari.db

--- a/common/audio/src/main/java/com/quran/labs/androidquran/common/audio/model/playback/AudioPathInfo.kt
+++ b/common/audio/src/main/java/com/quran/labs/androidquran/common/audio/model/playback/AudioPathInfo.kt
@@ -4,6 +4,9 @@ import android.os.Parcelable
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
-data class AudioPathInfo(val urlFormat: String,
-                         val localDirectory: String,
-                         val gaplessDatabase: String?) : Parcelable
+data class AudioPathInfo(
+  val urlFormat: String,
+  val localDirectory: String,
+  val gaplessDatabase: String?,
+  val allowedExtensions: List<String>
+) : Parcelable

--- a/common/audio/src/main/java/com/quran/labs/androidquran/common/audio/util/AudioExtensionDecider.kt
+++ b/common/audio/src/main/java/com/quran/labs/androidquran/common/audio/util/AudioExtensionDecider.kt
@@ -1,0 +1,42 @@
+package com.quran.labs.androidquran.common.audio.util
+
+import com.quran.data.model.audio.Qari
+import com.quran.labs.androidquran.common.audio.model.QariItem
+
+/**
+ * Interface to determine the audio file extension for a given Qari or QariItem.
+ *
+ * Note: The fact that both [Qari] and [QariItem] are supported is due to the usage of
+ * both. In reality, this highlights an underlying issue, which is that these are really
+ * the exact same thing and should be unified in the future (the only real difference is
+ * one has a resource id for a name whereas the other has the actual resource string).
+ */
+interface AudioExtensionDecider {
+  /**
+   * Returns the audio file extension for the given Qari.
+   * This is the extension that should be used for downloading or streaming audio files.
+   */
+  fun audioExtensionForQari(qari: Qari): String
+
+  /**
+   * Returns the audio file extension for the given Qari.
+   * This is the extension that should be used for downloading or streaming audio files.
+   */
+  fun audioExtensionForQari(qariItem: QariItem): String
+
+  /**
+   * Returns a list of allowed audio file extensions for the given Qari.
+   * This can be used to filter or validate audio files for playback. It's mostly there in case
+   * we decide to allow a mix of audio formats for a Qari in the future (ex sura Fatiha can be
+   * mp3, sura Baqarah can be opus, and so on).
+   */
+  fun allowedAudioExtensions(qari: Qari): List<String>
+
+  /**
+   * Returns a list of allowed audio file extensions for the given Qari.
+   * This can be used to filter or validate audio files for playback. It's mostly there in case
+   * we decide to allow a mix of audio formats for a Qari in the future (ex sura Fatiha can be
+   * mp3, sura Baqarah can be opus, and so on).
+   */
+  fun allowedAudioExtensions(qariItem: QariItem): List<String>
+}

--- a/common/audio/src/main/java/com/quran/labs/androidquran/common/audio/util/QariUtil.kt
+++ b/common/audio/src/main/java/com/quran/labs/androidquran/common/audio/util/QariUtil.kt
@@ -32,15 +32,6 @@ class QariUtil @Inject constructor(private val pageProvider: PageProvider) {
    * @return a list of [QariItem] representing the qaris to show.
    */
   fun getQariList(context: Context): List<QariItem> {
-    return getQariList().map { item ->
-       QariItem(
-        id = item.id,
-        name = context.getString(item.nameResource),
-        url = item.url,
-        path = item.path,
-        hasGaplessAlternative = item.hasGaplessAlternative,
-        db = item.db
-      )
-    }
+    return getQariList().map { item -> QariItem.fromQari(context, item) }
   }
 }

--- a/common/data/src/main/java/com/quran/data/model/audio/Qari.kt
+++ b/common/data/src/main/java/com/quran/data/model/audio/Qari.kt
@@ -6,10 +6,20 @@ data class Qari(
   val id: Int,
   @StringRes val nameResource: Int,
   val url: String,
+  val opusUrl: String? = null,
   val path: String,
   val hasGaplessAlternative: Boolean,
-  val db: String? = null
+  val db: String? = null,
 ) {
   val databaseName = if (db.isNullOrEmpty()) null else db
   val isGapless: Boolean = databaseName != null
+  val hasOpus = opusUrl != null && opusUrl.isNotEmpty()
+
+  fun url(extension: String): String {
+    return when (extension) {
+        "opus" -> opusUrl ?: throw IllegalArgumentException("Opus is not available for qari $id")
+        "mp3" -> url
+        else -> throw IllegalArgumentException("Unsupported audio format: $extension")
+    }
+  }
 }

--- a/feature/audio/src/main/java/com/quran/labs/androidquran/feature/audio/AudioUpdater.kt
+++ b/feature/audio/src/main/java/com/quran/labs/androidquran/feature/audio/AudioUpdater.kt
@@ -23,7 +23,7 @@ object AudioUpdater {
     audioSetUpdate: AudioSetUpdate,
     qaris: List<QariItem>
   ): QariItem? {
-    return qaris.firstOrNull { it.url == audioSetUpdate.path }
+    return qaris.firstOrNull { it.url == audioSetUpdate.path || it.opusUrl == audioSetUpdate.path }
   }
 
   private fun makeLocalUpdate(audioFileChecker: AudioFileChecker,

--- a/feature/autoquran/build.gradle
+++ b/feature/autoquran/build.gradle
@@ -20,6 +20,7 @@ dependencies {
   api(libs.androidx.media3.session)
   implementation(libs.androidx.media3.ui)
 
+  implementation project(":common:audio")
   implementation project(":common:data")
   implementation project(":common:di")
   implementation project(":common:ui:core")

--- a/feature/autoquran/src/main/java/com/quran/labs/feature/autoquran/common/BrowsableSurahBuilder.kt
+++ b/feature/autoquran/src/main/java/com/quran/labs/feature/autoquran/common/BrowsableSurahBuilder.kt
@@ -7,13 +7,17 @@ import androidx.media3.common.MimeTypes
 import com.google.common.collect.ImmutableList
 import com.quran.data.model.audio.Qari
 import com.quran.data.source.PageProvider
+import com.quran.labs.androidquran.common.audio.util.AudioExtensionDecider
 import com.quran.mobile.di.qualifier.ApplicationContext
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
-class BrowsableSurahBuilder @Inject constructor(@ApplicationContext private val appContext: Context,
-                                                private val pageProvider: PageProvider) {
+class BrowsableSurahBuilder @Inject constructor(
+  @ApplicationContext private val appContext: Context,
+  private val pageProvider: PageProvider,
+  private val audioExtensionDecider: AudioExtensionDecider
+) {
 
   private val qariMediaItem: MediaItem by lazy {
     MediaItem.Builder()
@@ -130,7 +134,8 @@ class BrowsableSurahBuilder @Inject constructor(@ApplicationContext private val 
    * Make a [MediaItem] representing a sura for a [Qari]
    */
   private fun makeSuraMediaItem(qari: Qari, sura: Int): MediaItem {
-    val suraName = getSuraName(appContext, sura, true, false)
+    val suraName = getSuraName(appContext, sura, wantPrefix = true, wantTranslation = false)
+    val extension = audioExtensionDecider.audioExtensionForQari(qari)
     return MediaItem.Builder()
       .setMediaId("sura_${sura}_${qari.id}")
       .setMediaMetadata(
@@ -145,7 +150,7 @@ class BrowsableSurahBuilder @Inject constructor(@ApplicationContext private val 
           .build()
       )
       .setMimeType(MimeTypes.AUDIO_MPEG)
-      .setUri(qari.url + makeThreeDigit(sura) + ".mp3")
+      .setUri(qari.url + makeThreeDigit(sura) + ".$extension")
       .build()
   }
 

--- a/pages/madani/src/main/java/com/quran/data/page/provider/madani/MadaniPageProvider.kt
+++ b/pages/madani/src/main/java/com/quran/data/page/provider/madani/MadaniPageProvider.kt
@@ -49,26 +49,26 @@ class MadaniPageProvider : PageProvider {
       Qari(
         0,
         audioR.string.qari_minshawi_murattal_gapless,
-        "https://download.quranicaudio.com/quran/muhammad_siddeeq_al-minshaawee/",
-        "minshawi_murattal",
-        false,
-        "minshawi_murattal"
+        url = "https://download.quranicaudio.com/quran/muhammad_siddeeq_al-minshaawee/",
+        path = "minshawi_murattal",
+        hasGaplessAlternative = false,
+        db = "minshawi_murattal"
       ),
       Qari(
         1,
         audioR.string.qari_husary_gapless,
-        "https://download.quranicaudio.com/quran/mahmood_khaleel_al-husaree/",
-        "husary",
-        false,
-        "husary"
+        url = "https://download.quranicaudio.com/quran/mahmood_khaleel_al-husaree/",
+        path = "husary",
+        hasGaplessAlternative = false,
+        db = "husary"
       ),
       Qari(
         2,
         audioR.string.qari_basfar,
-        "https://mirrors.quranicaudio.com/everyayah/Abdullah_Basfar_192kbps/",
-        "2",
-        false,
-        null
+        url = "https://mirrors.quranicaudio.com/everyayah/Abdullah_Basfar_192kbps/",
+        path = "2",
+        hasGaplessAlternative = false,
+        db = null
       )
     )
   }


### PR DESCRIPTION
This adds support for different audio formats and places the logic to
decide which format to use behind an interface so that it can be tweaked
later if necessary.

For now, all new qaris will default to opus only. Based on this, can
decide what to do on existing qaris that get opus support in the future
in sha' Allah.
