### PR TITLE
Specify audio only playback for ExoPlayer

### DIFF
--- a/feature/autoquran/build.gradle
+++ b/feature/autoquran/build.gradle
@@ -16,7 +16,6 @@ dependencies {
   implementation libs.androidx.appcompat
   api libs.androidx.media
   implementation(libs.androidx.media3.exoplayer)
-  implementation(libs.androidx.media3.exoplayer.dash)
   api(libs.androidx.media3.session)
   implementation(libs.androidx.media3.ui)
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -77,7 +77,6 @@ turbineVersion = "1.2.1"
 [libraries]
 androidx-junit = { module = "androidx.test.ext:junit", version.ref = "junit" }
 androidx-media3-exoplayer = { module = "androidx.media3:media3-exoplayer", version.ref = "media3ExoplayerVersion" }
-androidx-media3-exoplayer-dash = { module = "androidx.media3:media3-exoplayer-dash", version.ref = "media3ExoplayerVersion" }
 androidx-media3-session = { module = "androidx.media3:media3-session", version.ref = "media3ExoplayerVersion" }
 androidx-media3-ui = { module = "androidx.media3:media3-ui", version.ref = "media3ExoplayerVersion" }
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutinesVersion" }


### PR DESCRIPTION
Set the RenderersFactory to only support audio. This will allow r8 to
remove video renderers that the app will not use. Also remove the dash
artifact since we don't need it.
