### PR TITLE
Fix missing basmallah for gapless playback

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/service/AudioService.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/service/AudioService.kt
@@ -825,8 +825,12 @@ class AudioService : Service(), Player.Listener {
           MediaItem.fromUri(url)
         }
 
-        val potentialTiming = timings?.get(localAudioQueue.getCurrentAyah(), -1) ?: -1
-        if (potentialTiming > -1 && overrideResource == 0) {
+        val potentialTiming = if (timings != null && overrideResource == 0) {
+          getSeekPosition(false)
+        } else {
+          -1
+        }
+        if (potentialTiming > -1) {
           localPlayer.setMediaItem(mediaItem, potentialTiming)
         } else {
           localPlayer.setMediaItem(mediaItem)


### PR DESCRIPTION
When playing from a gapless sura, the MediaPlayer code used to start at
the timestamp for ayah=0 (usually the basmallah for suras that aren't
Fatiha nor Tawba), falling back to ayah=1 otherwise. During the
migration to ExoPlayer, this was inadvertently changed to always start
at ayah=1, preventing the basmallah from playing.
