### PR TITLE
Add an in-app theme switcher

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/QuranApplication.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/QuranApplication.kt
@@ -5,9 +5,12 @@ import androidx.appcompat.app.AppCompatDelegate
 import androidx.work.Configuration
 import androidx.work.WorkManager
 import com.quran.labs.androidquran.core.worker.QuranWorkerFactory
+import com.quran.labs.androidquran.data.Constants
 import com.quran.labs.androidquran.di.component.application.ApplicationComponent
 import com.quran.labs.androidquran.di.component.application.DaggerApplicationComponent
+import com.quran.labs.androidquran.util.QuranSettings
 import com.quran.labs.androidquran.util.RecordingLogTree
+import com.quran.labs.androidquran.util.ThemeUtil
 import com.quran.labs.androidquran.widget.BookmarksWidgetSubscriber
 import com.quran.mobile.di.QuranApplicationComponent
 import com.quran.mobile.di.QuranApplicationComponentProvider
@@ -19,6 +22,7 @@ open class QuranApplication : Application(), QuranApplicationComponentProvider {
 
   @Inject lateinit var quranWorkerFactory: QuranWorkerFactory
   @Inject lateinit var bookmarksWidgetSubscriber: BookmarksWidgetSubscriber
+  @Inject lateinit var quranSettings: QuranSettings
 
   override fun provideQuranApplicationComponent(): QuranApplicationComponent {
     return applicationComponent
@@ -32,8 +36,9 @@ open class QuranApplication : Application(), QuranApplicationComponentProvider {
     initializeWorkManager()
     bookmarksWidgetSubscriber.subscribeBookmarksWidgetIfNecessary()
 
-    // set dark mode as the default for now
-    AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_YES)
+    // theme setup
+    val theme = quranSettings.currentTheme()
+    ThemeUtil.setTheme(theme)
   }
 
   open fun setupTimber() {

--- a/app/src/main/java/com/quran/labs/androidquran/data/Constants.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/data/Constants.kt
@@ -91,4 +91,10 @@ object Constants {
   const val PREF_SHOW_SIDELINES = "showSidelines"
   const val PREF_SHOW_LINE_DIVIDERS = "showLineDividers"
   const val PREFS_PREFER_DNS_OVER_HTTPS = "preferDnsOverHttps"
+  const val PREF_APP_THEME = "appTheme"
+
+  // Themes
+  const val THEME_LIGHT = "light"
+  const val THEME_DARK = "dark"
+  const val THEME_DEFAULT = "default"
 }

--- a/app/src/main/java/com/quran/labs/androidquran/ui/fragment/QuranSettingsFragment.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/fragment/QuranSettingsFragment.kt
@@ -16,6 +16,7 @@ import com.quran.labs.androidquran.data.Constants
 import com.quran.labs.androidquran.pageselect.PageSelectActivity
 import com.quran.labs.androidquran.ui.TranslationManagerActivity
 import com.quran.labs.androidquran.util.QuranUtils
+import com.quran.labs.androidquran.util.ThemeUtil
 import com.quran.mobile.di.ExtraPreferencesProvider
 import com.quran.mobile.feature.downloadmanager.AudioManagerActivity
 import javax.inject.Inject
@@ -53,6 +54,13 @@ class QuranSettingsFragment : PreferenceFragmentCompat() {
         LocaleListCompat.forLanguageTags("ar-EG")
       }
       AppCompatDelegate.setApplicationLocales(localeList)
+      true
+    }
+
+    // handle theme preference
+    val themePref: Preference? = findPreference(Constants.PREF_APP_THEME)
+    themePref?.onPreferenceChangeListener = Preference.OnPreferenceChangeListener { _, newValue ->
+      ThemeUtil.setTheme(newValue as String)
       true
     }
 

--- a/app/src/main/java/com/quran/labs/androidquran/util/QuranSettings.java
+++ b/app/src/main/java/com/quran/labs/androidquran/util/QuranSettings.java
@@ -226,6 +226,22 @@ public class QuranSettings {
         appContext.getResources().getBoolean(R.bool.show_sura_names_translation));
   }
 
