### PR TITLE
Remove automotive required tag

### DIFF
--- a/feature/autoquran/src/main/AndroidManifest.xml
+++ b/feature/autoquran/src/main/AndroidManifest.xml
@@ -2,12 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
-  <uses-feature
-      android:name="android.hardware.type.automotive"
-      android:required="false" />
   <uses-permission android:name="android.permission.INTERNET" />
   <uses-permission android:name="android.permission.WAKE_LOCK" />
-
 
   <application>
     <meta-data


### PR DESCRIPTION
The Play Store does not allow combining the hardware required tag with
com.google.android.gms.car.application, so remove it.
