### PR TITLE
Improve dns lookups

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/data/Constants.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/data/Constants.kt
@@ -90,7 +90,6 @@ object Constants {
   const val PREF_SURA_TRANSLATED_NAME = "suraTranslatedName"
   const val PREF_SHOW_SIDELINES = "showSidelines"
   const val PREF_SHOW_LINE_DIVIDERS = "showLineDividers"
-  const val PREFS_PREFER_DNS_OVER_HTTPS = "preferDnsOverHttps"
   const val PREF_APP_THEME = "appTheme"
 
   // Themes

--- a/app/src/main/java/com/quran/labs/androidquran/util/QuranSettings.java
+++ b/app/src/main/java/com/quran/labs/androidquran/util/QuranSettings.java
@@ -146,14 +146,6 @@ public class QuranSettings {
         Constants.DEFAULT_TEXT_SIZE);
   }
 
-  public boolean getPreferDnsOverHttps() {
-    return prefs.getBoolean(Constants.PREFS_PREFER_DNS_OVER_HTTPS, true);
-  }
-
-  public void setPreferDnsOverHttps(boolean preferDnsOverHttps) {
-    prefs.edit().putBoolean(Constants.PREFS_PREFER_DNS_OVER_HTTPS, preferDnsOverHttps).apply();
-  }
-
   public int getLastPage() {
     return prefs.getInt(Constants.PREF_LAST_PAGE, Constants.NO_PAGE);
   }

--- a/app/src/main/java/com/quran/labs/androidquran/util/SettingsImpl.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/util/SettingsImpl.kt
@@ -98,11 +98,5 @@ class SettingsImpl @Inject constructor(private val quranSettings: QuranSettings)
 
   override suspend fun translationTextSize(): Int = quranSettings.translationTextSize
 
-  override suspend fun preferDnsOverHttps(): Boolean = quranSettings.preferDnsOverHttps
-
-  override suspend fun setPreferDnsOverHttps(value: Boolean) {
-    quranSettings.preferDnsOverHttps = value
-  }
-
   override fun preferencesFlow(): Flow<String> = preferencesFlow
 }

--- a/app/src/main/res/values-uz/strings.xml
+++ b/app/src/main/res/values-uz/strings.xml
@@ -184,9 +184,6 @@
   <string name="prefs_sura_translated_name_title">Sura nomi tarjimasi</string>
   <string name="prefs_sura_translated_name_summary">Sura nomi tarjimasi koʻrsatilsin</string>
   <string name="prefs_preview">Oldindan koʻrish</string>
-  <string name="prefs_dns_over_https_title">HTTPS orqali DNS</string>
-  <string name="prefs_dns_over_https_summary_on">""</string>
-  <string name="prefs_dns_over_https_summary_off">""</string>
   <string name="prefs_ayah_text_title">Oyat matni hajmi</string>
   <string name="prefs_export_csv_title">CSV formatda eksport</string>
   <string name="prefs_export_csv_summary">Xatchoʻp va teglarni CSV formatda eksport qilish</string>

--- a/app/src/main/res/values/preferences_keys.xml
+++ b/app/src/main/res/values/preferences_keys.xml
@@ -38,7 +38,6 @@
   <string translatable="false" name="prefs_send_logs">sendLogsKey</string>
   <string translatable="false" name="prefs_page_type">pageTypeKey</string>
   <string translatable="false" name="prefs_category_dual_screen_key">dualScreenKey</string>
-  <string translatable="false" name="prefs_prefer_dns_over_https">preferDnsOverHttps</string>
 
   <!-- Preference but value controlled by AppCompat or the OS -->
   <string translatable="false" name="use_arabic_names">useArabicNames</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -177,9 +177,6 @@
   <string name="prefs_night_mode_text_brightness_summary">Brightness of the text when night mode is active</string>
   <string name="prefs_night_mode_background_brightness_title">Background brightness</string>
   <string name="prefs_night_mode_background_brightness_summary">Brightness of the page when night mode is active</string>
-  <string name="prefs_dns_over_https_title">DNS over HTTPS</string>
-  <string name="prefs_dns_over_https_summary_on">Prefer DNS over HTTPS</string>
-  <string name="prefs_dns_over_https_summary_off">Do not use DNS over HTTPS</string>
   <string name="prefs_overlay_page_info_title">Show page info</string>
   <string name="prefs_overlay_page_info_summary">Overlay page number, surah name, and juz\' number while reading</string>
   <string name="prefs_display_marker_title">Display marker popups</string>

--- a/app/src/main/res/xml/quran_advanced_preferences.xml
+++ b/app/src/main/res/xml/quran_advanced_preferences.xml
@@ -28,14 +28,6 @@
       android:title="@string/prefs_app_location_title"
       app:iconSpaceReserved="false"/>
 