+  public String currentTheme() {
+    final String theme = prefs.getString(Constants.PREF_APP_THEME, null);
+    if (theme == null) {
+      final int version = getVersion();
+      final String defaultTheme;
+      if (version == 0) {
+        defaultTheme = Constants.THEME_DEFAULT;
+      } else {
+        defaultTheme = Constants.THEME_DARK;
+      }
+      prefs.edit().putString(Constants.PREF_APP_THEME, defaultTheme).apply();
+      return defaultTheme;
+    }
+    return theme;
+  }
+
   // probably should eventually move this to Application.onCreate..
   public void upgradePreferences(PreferencesUpgrade preferencesUpgrade) {
     int version = getVersion();

--- a/app/src/main/java/com/quran/labs/androidquran/util/ThemeUtil.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/util/ThemeUtil.kt
@@ -1,0 +1,17 @@
+package com.quran.labs.androidquran.util
+
+import androidx.appcompat.app.AppCompatDelegate
+import com.quran.labs.androidquran.data.Constants
+
+object ThemeUtil {
+
+  fun setTheme(theme: String) {
+    val mappedTheme = when (theme) {
+      Constants.THEME_LIGHT -> AppCompatDelegate.MODE_NIGHT_NO
+      Constants.THEME_DARK -> AppCompatDelegate.MODE_NIGHT_YES
+      Constants.THEME_DEFAULT -> AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM
+      else -> AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM
+    }
+    AppCompatDelegate.setDefaultNightMode(mappedTheme)
+  }
+}

--- a/app/src/main/res/values-ar/arrays.xml
+++ b/app/src/main/res/values-ar/arrays.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <array name="themes">
+    <item>فاتح</item>
+    <item>داكن</item>
+    <item>تلقائي</item>
+  </array>
+</resources>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -68,6 +68,7 @@
   <string name="get_arabic_search_db">حمل قاعدة البيانات</string>
 
   <!-- Quran Preference Activity -->
+  <string name="appearance">المظهر</string>
   <string name="prefs_volume_key_navigation_title">تصفح بمفاتيح الصوت</string>
   <string name="prefs_volume_key_navigation_summary">استخدم مفاتيح الصوت للتصفح بين الصفحات</string>
   <string name="prefs_category_reading">إعدادات القراءة</string>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -1,14 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string-array name="download_amount_preference" translatable="false">
-        <item>@string/quran_page</item>
-        <item>@string/quran_sura</item>
-        <item>@string/quran_juz2</item>
-    </string-array>
+  <string-array name="download_amount_preference" translatable="false">
+    <item>@string/quran_page</item>
+    <item>@string/quran_sura</item>
+    <item>@string/quran_juz2</item>
+  </string-array>
 
-    <string-array name="download_amount_preference_values" translatable="false">
-        <item>1</item>
-        <item>2</item>
-        <item>3</item>
-    </string-array>
+  <string-array name="download_amount_preference_values" translatable="false">
+    <item>1</item>
+    <item>2</item>
+    <item>3</item>
+  </string-array>
+
+  <array name="themes">
+    <item>Light</item>
+    <item>Dark</item>
+    <item>Automatic</item>
+  </array>
 </resources>

--- a/app/src/main/res/values/preferences_keys.xml
+++ b/app/src/main/res/values/preferences_keys.xml
@@ -7,6 +7,7 @@
 
   <string translatable="false" name="prefs_path">quranSettings</string>
   <string translatable="false" name="prefs_advanced_path">quranAdvancedSettings</string>
+  <string translatable="false" name="prefs_app_theme">appTheme</string>
   <string translatable="false" name="prefs_new_background">useNewBackground</string>
   <string translatable="false" name="prefs_dual_page_enabled">useDualPageMode</string>
   <string translatable="false" name="prefs_night_mode">nightMode</string>
@@ -41,4 +42,11 @@
 
   <!-- Preference but value controlled by AppCompat or the OS -->
   <string translatable="false" name="use_arabic_names">useArabicNames</string>
+
+  <!-- theme property values, do not translate -->
+  <array name="theme_values" translatable="false">
+    <item>light</item>
+    <item>dark</item>
+    <item>default</item>
+  </array>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -155,6 +155,7 @@
   <string name="get_arabic_search_db">Get Arabic Search Database</string>
 
   <!-- Quran Preference Activity -->
+  <string name="appearance">Appearance</string>
   <string name="prefs_volume_key_navigation_title">Volume key navigation</string>
   <string name="prefs_volume_key_navigation_summary">Navigate between pages using volume keys</string>
   <string name="prefs_category_reading">Reading Preferences</string>

--- a/app/src/main/res/xml/quran_preferences.xml
+++ b/app/src/main/res/xml/quran_preferences.xml
@@ -18,6 +18,15 @@
         android:title="@string/prefs_use_arabic_title"
         app:iconSpaceReserved="false"/>
 
+    <androidx.preference.ListPreference
+        android:defaultValue="default"
+        android:dialogTitle="@string/appearance"
+        android:entries="@array/themes"
+        android:entryValues="@array/theme_values"
+        android:key="@string/prefs_app_theme"
+        android:title="@string/appearance"
+        app:iconSpaceReserved="false" />
+
     <CheckBoxPreference
         android:defaultValue="true"
         android:key="@string/prefs_new_background"


### PR DESCRIPTION
Add the ability to switch between day, night, and auto modes. Default to
night mode for people already using the app, and to auto mode for
everyone else.

Fixes HHAND-3199.
