### PR TITLE
Allow toolbar and audio bar height to change

### DIFF
--- a/app/src/main/res/layout/quran_page_activity.xml
+++ b/app/src/main/res/layout/quran_page_activity.xml
@@ -29,7 +29,8 @@
     <androidx.appcompat.widget.Toolbar
         android:id="@+id/toolbar"
         android:layout_width="match_parent"
-        android:layout_height="?attr/actionBarSize"
+        android:layout_height="wrap_content"
+        android:minHeight="?attr/actionBarSize"
         android:theme="@style/ToolbarStyle"
         app:popupTheme="@style/ThemeOverlay.AppCompat.DayNight"
         app:titleTextAppearance="@style/ToolbarTitleText"

--- a/feature/audiobar/src/main/kotlin/com/quran/mobile/feature/audiobar/AudioBarWrapper.kt
+++ b/feature/audiobar/src/main/kotlin/com/quran/mobile/feature/audiobar/AudioBarWrapper.kt
@@ -8,7 +8,7 @@ import androidx.compose.foundation.layout.add
 import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.displayCutout
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
@@ -71,7 +71,7 @@ class AudioBarWrapper @JvmOverloads constructor(
             )
             .padding(top = 8.dp)
             .padding(horizontal = 16.dp)
-            .height(dimensionResource(id = R.dimen.audiobar_height))
+            .heightIn(min = dimensionResource(id = R.dimen.audiobar_height))
         )
       }
     }

--- a/feature/audiobar/src/main/kotlin/com/quran/mobile/feature/audiobar/ui/AudioBar.kt
+++ b/feature/audiobar/src/main/kotlin/com/quran/mobile/feature/audiobar/ui/AudioBar.kt
@@ -1,7 +1,6 @@
 package com.quran.mobile.feature.audiobar.ui
 
 import android.content.res.Configuration
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -30,7 +29,7 @@ internal fun AudioBar(
   eventListeners: AudioBarUiEvents,
   modifier: Modifier = Modifier
 ) {
-  val updatedModifier = modifier.fillMaxSize()
+  val updatedModifier = modifier
 
   when (audioBarState) {
     is AudioBarState.Paused -> PausedAudioBar(


### PR DESCRIPTION
Instead of forcing the toolbar and audio bar to be the default, make
that the minimum height and wrap content to support cases where font
sizes or display sizes are increased.

Fixes #3230.