-  <CheckBoxPreference
-      android:key="@string/prefs_prefer_dns_over_https"
-      android:persistent="true"
-      android:title="@string/prefs_dns_over_https_title"
-      android:summaryOn="@string/prefs_dns_over_https_summary_on"
-      android:summaryOff="@string/prefs_dns_over_https_summary_off"
-      app:iconSpaceReserved="false"/>
-
   <Preference
       android:key="@string/prefs_send_logs"
       android:summary="@string/prefs_send_logs_summary"

--- a/common/data/src/main/java/com/quran/data/dao/Settings.kt
+++ b/common/data/src/main/java/com/quran/data/dao/Settings.kt
@@ -18,8 +18,6 @@ interface Settings {
   suspend fun setShouldShowLineDividers(show: Boolean)
   suspend fun setAyahTextSize(value: Int)
   suspend fun translationTextSize(): Int
-  suspend fun preferDnsOverHttps(): Boolean
-  suspend fun setPreferDnsOverHttps(value: Boolean)
 
   fun preferencesFlow(): Flow<String>
 }

--- a/common/networking/build.gradle.kts
+++ b/common/networking/build.gradle.kts
@@ -21,4 +21,6 @@ dependencies {
   implementation(libs.dnsjava)
   implementation(libs.okhttp.dnsoverhttps)
   api(libs.okhttp.tls)
+
+  implementation(libs.timber)
 }

--- a/common/networking/src/main/java/com/quran/common/networking/dns/MultiDns.kt
+++ b/common/networking/src/main/java/com/quran/common/networking/dns/MultiDns.kt
@@ -1,21 +1,53 @@
 package com.quran.common.networking.dns
 
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.selects.select
 import okhttp3.Dns
+import timber.log.Timber
 import java.net.InetAddress
 import java.net.UnknownHostException
 
 class MultiDns(private val servers: List<Dns>) : Dns {
 
   override fun lookup(hostname: String): MutableList<InetAddress> {
-    var lastException: Exception? = null
-    for (i in servers.indices) {
-      try {
-        return servers[i].lookup(hostname).toMutableList()
-      } catch (unknownHostException: UnknownHostException) {
-        lastException = unknownHostException
+    return runBlocking {
+      val start = System.currentTimeMillis()
+      coroutineScope {
+        val deferreds = servers.map { dns ->
+          async(Dispatchers.IO) { runCatching { dns.lookup(hostname).toMutableList() } }
+        }
+
+        val remaining = deferreds.toMutableList()
+        val exceptions = mutableListOf<Throwable>()
+
+        while (remaining.isNotEmpty()) {
+          val (result, completedDeferred) = select<Pair<Result<MutableList<InetAddress>>, *>> {
+            remaining.withIndex().forEach { (index, deferred) ->
+              deferred.onAwait { answer ->
+                Timber.d("DNS server ${servers[index]} responded for $hostname in ${System.currentTimeMillis() - start}ms")
+                answer to deferred }
+            }
+          }
+
+          remaining.remove(completedDeferred)
+          result.onSuccess { successResult ->
+            // first one to succeed wins
+            remaining.forEach { it.cancel() }
+            return@coroutineScope successResult
+          }.onFailure { exception ->
+            // This one failed, let's wait for the others
+            exceptions.add(exception)
+          }
+        }
+
+        // all lookups failed
+        val primaryException = UnknownHostException("All DNS servers failed for hostname: $hostname")
+        exceptions.forEach { primaryException.addSuppressed(it) }
+        throw primaryException
       }
     }
-
-    throw lastException!!
   }
 }

--- a/pages/common/madani/src/main/kotlin/com/quran/labs/androidquran/pages/common/madani/upgrade/MadaniPreferencesUpgrade.kt
+++ b/pages/common/madani/src/main/kotlin/com/quran/labs/androidquran/pages/common/madani/upgrade/MadaniPreferencesUpgrade.kt
@@ -27,7 +27,6 @@ class MadaniPreferencesUpgrade @Inject constructor(private val settings: Setting
 
       if (from <= 3441) {
         settings.setAyahTextSize(settings.translationTextSize())
-        settings.setPreferDnsOverHttps(true)
       }
     }
     return true


### PR DESCRIPTION
This patch does a few things:
- re-adds Dns.SYSTEM - this wasn't actually a default in DnsFallback
- removes the advanced setting for DnsOverHttps
- instead of iterating through all the dns servers sequentially and
  using the first response, query all providers in parallel and return
  the first result.

Fixes #3235.
