### PR TITLE
Fix silent crash for audio updates

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/worker/AudioUpdateWorker.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/worker/AudioUpdateWorker.kt
@@ -39,7 +39,8 @@ class AudioUpdateWorker(
     val audioPathRoot = quranFileUtils.getQuranAudioDirectory(context)
     if (audioPathRoot != null) {
       val currentVersion = quranSettings.currentAudioRevision
-      val updates = audioUpdateService.getUpdates(currentVersion)
+      val response = audioUpdateService.getUpdates(currentVersion)
+      val updates = if (response.isSuccessful) response.body() else null
 
       if (updates != null && currentVersion != updates.currentRevision) {
         Timber.d("local version: %d - server version: %d",

--- a/feature/audio/src/main/java/com/quran/labs/androidquran/feature/audio/api/AudioUpdateService.kt
+++ b/feature/audio/src/main/java/com/quran/labs/androidquran/feature/audio/api/AudioUpdateService.kt
@@ -1,9 +1,10 @@
 package com.quran.labs.androidquran.feature.audio.api
 
+import retrofit2.Response
 import retrofit2.http.GET
 import retrofit2.http.Query
 
 interface AudioUpdateService {
   @GET("/data/audio_updates.php")
-  suspend fun getUpdates(@Query("revision") revision: Int): AudioUpdates?
+  suspend fun getUpdates(@Query("revision") revision: Int): Response<AudioUpdates>
 }


### PR DESCRIPTION
The audio update worker returns 204 when there are no new audio updates.
Return a Response wrapper instead to be able to better handle this case.
