### PR TITLE
Do not wait for all DNS resolvers to return

### DIFF
--- a/common/networking/src/main/java/com/quran/common/networking/dns/MultiDns.kt
+++ b/common/networking/src/main/java/com/quran/common/networking/dns/MultiDns.kt
@@ -1,8 +1,10 @@
 package com.quran.common.networking.dns
 
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
-import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.selects.select
 import okhttp3.Dns
@@ -15,38 +17,47 @@ class MultiDns(private val servers: List<Dns>) : Dns {
   override fun lookup(hostname: String): MutableList<InetAddress> {
     return runBlocking {
       val start = System.currentTimeMillis()
-      coroutineScope {
-        val deferreds = servers.map { dns ->
-          async(Dispatchers.IO) { runCatching { dns.lookup(hostname).toMutableList() } }
+
+      val job = SupervisorJob()
+      val externalScope = CoroutineScope(Dispatchers.IO + job)
+
+      val tasks: List<Pair<Deferred<Result<MutableList<InetAddress>>>, Dns>> =
+        servers.map { dns ->
+          externalScope.async {
+            runCatching { dns.lookup(hostname).toMutableList() }
+          } to dns
         }
 
-        val remaining = deferreds.toMutableList()
+      try {
+        val remaining = tasks.toMutableList()
         val exceptions = mutableListOf<Throwable>()
 
         while (remaining.isNotEmpty()) {
-          val (result, completedDeferred) = select<Pair<Result<MutableList<InetAddress>>, *>> {
-            remaining.withIndex().forEach { (index, deferred) ->
+          val (result, completedDeferred, provider) = select<Triple<Result<MutableList<InetAddress>>, Deferred<Result<MutableList<InetAddress>>>, Dns>> {
+            remaining.forEach { (deferred, dns) ->
               deferred.onAwait { answer ->
-                Timber.d("DNS server ${servers[index]} responded for $hostname in ${System.currentTimeMillis() - start}ms")
-                answer to deferred }
+                Timber.d("DNS server $dns responded for $hostname in ${System.currentTimeMillis() - start}ms")
+                Triple(answer, deferred, dns)
+              }
             }
           }
 
-          remaining.remove(completedDeferred)
+          remaining.removeAll { it.first == completedDeferred }
+
           result.onSuccess { successResult ->
-            // first one to succeed wins
-            remaining.forEach { it.cancel() }
-            return@coroutineScope successResult
+            Timber.d("DNS got result from $provider; cancelling others and returning")
+            job.cancel()
+            return@runBlocking successResult
           }.onFailure { exception ->
-            // This one failed, let's wait for the others
             exceptions.add(exception)
           }
         }
 
-        // all lookups failed
         val primaryException = UnknownHostException("All DNS servers failed for hostname: $hostname")
-        exceptions.forEach { primaryException.addSuppressed(it) }
+        exceptions.forEach(primaryException::addSuppressed)
         throw primaryException
+      } finally {
+        job.cancel()
       }
     }
   }


### PR DESCRIPTION
Previously, due to the coroutine scope, MultiDns was forced to await all
dns providers to finish before returning. Since the lookups are blocking
calls and do not respect cancellation, this could take some time. This
patch fixes it so they're in a separate coroutine scope, so that we
don't have to wait on the cancellation before returning.
