### PR TITLE
Fix icon colors on some versions of Android

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/presenter/bookmark/BookmarkPresenter.java
+++ b/app/src/main/java/com/quran/labs/androidquran/presenter/bookmark/BookmarkPresenter.java
@@ -348,7 +348,7 @@ public class BookmarkPresenter implements Presenter<BookmarksFragment> {
 
     // add untagged bookmarks
     List<Bookmark> untagged = tagsMapping.get(BOOKMARKS_WITHOUT_TAGS_ID);
-    if (untagged != null && untagged.size() > 0) {
+    if (untagged != null && !untagged.isEmpty()) {
       rows.add(QuranRowFactory.fromNotTaggedHeader(appContext));
       for (int i = 0, untaggedSize = untagged.size(); i < untaggedSize; i++) {
         rows.add(quranRowFactory.fromBookmark(appContext, untagged.get(i)));
@@ -372,12 +372,12 @@ public class BookmarkPresenter implements Presenter<BookmarksFragment> {
     }
 
     // add page bookmarks header if needed
-    if (rows.size() > 0) {
+    if (!rows.isEmpty()) {
       rows.add(0, quranRowFactory.fromPageBookmarksHeader(appContext));
     }
 
     // add ayah bookmarks if any
-    if (ayahBookmarks.size() > 0) {
+    if (!ayahBookmarks.isEmpty()) {
       rows.add(quranRowFactory.fromAyahBookmarksHeader(appContext));
       for (int i = 0, ayahBookmarksSize = ayahBookmarks.size(); i < ayahBookmarksSize; i++) {
         rows.add(quranRowFactory.fromBookmark(appContext, ayahBookmarks.get(i)));

--- a/app/src/main/java/com/quran/labs/androidquran/ui/helpers/QuranListAdapter.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/helpers/QuranListAdapter.kt
@@ -8,6 +8,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
 import android.widget.TextView
+import androidx.core.content.ContextCompat
 import androidx.core.util.set
 import androidx.recyclerview.widget.RecyclerView
 import com.quran.data.model.bookmark.Tag
@@ -155,11 +156,11 @@ class QuranListAdapter(
         }
         else -> {
           image.setImageResource(item.imageResource)
-          if (item.imageFilterColor == null) {
+          if (item.imageFilterColorResource == null) {
             image.colorFilter = null
           } else {
             image.setColorFilter(
-              item.imageFilterColor, PorterDuff.Mode.SRC_ATOP
+              ContextCompat.getColor(context, item.imageFilterColorResource), PorterDuff.Mode.SRC_ATOP
             )
           }
 

--- a/app/src/main/java/com/quran/labs/androidquran/ui/helpers/QuranRow.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/helpers/QuranRow.java
@@ -1,5 +1,8 @@
 package com.quran.labs.androidquran.ui.helpers;
 
+import androidx.annotation.ColorRes;
+import androidx.annotation.DrawableRes;
+
 import com.quran.data.model.bookmark.Bookmark;
 
 public class QuranRow {
@@ -18,7 +21,7 @@ public class QuranRow {
   public String metadata;
   public int rowType;
   public Integer imageResource;
-  public Integer imageFilterColor;
+  public Integer imageFilterColorResource;
   public Integer juzType;
   public String juzOverlayText;
   public long dateAddedInMillis;
@@ -41,7 +44,7 @@ public class QuranRow {
     private long bookmarkId = -1;
     private String juzOverlayText;
     private long dateAddedInMillis;
-    private Integer imageFilterColor;
+    private Integer imageFilterColorResource;
     private Bookmark bookmark;
 
     public Builder withType(int type) {
@@ -80,13 +83,13 @@ public class QuranRow {
       return this;
     }
 
-    public Builder withImageResource(int resId) {
+    public Builder withImageResource(@DrawableRes int resId) {
       imageResource = resId;
       return this;
     }
 
-    public Builder withImageOverlayColor(int color) {
-      imageFilterColor = color;
+    public Builder withImageOverlayColorResource(@ColorRes int colorResource) {
+      imageFilterColorResource = colorResource;
       return this;
     }
 
@@ -112,13 +115,13 @@ public class QuranRow {
 
     public QuranRow build() {
       return new QuranRow(text, metadata, rowType, sura,
-          ayah, page, imageResource, imageFilterColor, juzType,
+          ayah, page, imageResource, imageFilterColorResource, juzType,
           juzOverlayText, bookmarkId, tagId, bookmark, dateAddedInMillis);
     }
   }
 
   private QuranRow(String text, String metadata, int rowType,
-      int sura, int ayah, int page, Integer imageResource, Integer filterColor,
+      int sura, int ayah, int page, Integer imageResource, Integer filterColorResource,
       Integer juzType, String juzOverlayText, long bookmarkId, long tagId, Bookmark bookmark,
                    long dateAddedInMillis) {
     this.text = text;
@@ -128,7 +131,7 @@ public class QuranRow {
     this.page = page;
     this.metadata = metadata;
     this.imageResource = imageResource;
-    this.imageFilterColor = filterColor;
+    this.imageFilterColorResource = filterColorResource;
     this.juzType = juzType;
     this.juzOverlayText = juzOverlayText;
     this.tagId = tagId;

--- a/app/src/main/java/com/quran/labs/androidquran/ui/helpers/QuranRowFactory.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/helpers/QuranRowFactory.java
@@ -2,8 +2,6 @@ package com.quran.labs.androidquran.ui.helpers;
 
 import android.content.Context;
 
-import androidx.core.content.ContextCompat;
-
 import com.quran.data.core.QuranInfo;
 import com.quran.data.model.bookmark.Bookmark;
 import com.quran.data.model.bookmark.Tag;
@@ -49,7 +47,7 @@ public class QuranRowFactory {
         .withPage(page)
         .withDate(timeStamp)
         .withImageResource(R.drawable.bookmark_currentpage)
-        .withImageOverlayColor(ContextCompat.getColor(context, R.color.icon_tint))
+        .withImageOverlayColorResource(R.color.icon_tint)
         .build();
   }
 
@@ -69,7 +67,7 @@ public class QuranRowFactory {
           .withDate(bookmark.getTimestamp())
           .withSura(sura)
           .withImageResource(com.quran.labs.androidquran.common.toolbar.R.drawable.ic_favorite)
-          .withImageOverlayColor(ContextCompat.getColor(context, R.color.icon_tint));
+          .withImageOverlayColorResource(R.color.icon_tint);
     } else {
       String ayahText = bookmark.getAyahText();
 
@@ -90,7 +88,7 @@ public class QuranRowFactory {
           .withBookmark(bookmark)
           .withDate(bookmark.getTimestamp())
           .withImageResource(com.quran.labs.androidquran.common.toolbar.R.drawable.ic_favorite)
-          .withImageOverlayColor(ContextCompat.getColor(context, R.color.ayah_bookmark_color));
+          .withImageOverlayColorResource(R.color.ayah_bookmark_color);
     }
 
     if (tagId != null) {

--- a/app/src/main/java/com/quran/labs/androidquran/widget/BookmarksWidgetListProvider.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/widget/BookmarksWidgetListProvider.kt
@@ -6,6 +6,7 @@ import android.graphics.Color
 import android.os.Bundle
 import android.widget.RemoteViews
 import android.widget.RemoteViewsService.RemoteViewsFactory
+import androidx.core.content.ContextCompat
 import com.quran.data.core.QuranInfo
 import com.quran.labs.androidquran.QuranApplication
 import com.quran.labs.androidquran.R
@@ -62,11 +63,12 @@ class BookmarksWidgetListProvider(private val context: Context) : RemoteViewsFac
     remoteView.setTextViewText(R.id.sura_title, item.text)
     remoteView.setTextViewText(R.id.sura_meta_data, item.metadata)
     remoteView.setImageViewResource(R.id.widget_favorite_icon, item.imageResource)
-    if (item.imageFilterColor == null) {
+    if (item.imageFilterColorResource == null) {
       // If a color filter isn't set, then sometimes the color filter of bookmarks can crossover into each other
       remoteView.setInt(R.id.widget_favorite_icon, "setColorFilter", Color.WHITE)
     } else {
-      remoteView.setInt(R.id.widget_favorite_icon, "setColorFilter", item.imageFilterColor)
+      val imageFilterColor = ContextCompat.getColor(context, item.imageFilterColorResource)
+      remoteView.setInt(R.id.widget_favorite_icon, "setColorFilter", imageFilterColor)
     }
     val fillInIntent = Intent().apply {
       putExtras(Bundle().apply {


### PR DESCRIPTION
The QuranRowFactory was getting tint colors using the application
context, which does not know about the current theming situation. This
updates it so that a resource id is sent instead, and then is resolved
using the correct activity context.

Ideally, nothing in QuranRowFactory should need a context, but
unfortunately, strings do at the moment, so this will have to be cleaned
up sometime in the future to avoid it causing issues when swapping
between Arabic and non-Arabic locales.
