### PR TITLE
Allow androidx-startup for OkHttp initialization

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -226,10 +226,16 @@
           android:value="true" />
     </service>
 
-    <!-- override WorkManager initialization -->
+    <!-- override WorkManager initialization, but keep androidx.startup for others -->
     <provider
         android:name="androidx.startup.InitializationProvider"
         android:authorities="${applicationId}.androidx-startup"
-        tools:node="remove" />
+        android:exported="false"
+        tools:node="merge">
+      <meta-data
+          android:name="androidx.work.WorkManagerInitializer"
+          android:value="androidx.startup"
+          tools:node="remove" />
+    </provider>
   </application>
 </manifest>


### PR DESCRIPTION
Initially, androidx-startup was disabled to override WorkManager's
initialization. However, the way being used before disabled all
androidx-startup. This patch updates it to only disable WorkManager's
initialization, thereby fixing things like OkHttp which require some
initialization for PublicSuffixDatabase, etc).

Fixes #3283.
