### PR TITLE
Fix audio being shown as loading forever

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/service/AudioService.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/service/AudioService.kt
@@ -751,9 +751,9 @@ class AudioService : Service(), Player.Listener {
     if (playerOverride) {
       if (!player.isPlaying) {
         player.play()
-        state = State.Playing
-        updateAudioPlaybackStatus()
       }
+      state = State.Playing
+      updateAudioPlaybackStatus()
       return
     }
 
@@ -771,13 +771,16 @@ class AudioService : Service(), Player.Listener {
           serviceHandler.sendEmptyMessageDelayed(MSG_START_AUDIO, 200)
         }
         return
-      } else if (audioRequest.isGapless()) {
-        serviceHandler.sendEmptyMessageDelayed(MSG_UPDATE_AUDIO_POS, 200)
       }
       player.play()
-      state = State.Playing
-      updateAudioPlaybackStatus()
     }
+
+    if (audioRequest.isGapless()) {
+      serviceHandler.sendEmptyMessageDelayed(MSG_UPDATE_AUDIO_POS, 200)
+    }
+
+    state = State.Playing
+    updateAudioPlaybackStatus()
   }
 
 


### PR DESCRIPTION
Fix bugs causing the audio to always appear to be loading forever
whenever the file changes (whether in gapped or gapless modes).
