### PR TITLE
Replace ktx Firebase with vanilla version

### DIFF
--- a/feature/firebase-analytics/build.gradle
+++ b/feature/firebase-analytics/build.gradle
@@ -17,7 +17,7 @@ dependencies {
 
   implementation libs.androidx.annotation
 
-  implementation libs.firebase.analytics.ktx
+  implementation libs.firebase.analytics
   implementation libs.firebase.crashlytics
 
   // dagger

--- a/feature/firebase-analytics/src/main/java/com/quran/analytics/provider/FirebaseProvider.kt
+++ b/feature/firebase-analytics/src/main/java/com/quran/analytics/provider/FirebaseProvider.kt
@@ -1,9 +1,9 @@
 package com.quran.analytics.provider
 
 import android.os.Bundle
+import com.google.firebase.Firebase
 import com.google.firebase.analytics.FirebaseAnalytics
-import com.google.firebase.analytics.ktx.analytics
-import com.google.firebase.ktx.Firebase
+import com.google.firebase.analytics.analytics
 import com.quran.analytics.AnalyticsProvider
 import com.quran.mobile.feature.firebase_analytics.BuildConfig
 import javax.inject.Inject
@@ -22,6 +22,7 @@ class FirebaseProvider @Inject constructor(): AnalyticsProvider {
       }
     }
 
+    @Suppress("KotlinConstantConditions")
     if (!BuildConfig.DEBUG) {
       firebaseAnalytics.logEvent(name, bundle)
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -173,7 +173,7 @@ dnsjava = { module = "dnsjava:dnsjava", version.ref = "dnsjavaVersion" }
 
 # tools
 errorprone-core = { module = "com.google.errorprone:error_prone_core", version.ref = "errorproneCoreVersion" }
-firebase-analytics-ktx = { module = "com.google.firebase:firebase-analytics-ktx", version.ref = "firebaseAnalyticsVersion" }
+firebase-analytics = { module = "com.google.firebase:firebase-analytics", version.ref = "firebaseAnalyticsVersion" }
 firebase-crashlytics = { module = "com.google.firebase:firebase-crashlytics", version.ref = "firebaseCrashlyticsVersion" }
 
 # testing


### PR DESCRIPTION
Firebase ktx artifacts are deprecated and the recommendation is to move
to the non-ktx artifacts.

Fixes #3305.
