### PR TITLE
Fix basmallah between repeats

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/service/AudioService.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/service/AudioService.kt
@@ -732,7 +732,8 @@ class AudioService : Service(), Player.Listener {
       processUpdatePlaybackSpeed(speed)
     }
 
-    if (audioRequest?.isGapless() == true) {
+    if (audioRequest?.isGapless() == true && !playerOverride) {
+      Timber.d("configAndStartExoPlayer: restarting position updates")
       serviceHandler.sendEmptyMessageDelayed(MSG_UPDATE_AUDIO_POS, 200)
     }
   }


### PR DESCRIPTION
Due to a migration bug when moving from MediaPlayer to ExoPlayer, the
timing updater was run while the basmallah was playing in between sura
transitions during repeat ranges, causing the basmallah to not play or
be cut off. This fixes it to not restart the timing updater for player
overrides (basmallah playbacks).
