### PR TITLE
Remove material-icons-extended

### DIFF
--- a/common/ui/core/build.gradle
+++ b/common/ui/core/build.gradle
@@ -7,7 +7,6 @@ android.namespace 'com.quran.mobile.common.ui.core'
 dependencies {
   implementation libs.compose.foundation
   implementation libs.compose.material
-  implementation libs.compose.material.icons
   implementation libs.compose.material3
   implementation libs.compose.ui
   implementation libs.compose.ui.tooling.preview

--- a/common/ui/core/src/main/java/com/quran/labs/androidquran/common/ui/core/Theme.kt
+++ b/common/ui/core/src/main/java/com/quran/labs/androidquran/common/ui/core/Theme.kt
@@ -2,80 +2,96 @@ package com.quran.labs.androidquran.common.ui.core
 
 import android.os.Build
 import androidx.compose.foundation.isSystemInDarkTheme
-import androidx.compose.material.icons.Icons
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.LayoutDirection
 
 private val LightColors = lightColorScheme(
-    primary = lightPrimary,
-    onPrimary = lightOnPrimary,
-    primaryContainer = lightPrimaryContainer,
-    onPrimaryContainer = lightOnPrimaryContainer,
-    secondary = lightSecondary,
-    onSecondary = lightOnSecondary,
-    secondaryContainer = lightSecondaryContainer,
-    onSecondaryContainer = lightOnSecondaryContainer,
-    tertiary = lightTertiary,
-    onTertiary = lightOnTertiary,
-    tertiaryContainer = lightTertiaryContainer,
-    onTertiaryContainer = lightOnTertiaryContainer,
-    error = lightError,
-    errorContainer = lightErrorContainer,
-    onError = lightOnError,
-    onErrorContainer = lightOnErrorContainer,
-    background = lightBackground,
-    onBackground = lightOnBackground,
-    surface = lightSurface,
-    onSurface = lightOnSurface,
-    surfaceVariant = lightSurfaceVariant,
-    onSurfaceVariant = lightOnSurfaceVariant,
-    outline = lightOutline,
-    inverseOnSurface = lightInverseOnSurface,
-    inverseSurface = lightInverseSurface,
-    inversePrimary = lightInversePrimary,
-    surfaceTint = lightSurfaceTint,
-    surfaceContainerHighest = lightSurfaceColorHighest
+  primary = lightPrimary,
+  onPrimary = lightOnPrimary,
+  primaryContainer = lightPrimaryContainer,
+  onPrimaryContainer = lightOnPrimaryContainer,
+  secondary = lightSecondary,
+  onSecondary = lightOnSecondary,
+  secondaryContainer = lightSecondaryContainer,
+  onSecondaryContainer = lightOnSecondaryContainer,
+  tertiary = lightTertiary,
+  onTertiary = lightOnTertiary,
+  tertiaryContainer = lightTertiaryContainer,
+  onTertiaryContainer = lightOnTertiaryContainer,
+  error = lightError,
+  errorContainer = lightErrorContainer,
+  onError = lightOnError,
+  onErrorContainer = lightOnErrorContainer,
+  background = lightBackground,
+  onBackground = lightOnBackground,
+  surface = lightSurface,
+  onSurface = lightOnSurface,
+  surfaceVariant = lightSurfaceVariant,
+  onSurfaceVariant = lightOnSurfaceVariant,
+  outline = lightOutline,
+  inverseOnSurface = lightInverseOnSurface,
+  inverseSurface = lightInverseSurface,
+  inversePrimary = lightInversePrimary,
+  surfaceTint = lightSurfaceTint,
+  surfaceContainerHighest = lightSurfaceColorHighest
 )
 
 private val DarkColors = darkColorScheme(
-    primary = darkPrimary,
-    onPrimary = darkOnPrimary,
-    primaryContainer = darkPrimaryContainer,
-    onPrimaryContainer = darkOnPrimaryContainer,
-    secondary = darkSecondary,
-    onSecondary = darkOnSecondary,
-    secondaryContainer = darkSecondaryContainer,
-    onSecondaryContainer = darkOnSecondaryContainer,
-    tertiary = darkTertiary,
-    onTertiary = darkOnTertiary,
-    tertiaryContainer = darkTertiaryContainer,
-    onTertiaryContainer = darkOnTertiaryContainer,
-    error = darkError,
-    errorContainer = darkErrorContainer,
-    onError = darkOnError,
-    onErrorContainer = darkOnErrorContainer,
-    background = darkBackground,
-    onBackground = darkOnBackground,
-    surface = darkSurface,
-    onSurface = darkOnSurface,
-    surfaceVariant = darkSurfaceVariant,
-    onSurfaceVariant = darkOnSurfaceVariant,
-    outline = darkOutline,
-    inverseOnSurface = darkInverseOnSurface,
-    inverseSurface = darkInverseSurface,
-    inversePrimary = darkInversePrimary,
-    surfaceTint = darkSurfaceTint,
-    surfaceContainerHighest = darkSurfaceColorHighest
+  primary = darkPrimary,
+  onPrimary = darkOnPrimary,
+  primaryContainer = darkPrimaryContainer,
+  onPrimaryContainer = darkOnPrimaryContainer,
+  secondary = darkSecondary,
+  onSecondary = darkOnSecondary,
+  secondaryContainer = darkSecondaryContainer,
+  onSecondaryContainer = darkOnSecondaryContainer,
+  tertiary = darkTertiary,
+  onTertiary = darkOnTertiary,
+  tertiaryContainer = darkTertiaryContainer,
+  onTertiaryContainer = darkOnTertiaryContainer,
+  error = darkError,
+  errorContainer = darkErrorContainer,
+  onError = darkOnError,
+  onErrorContainer = darkOnErrorContainer,
+  background = darkBackground,
+  onBackground = darkOnBackground,
+  surface = darkSurface,
+  onSurface = darkOnSurface,
+  surfaceVariant = darkSurfaceVariant,
+  onSurfaceVariant = darkOnSurfaceVariant,
+  outline = darkOutline,
+  inverseOnSurface = darkInverseOnSurface,
+  inverseSurface = darkInverseSurface,
+  inversePrimary = darkInversePrimary,
+  surfaceTint = darkSurfaceTint,
+  surfaceContainerHighest = darkSurfaceColorHighest
 )
 
 private val forceLtr = listOf("huawei", "lenovo", "tecno")
 
-val QuranIcons = Icons.Filled
+object QuranIcons {
+  val ArrowBack: ImageVector get() = com.quran.labs.androidquran.common.ui.core.icons.ArrowBack
+  val Chat: ImageVector get() = com.quran.labs.androidquran.common.ui.core.icons.Chat
+  val Check: ImageVector get() = com.quran.labs.androidquran.common.ui.core.icons.Check
+  val Close: ImageVector get() = com.quran.labs.androidquran.common.ui.core.icons.Close
+  val ExpandMore: ImageVector get() = com.quran.labs.androidquran.common.ui.core.icons.ExpandMore
+  val FastForward: ImageVector get() = com.quran.labs.androidquran.common.ui.core.icons.FastForward
+  val FastRewind: ImageVector get() = com.quran.labs.androidquran.common.ui.core.icons.FastRewind
+  val MenuBook: ImageVector get() = com.quran.labs.androidquran.common.ui.core.icons.MenuBook
+  val Mic: ImageVector get() = com.quran.labs.androidquran.common.ui.core.icons.Mic
+  val Pause: ImageVector get() = com.quran.labs.androidquran.common.ui.core.icons.Pause
+  val PlayArrow: ImageVector get() = com.quran.labs.androidquran.common.ui.core.icons.PlayArrow
+  val Repeat: ImageVector get() = com.quran.labs.androidquran.common.ui.core.icons.Repeat
+  val Settings: ImageVector get() = com.quran.labs.androidquran.common.ui.core.icons.Settings
+  val Speed: ImageVector get() = com.quran.labs.androidquran.common.ui.core.icons.Speed
+  val Stop: ImageVector get() = com.quran.labs.androidquran.common.ui.core.icons.Stop
+}
 
 @Composable
 fun QuranTheme(

--- a/common/ui/core/src/main/java/com/quran/labs/androidquran/common/ui/core/icons/ArrowBack.kt
+++ b/common/ui/core/src/main/java/com/quran/labs/androidquran/common/ui/core/icons/ArrowBack.kt
@@ -1,0 +1,30 @@
+package com.quran.labs.androidquran.common.ui.core.icons
+
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.tooling.preview.Preview
+
+val ArrowBack: ImageVector by lazy {
+  materialIcon(name = "Filled.ArrowBack", autoMirror = true) {
+    materialPath {
+      moveTo(20.0f, 11.0f)
+      horizontalLineTo(7.83f)
+      lineToRelative(5.59f, -5.59f)
+      lineTo(12.0f, 4.0f)
+      lineToRelative(-8.0f, 8.0f)
+      lineToRelative(8.0f, 8.0f)
+      lineToRelative(1.41f, -1.41f)
+      lineTo(7.83f, 13.0f)
+      horizontalLineTo(20.0f)
+      verticalLineToRelative(-2.0f)
+      close()
+    }
+  }
+}
+
+@Preview
+@Composable
+private fun ArrowBackIconPreview() {
+  Icon(imageVector = ArrowBack, contentDescription = null)
+}

--- a/common/ui/core/src/main/java/com/quran/labs/androidquran/common/ui/core/icons/Chat.kt
+++ b/common/ui/core/src/main/java/com/quran/labs/androidquran/common/ui/core/icons/Chat.kt
@@ -1,0 +1,47 @@
+package com.quran.labs.androidquran.common.ui.core.icons
+
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.tooling.preview.Preview
+
+val Chat: ImageVector by lazy {
+  materialIcon(name = "Filled.Chat", autoMirror = true) {
+    materialPath {
+      moveTo(20.0f, 2.0f)
+      lineTo(4.0f, 2.0f)
+      curveToRelative(-1.1f, 0.0f, -1.99f, 0.9f, -1.99f, 2.0f)
+      lineTo(2.0f, 22.0f)
+      lineToRelative(4.0f, -4.0f)
+      horizontalLineToRelative(14.0f)
+      curveToRelative(1.1f, 0.0f, 2.0f, -0.9f, 2.0f, -2.0f)
+      lineTo(22.0f, 4.0f)
+      curveToRelative(0.0f, -1.1f, -0.9f, -2.0f, -2.0f, -2.0f)
+      close()
+      moveTo(6.0f, 9.0f)
+      horizontalLineToRelative(12.0f)
+      verticalLineToRelative(2.0f)
+      lineTo(6.0f, 11.0f)
+      lineTo(6.0f, 9.0f)
+      close()
+      moveTo(14.0f, 14.0f)
+      lineTo(6.0f, 14.0f)
+      verticalLineToRelative(-2.0f)
+      horizontalLineToRelative(8.0f)
+      verticalLineToRelative(2.0f)
+      close()
+      moveTo(18.0f, 8.0f)
+      lineTo(6.0f, 8.0f)
+      lineTo(6.0f, 6.0f)
+      horizontalLineToRelative(12.0f)
+      verticalLineToRelative(2.0f)
+      close()
+    }
+  }
+}
+
+@Preview
+@Composable
+private fun ChatIconPreview() {
+  Icon(imageVector = Chat, contentDescription = null)
+}

--- a/common/ui/core/src/main/java/com/quran/labs/androidquran/common/ui/core/icons/Check.kt
+++ b/common/ui/core/src/main/java/com/quran/labs/androidquran/common/ui/core/icons/Check.kt
@@ -1,0 +1,26 @@
+package com.quran.labs.androidquran.common.ui.core.icons
+
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.tooling.preview.Preview
+
+val Check: ImageVector by lazy {
+  materialIcon(name = "Filled.Check") {
+    materialPath {
+      moveTo(9.0f, 16.17f)
+      lineTo(4.83f, 12.0f)
+      lineToRelative(-1.42f, 1.41f)
+      lineTo(9.0f, 19.0f)
+      lineTo(21.0f, 7.0f)
+      lineToRelative(-1.41f, -1.41f)
+      close()
+    }
+  }
+}
+
+@Preview
+@Composable
+private fun CheckIconPreview() {
+  Icon(imageVector = Check, contentDescription = null)
+}

--- a/common/ui/core/src/main/java/com/quran/labs/androidquran/common/ui/core/icons/Close.kt
+++ b/common/ui/core/src/main/java/com/quran/labs/androidquran/common/ui/core/icons/Close.kt
@@ -1,0 +1,32 @@
+package com.quran.labs.androidquran.common.ui.core.icons
+
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.tooling.preview.Preview
+
+val Close: ImageVector by lazy {
+  materialIcon(name = "Filled.Close") {
+    materialPath {
+      moveTo(19.0f, 6.41f)
+      lineTo(17.59f, 5.0f)
+      lineTo(12.0f, 10.59f)
+      lineTo(6.41f, 5.0f)
+      lineTo(5.0f, 6.41f)
+      lineTo(10.59f, 12.0f)
+      lineTo(5.0f, 17.59f)
+      lineTo(6.41f, 19.0f)
+      lineTo(12.0f, 13.41f)
+      lineTo(17.59f, 19.0f)
+      lineTo(19.0f, 17.59f)
+      lineTo(13.41f, 12.0f)
+      close()
+    }
+  }
+}
+
+@Preview
+@Composable
+private fun CloseIconPreview() {
+  Icon(imageVector = Close, contentDescription = null)
+}

--- a/common/ui/core/src/main/java/com/quran/labs/androidquran/common/ui/core/icons/ExpandMore.kt
+++ b/common/ui/core/src/main/java/com/quran/labs/androidquran/common/ui/core/icons/ExpandMore.kt
@@ -1,0 +1,26 @@
+package com.quran.labs.androidquran.common.ui.core.icons
+
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.tooling.preview.Preview
+
+val ExpandMore: ImageVector by lazy {
+  materialIcon(name = "Filled.ExpandMore") {
+    materialPath {
+      moveTo(16.59f, 8.59f)
+      lineTo(12.0f, 13.17f)
+      lineTo(7.41f, 8.59f)
+      lineTo(6.0f, 10.0f)
+      lineToRelative(6.0f, 6.0f)
+      lineToRelative(6.0f, -6.0f)
+      close()
+    }
+  }
+}
+
+@Preview
+@Composable
+private fun ExpandMoreIconPreview() {
+  Icon(imageVector = ExpandMore, contentDescription = null)
+}

--- a/common/ui/core/src/main/java/com/quran/labs/androidquran/common/ui/core/icons/FastForward.kt
+++ b/common/ui/core/src/main/java/com/quran/labs/androidquran/common/ui/core/icons/FastForward.kt
@@ -1,0 +1,29 @@
+package com.quran.labs.androidquran.common.ui.core.icons
+
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.tooling.preview.Preview
+
+val FastForward: ImageVector by lazy {
+  materialIcon(name = "Filled.FastForward") {
+    materialPath {
+      moveTo(4.0f, 18.0f)
+      lineToRelative(8.5f, -6.0f)
+      lineTo(4.0f, 6.0f)
+      verticalLineToRelative(12.0f)
+      close()
+      moveTo(13.0f, 6.0f)
+      verticalLineToRelative(12.0f)
+      lineToRelative(8.5f, -6.0f)
+      lineTo(13.0f, 6.0f)
+      close()
+    }
+  }
+}
+
+@Preview
+@Composable
+private fun FastForwardIconPreview() {
+  Icon(imageVector = FastForward, contentDescription = null)
+}

--- a/common/ui/core/src/main/java/com/quran/labs/androidquran/common/ui/core/icons/FastRewind.kt
+++ b/common/ui/core/src/main/java/com/quran/labs/androidquran/common/ui/core/icons/FastRewind.kt
@@ -1,0 +1,29 @@
+package com.quran.labs.androidquran.common.ui.core.icons
+
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.tooling.preview.Preview
+
+val FastRewind: ImageVector by lazy {
+  materialIcon(name = "Filled.FastRewind") {
+    materialPath {
+      moveTo(11.0f, 18.0f)
+      lineTo(11.0f, 6.0f)
+      lineToRelative(-8.5f, 6.0f)
+      lineToRelative(8.5f, 6.0f)
+      close()
+      moveTo(11.5f, 12.0f)
+      lineToRelative(8.5f, 6.0f)
+      lineTo(20.0f, 6.0f)
+      lineToRelative(-8.5f, 6.0f)
+      close()
+    }
+  }
+}
+
+@Preview
+@Composable
+private fun FastRewindIconPreview() {
+  Icon(imageVector = FastRewind, contentDescription = null)
+}

--- a/common/ui/core/src/main/java/com/quran/labs/androidquran/common/ui/core/icons/MenuBook.kt
+++ b/common/ui/core/src/main/java/com/quran/labs/androidquran/common/ui/core/icons/MenuBook.kt
@@ -1,0 +1,74 @@
+package com.quran.labs.androidquran.common.ui.core.icons
+
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.tooling.preview.Preview
+
+val MenuBook: ImageVector by lazy {
+  materialIcon(name = "Filled.MenuBook", autoMirror = true) {
+    materialPath {
+      moveTo(21.0f, 5.0f)
+      curveToRelative(-1.11f, -0.35f, -2.33f, -0.5f, -3.5f, -0.5f)
+      curveToRelative(-1.95f, 0.0f, -4.05f, 0.4f, -5.5f, 1.5f)
+      curveToRelative(-1.45f, -1.1f, -3.55f, -1.5f, -5.5f, -1.5f)
+      reflectiveCurveTo(2.45f, 4.9f, 1.0f, 6.0f)
+      verticalLineToRelative(14.65f)
+      curveToRelative(0.0f, 0.25f, 0.25f, 0.5f, 0.5f, 0.5f)
+      curveToRelative(0.1f, 0.0f, 0.15f, -0.05f, 0.25f, -0.05f)
+      curveTo(3.1f, 20.45f, 5.05f, 20.0f, 6.5f, 20.0f)
+      curveToRelative(1.95f, 0.0f, 4.05f, 0.4f, 5.5f, 1.5f)
+      curveToRelative(1.35f, -0.85f, 3.8f, -1.5f, 5.5f, -1.5f)
+      curveToRelative(1.65f, 0.0f, 3.35f, 0.3f, 4.75f, 1.05f)
+      curveToRelative(0.1f, 0.05f, 0.15f, 0.05f, 0.25f, 0.05f)
+      curveToRelative(0.25f, 0.0f, 0.5f, -0.25f, 0.5f, -0.5f)
+      verticalLineTo(6.0f)
+      curveTo(22.4f, 5.55f, 21.75f, 5.25f, 21.0f, 5.0f)
+      close()
+      moveTo(21.0f, 18.5f)
+      curveToRelative(-1.1f, -0.35f, -2.3f, -0.5f, -3.5f, -0.5f)
+      curveToRelative(-1.7f, 0.0f, -4.15f, 0.65f, -5.5f, 1.5f)
+      verticalLineTo(8.0f)
+      curveToRelative(1.35f, -0.85f, 3.8f, -1.5f, 5.5f, -1.5f)
+      curveToRelative(1.2f, 0.0f, 2.4f, 0.15f, 3.5f, 0.5f)
+      verticalLineTo(18.5f)
+      close()
+    }
+    materialPath {
+      moveTo(17.5f, 10.5f)
+      curveToRelative(0.88f, 0.0f, 1.73f, 0.09f, 2.5f, 0.26f)
+      verticalLineTo(9.24f)
+      curveTo(19.21f, 9.09f, 18.36f, 9.0f, 17.5f, 9.0f)
+      curveToRelative(-1.7f, 0.0f, -3.24f, 0.29f, -4.5f, 0.83f)
+      verticalLineToRelative(1.66f)
+      curveTo(14.13f, 10.85f, 15.7f, 10.5f, 17.5f, 10.5f)
+      close()
+    }
+    materialPath {
+      moveTo(13.0f, 12.49f)
+      verticalLineToRelative(1.66f)
+      curveToRelative(1.13f, -0.64f, 2.7f, -0.99f, 4.5f, -0.99f)
+      curveToRelative(0.88f, 0.0f, 1.73f, 0.09f, 2.5f, 0.26f)
+      verticalLineTo(11.9f)
+      curveToRelative(-0.79f, -0.15f, -1.64f, -0.24f, -2.5f, -0.24f)
+      curveTo(15.8f, 11.66f, 14.26f, 11.96f, 13.0f, 12.49f)
+      close()
+    }
+    materialPath {
+      moveTo(17.5f, 14.33f)
+      curveToRelative(-1.7f, 0.0f, -3.24f, 0.29f, -4.5f, 0.83f)
+      verticalLineToRelative(1.66f)
+      curveToRelative(1.13f, -0.64f, 2.7f, -0.99f, 4.5f, -0.99f)
+      curveToRelative(0.88f, 0.0f, 1.73f, 0.09f, 2.5f, 0.26f)
+      verticalLineToRelative(-1.52f)
+      curveTo(19.21f, 14.41f, 18.36f, 14.33f, 17.5f, 14.33f)
+      close()
+    }
+  }
+}
+
+@Preview
+@Composable
+private fun MenuBookIconPreview() {
+  Icon(imageVector = MenuBook, contentDescription = null)
+}

--- a/common/ui/core/src/main/java/com/quran/labs/androidquran/common/ui/core/icons/Mic.kt
+++ b/common/ui/core/src/main/java/com/quran/labs/androidquran/common/ui/core/icons/Mic.kt
@@ -1,0 +1,38 @@
+package com.quran.labs.androidquran.common.ui.core.icons
+
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.tooling.preview.Preview
+
+val Mic: ImageVector by lazy {
+  materialIcon(name = "Filled.Mic") {
+    materialPath {
+      moveTo(12.0f, 14.0f)
+      curveToRelative(1.66f, 0.0f, 2.99f, -1.34f, 2.99f, -3.0f)
+      lineTo(15.0f, 5.0f)
+      curveToRelative(0.0f, -1.66f, -1.34f, -3.0f, -3.0f, -3.0f)
+      reflectiveCurveTo(9.0f, 3.34f, 9.0f, 5.0f)
+      verticalLineToRelative(6.0f)
+      curveToRelative(0.0f, 1.66f, 1.34f, 3.0f, 3.0f, 3.0f)
+      close()
+      moveTo(17.3f, 11.0f)
+      curveToRelative(0.0f, 3.0f, -2.54f, 5.1f, -5.3f, 5.1f)
+      reflectiveCurveTo(6.7f, 14.0f, 6.7f, 11.0f)
+      lineTo(5.0f, 11.0f)
+      curveToRelative(0.0f, 3.41f, 2.72f, 6.23f, 6.0f, 6.72f)
+      lineTo(11.0f, 21.0f)
+      horizontalLineToRelative(2.0f)
+      verticalLineToRelative(-3.28f)
+      curveToRelative(3.28f, -0.48f, 6.0f, -3.3f, 6.0f, -6.72f)
+      horizontalLineToRelative(-1.7f)
+      close()
+    }
+  }
+}
+
+@Preview
+@Composable
+private fun MicIconPreview() {
+  Icon(imageVector = Mic, contentDescription = null)
+}

--- a/common/ui/core/src/main/java/com/quran/labs/androidquran/common/ui/core/icons/Pause.kt
+++ b/common/ui/core/src/main/java/com/quran/labs/androidquran/common/ui/core/icons/Pause.kt
@@ -1,0 +1,31 @@
+package com.quran.labs.androidquran.common.ui.core.icons
+
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.tooling.preview.Preview
+
+val Pause: ImageVector by lazy {
+  materialIcon(name = "Filled.Pause") {
+    materialPath {
+      moveTo(6.0f, 19.0f)
+      horizontalLineToRelative(4.0f)
+      lineTo(10.0f, 5.0f)
+      lineTo(6.0f, 5.0f)
+      verticalLineToRelative(14.0f)
+      close()
+      moveTo(14.0f, 5.0f)
+      verticalLineToRelative(14.0f)
+      horizontalLineToRelative(4.0f)
+      lineTo(18.0f, 5.0f)
+      horizontalLineToRelative(-4.0f)
+      close()
+    }
+  }
+}
+
+@Preview
+@Composable
+private fun PauseIconPreview() {
+  Icon(imageVector = Pause, contentDescription = null)
+}

--- a/common/ui/core/src/main/java/com/quran/labs/androidquran/common/ui/core/icons/PlayArrow.kt
+++ b/common/ui/core/src/main/java/com/quran/labs/androidquran/common/ui/core/icons/PlayArrow.kt
@@ -1,0 +1,23 @@
+package com.quran.labs.androidquran.common.ui.core.icons
+
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.tooling.preview.Preview
+
+val PlayArrow: ImageVector by lazy {
+  materialIcon(name = "Filled.PlayArrow") {
+    materialPath {
+      moveTo(8.0f, 5.0f)
+      verticalLineToRelative(14.0f)
+      lineToRelative(11.0f, -7.0f)
+      close()
+    }
+  }
+}
+
+@Preview
+@Composable
+private fun PlayArrowIconPreview() {
+  Icon(imageVector = PlayArrow, contentDescription = null)
+}

--- a/common/ui/core/src/main/java/com/quran/labs/androidquran/common/ui/core/icons/Repeat.kt
+++ b/common/ui/core/src/main/java/com/quran/labs/androidquran/common/ui/core/icons/Repeat.kt
@@ -1,0 +1,41 @@
+package com.quran.labs.androidquran.common.ui.core.icons
+
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.tooling.preview.Preview
+
+val Repeat: ImageVector by lazy {
+  materialIcon(name = "Filled.Repeat") {
+    materialPath {
+      moveTo(7.0f, 7.0f)
+      horizontalLineToRelative(10.0f)
+      verticalLineToRelative(3.0f)
+      lineToRelative(4.0f, -4.0f)
+      lineToRelative(-4.0f, -4.0f)
+      verticalLineToRelative(3.0f)
+      lineTo(5.0f, 5.0f)
+      verticalLineToRelative(6.0f)
+      horizontalLineToRelative(2.0f)
+      lineTo(7.0f, 7.0f)
+      close()
+      moveTo(17.0f, 17.0f)
+      lineTo(7.0f, 17.0f)
+      verticalLineToRelative(-3.0f)
+      lineToRelative(-4.0f, 4.0f)
+      lineToRelative(4.0f, 4.0f)
+      verticalLineToRelative(-3.0f)
+      horizontalLineToRelative(12.0f)
+      verticalLineToRelative(-6.0f)
+      horizontalLineToRelative(-2.0f)
+      verticalLineToRelative(4.0f)
+      close()
+    }
+  }
+}
+
+@Preview
+@Composable
+private fun RepeatIconPreview() {
+  Icon(imageVector = Repeat, contentDescription = null)
+}

--- a/common/ui/core/src/main/java/com/quran/labs/androidquran/common/ui/core/icons/Settings.kt
+++ b/common/ui/core/src/main/java/com/quran/labs/androidquran/common/ui/core/icons/Settings.kt
@@ -1,0 +1,65 @@
+package com.quran.labs.androidquran.common.ui.core.icons
+
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.tooling.preview.Preview
+
+val Settings: ImageVector by lazy {
+  materialIcon(name = "Filled.Settings") {
+    materialPath {
+      moveTo(19.14f, 12.94f)
+      curveToRelative(0.04f, -0.3f, 0.06f, -0.61f, 0.06f, -0.94f)
+      curveToRelative(0.0f, -0.32f, -0.02f, -0.64f, -0.07f, -0.94f)
+      lineToRelative(2.03f, -1.58f)
+      curveToRelative(0.18f, -0.14f, 0.23f, -0.41f, 0.12f, -0.61f)
+      lineToRelative(-1.92f, -3.32f)
+      curveToRelative(-0.12f, -0.22f, -0.37f, -0.29f, -0.59f, -0.22f)
+      lineToRelative(-2.39f, 0.96f)
+      curveToRelative(-0.5f, -0.38f, -1.03f, -0.7f, -1.62f, -0.94f)
+      lineTo(14.4f, 2.81f)
+      curveToRelative(-0.04f, -0.24f, -0.24f, -0.41f, -0.48f, -0.41f)
+      horizontalLineToRelative(-3.84f)
+      curveToRelative(-0.24f, 0.0f, -0.43f, 0.17f, -0.47f, 0.41f)
+      lineTo(9.25f, 5.35f)
+      curveTo(8.66f, 5.59f, 8.12f, 5.92f, 7.63f, 6.29f)
+      lineTo(5.24f, 5.33f)
+      curveToRelative(-0.22f, -0.08f, -0.47f, 0.0f, -0.59f, 0.22f)
+      lineTo(2.74f, 8.87f)
+      curveTo(2.62f, 9.08f, 2.66f, 9.34f, 2.86f, 9.48f)
+      lineToRelative(2.03f, 1.58f)
+      curveTo(4.84f, 11.36f, 4.8f, 11.69f, 4.8f, 12.0f)
+      reflectiveCurveToRelative(0.02f, 0.64f, 0.07f, 0.94f)
+      lineToRelative(-2.03f, 1.58f)
+      curveToRelative(-0.18f, 0.14f, -0.23f, 0.41f, -0.12f, 0.61f)
+      lineToRelative(1.92f, 3.32f)
+      curveToRelative(0.12f, 0.22f, 0.37f, 0.29f, 0.59f, 0.22f)
+      lineToRelative(2.39f, -0.96f)
+      curveToRelative(0.5f, 0.38f, 1.03f, 0.7f, 1.62f, 0.94f)
+      lineToRelative(0.36f, 2.54f)
+      curveToRelative(0.05f, 0.24f, 0.24f, 0.41f, 0.48f, 0.41f)
+      horizontalLineToRelative(3.84f)
+      curveToRelative(0.24f, 0.0f, 0.44f, -0.17f, 0.47f, -0.41f)
+      lineToRelative(0.36f, -2.54f)
+      curveToRelative(0.59f, -0.24f, 1.13f, -0.56f, 1.62f, -0.94f)
+      lineToRelative(2.39f, 0.96f)
+      curveToRelative(0.22f, 0.08f, 0.47f, 0.0f, 0.59f, -0.22f)
+      lineToRelative(1.92f, -3.32f)
+      curveToRelative(0.12f, -0.22f, 0.07f, -0.47f, -0.12f, -0.61f)
+      lineTo(19.14f, 12.94f)
+      close()
+      moveTo(12.0f, 15.6f)
+      curveToRelative(-1.98f, 0.0f, -3.6f, -1.62f, -3.6f, -3.6f)
+      reflectiveCurveToRelative(1.62f, -3.6f, 3.6f, -3.6f)
+      reflectiveCurveToRelative(3.6f, 1.62f, 3.6f, 3.6f)
+      reflectiveCurveTo(13.98f, 15.6f, 12.0f, 15.6f)
+      close()
+    }
+  }
+}
+
+@Preview
+@Composable
+private fun SettingsIconPreview() {
+  Icon(imageVector = Settings, contentDescription = null)
+}

--- a/common/ui/core/src/main/java/com/quran/labs/androidquran/common/ui/core/icons/Speed.kt
+++ b/common/ui/core/src/main/java/com/quran/labs/androidquran/common/ui/core/icons/Speed.kt
@@ -1,0 +1,37 @@
+package com.quran.labs.androidquran.common.ui.core.icons
+
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.tooling.preview.Preview
+
+val Speed: ImageVector by lazy {
+  materialIcon(name = "Filled.Speed") {
+    materialPath {
+      moveTo(20.38f, 8.57f)
+      lineToRelative(-1.23f, 1.85f)
+      arcToRelative(8.0f, 8.0f, 0.0f, false, true, -0.22f, 7.58f)
+      lineTo(5.07f, 18.0f)
+      arcTo(8.0f, 8.0f, 0.0f, false, true, 15.58f, 6.85f)
+      lineToRelative(1.85f, -1.23f)
+      arcTo(10.0f, 10.0f, 0.0f, false, false, 3.35f, 19.0f)
+      arcToRelative(2.0f, 2.0f, 0.0f, false, false, 1.72f, 1.0f)
+      horizontalLineToRelative(13.85f)
+      arcToRelative(2.0f, 2.0f, 0.0f, false, false, 1.74f, -1.0f)
+      arcToRelative(10.0f, 10.0f, 0.0f, false, false, -0.27f, -10.44f)
+      close()
+      moveTo(10.59f, 15.41f)
+      arcToRelative(2.0f, 2.0f, 0.0f, false, false, 2.83f, 0.0f)
+      lineToRelative(5.66f, -8.49f)
+      lineToRelative(-8.49f, 5.66f)
+      arcToRelative(2.0f, 2.0f, 0.0f, false, false, 0.0f, 2.83f)
+      close()
+    }
+  }
+}
+
+@Preview
+@Composable
+private fun SpeedIconPreview() {
+  Icon(imageVector = Speed, contentDescription = null)
+}

--- a/common/ui/core/src/main/java/com/quran/labs/androidquran/common/ui/core/icons/Stop.kt
+++ b/common/ui/core/src/main/java/com/quran/labs/androidquran/common/ui/core/icons/Stop.kt
@@ -1,0 +1,24 @@
+package com.quran.labs.androidquran.common.ui.core.icons
+
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.tooling.preview.Preview
+
+val Stop: ImageVector by lazy {
+  materialIcon(name = "Filled.Stop") {
+    materialPath {
+      moveTo(6.0f, 6.0f)
+      horizontalLineToRelative(12.0f)
+      verticalLineToRelative(12.0f)
+      horizontalLineTo(6.0f)
+      close()
+    }
+  }
+}
+
+@Preview
+@Composable
+private fun StopIconPreview() {
+  Icon(imageVector = Stop, contentDescription = null)
+}

--- a/common/ui/core/src/main/java/com/quran/labs/androidquran/common/ui/core/icons/Utils.kt
+++ b/common/ui/core/src/main/java/com/quran/labs/androidquran/common/ui/core/icons/Utils.kt
@@ -1,0 +1,66 @@
+package com.quran.labs.androidquran.common.ui.core.icons
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PathFillType
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.StrokeJoin
+import androidx.compose.ui.graphics.vector.DefaultFillType
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.PathBuilder
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+
+// these functions are taken from androidx.compose.material.icons with very
+// minor modifications.
+
+/**
+ * Utility delegate to construct a Material icon with default size information.
+ * This is used by generated icons, and should not be used manually.
+ *
+ * @param name the full name of the generated icon
+ * @param autoMirror determines if the vector asset should automatically be mirrored for right to
+ * left locales
+ * @param block builder lambda to add paths to this vector asset
+ */
+internal inline fun materialIcon(
+  name: String,
+  autoMirror: Boolean = false,
+  block: ImageVector.Builder.() -> ImageVector.Builder
+): ImageVector = ImageVector.Builder(
+  name = name,
+  defaultWidth = MaterialIconDimension.dp,
+  defaultHeight = MaterialIconDimension.dp,
+  viewportWidth = MaterialIconDimension,
+  viewportHeight = MaterialIconDimension,
+  autoMirror = autoMirror
+).block().build()
+
+/**
+ * Adds a vector path to this icon with Material defaults.
+ *
+ * @param fillAlpha fill alpha for this path
+ * @param strokeAlpha stroke alpha for this path
+ * @param pathFillType [PathFillType] for this path
+ * @param pathBuilder builder lambda to add commands to this path
+ */
+internal inline fun ImageVector.Builder.materialPath(
+  fillAlpha: Float = 1f,
+  strokeAlpha: Float = 1f,
+  pathFillType: PathFillType = DefaultFillType,
+  pathBuilder: PathBuilder.() -> Unit
+) =
+  path(
+    fill = SolidColor(Color.Black),
+    fillAlpha = fillAlpha,
+    stroke = null,
+    strokeAlpha = strokeAlpha,
+    strokeLineWidth = 1f,
+    strokeLineCap = StrokeCap.Butt,
+    strokeLineJoin = StrokeJoin.Bevel,
+    strokeLineMiter = 1f,
+    pathFillType = pathFillType,
+    pathBuilder = pathBuilder
+  )
+
+internal const val MaterialIconDimension = 24f

--- a/feature/audiobar/build.gradle.kts
+++ b/feature/audiobar/build.gradle.kts
@@ -23,7 +23,6 @@ dependencies {
   implementation(libs.compose.foundation)
   implementation(libs.compose.material)
   implementation(libs.compose.material3)
-  implementation(libs.compose.material.icons)
   implementation(libs.compose.ui)
   implementation(libs.compose.ui.tooling.preview)
   debugImplementation(libs.compose.ui.tooling)

--- a/feature/audiobar/src/main/kotlin/com/quran/mobile/feature/audiobar/ui/ErrorAudioBar.kt
+++ b/feature/audiobar/src/main/kotlin/com/quran/mobile/feature/audiobar/ui/ErrorAudioBar.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text

--- a/feature/audiobar/src/main/kotlin/com/quran/mobile/feature/audiobar/ui/LoadingAudioBar.kt
+++ b/feature/audiobar/src/main/kotlin/com/quran/mobile/feature/audiobar/ui/LoadingAudioBar.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator

--- a/feature/audiobar/src/main/kotlin/com/quran/mobile/feature/audiobar/ui/PlaybackAudioBar.kt
+++ b/feature/audiobar/src/main/kotlin/com/quran/mobile/feature/audiobar/ui/PlaybackAudioBar.kt
@@ -4,14 +4,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.width
-import androidx.compose.material.icons.filled.FastForward
-import androidx.compose.material.icons.filled.FastRewind
-import androidx.compose.material.icons.filled.Pause
-import androidx.compose.material.icons.filled.PlayArrow
-import androidx.compose.material.icons.filled.Repeat
-import androidx.compose.material.icons.filled.Settings
-import androidx.compose.material.icons.filled.Speed
-import androidx.compose.material.icons.filled.Stop
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.runtime.Composable

--- a/feature/audiobar/src/main/kotlin/com/quran/mobile/feature/audiobar/ui/PromptingAudioBar.kt
+++ b/feature/audiobar/src/main/kotlin/com/quran/mobile/feature/audiobar/ui/PromptingAudioBar.kt
@@ -6,8 +6,6 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
-import androidx.compose.material.icons.filled.Check
-import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton

--- a/feature/audiobar/src/main/kotlin/com/quran/mobile/feature/audiobar/ui/RecitationAudioBar.kt
+++ b/feature/audiobar/src/main/kotlin/com/quran/mobile/feature/audiobar/ui/RecitationAudioBar.kt
@@ -11,12 +11,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material.icons.filled.Chat
-import androidx.compose.material.icons.filled.Close
-import androidx.compose.material.icons.filled.MenuBook
-import androidx.compose.material.icons.filled.Mic
-import androidx.compose.material.icons.filled.Pause
-import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material3.Divider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton

--- a/feature/audiobar/src/main/kotlin/com/quran/mobile/feature/audiobar/ui/RepeatableButton.kt
+++ b/feature/audiobar/src/main/kotlin/com/quran/mobile/feature/audiobar/ui/RepeatableButton.kt
@@ -2,7 +2,6 @@ package com.quran.mobile.feature.audiobar.ui
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.icons.filled.Repeat
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme

--- a/feature/audiobar/src/main/kotlin/com/quran/mobile/feature/audiobar/ui/StoppedAudioBar.kt
+++ b/feature/audiobar/src/main/kotlin/com/quran/mobile/feature/audiobar/ui/StoppedAudioBar.kt
@@ -4,9 +4,6 @@ import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
-import androidx.compose.material.icons.filled.ExpandMore
-import androidx.compose.material.icons.filled.Mic
-import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text

--- a/feature/downloadmanager/build.gradle.kts
+++ b/feature/downloadmanager/build.gradle.kts
@@ -29,7 +29,6 @@ dependencies {
   implementation(libs.compose.animation)
   implementation(libs.compose.foundation)
   implementation(libs.compose.material)
-  implementation(libs.compose.material.icons)
   implementation(libs.compose.material3)
   implementation(libs.compose.ui)
   implementation(libs.compose.ui.tooling.preview)

--- a/feature/downloadmanager/src/main/kotlin/com/quran/mobile/feature/downloadmanager/ui/common/DownloadCommonRow.kt
+++ b/feature/downloadmanager/src/main/kotlin/com/quran/mobile/feature/downloadmanager/ui/common/DownloadCommonRow.kt
@@ -11,8 +11,6 @@ import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -25,6 +23,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.quran.labs.androidquran.common.audio.R
+import com.quran.labs.androidquran.common.ui.core.QuranIcons
 import com.quran.labs.androidquran.common.ui.core.QuranTheme
 
 @Composable
@@ -86,7 +85,7 @@ fun DownloadCommonRowPreview() {
         onRowPressed = { }
       ) {
         Image(
-          imageVector = Icons.Filled.Clear,
+          imageVector = QuranIcons.Close,
           contentDescription = "Test Icon",
           colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.onTertiary),
           modifier = Modifier
@@ -99,4 +98,3 @@ fun DownloadCommonRowPreview() {
     }
   }
 }
-

--- a/feature/downloadmanager/src/main/kotlin/com/quran/mobile/feature/downloadmanager/ui/common/DownloadManagerToolbar.kt
+++ b/feature/downloadmanager/src/main/kotlin/com/quran/mobile/feature/downloadmanager/ui/common/DownloadManagerToolbar.kt
@@ -1,8 +1,6 @@
 package com.quran.mobile.feature.downloadmanager.ui.common
 
 import androidx.compose.foundation.layout.RowScope
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
@@ -10,6 +8,7 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextOverflow
+import com.quran.labs.androidquran.common.ui.core.QuranIcons
 import com.quran.labs.androidquran.common.ui.core.modifier.autoMirror
 
 @Composable
@@ -29,7 +28,7 @@ fun DownloadManagerToolbar(
     navigationIcon = {
       IconButton(onClick = onBackPressed) {
         Icon(
-          imageVector = Icons.Filled.ArrowBack,
+          imageVector = QuranIcons.ArrowBack,
           contentDescription = "",
           modifier = Modifier.autoMirror()
         )

--- a/feature/downloadmanager/src/main/kotlin/com/quran/mobile/feature/downloadmanager/ui/sheikhdownload/SheikhDownloadToolbar.kt
+++ b/feature/downloadmanager/src/main/kotlin/com/quran/mobile/feature/downloadmanager/ui/sheikhdownload/SheikhDownloadToolbar.kt
@@ -1,13 +1,12 @@
 package com.quran.mobile.feature.downloadmanager.ui.sheikhdownload
 
 import androidx.compose.foundation.layout.RowScope
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import com.quran.labs.androidquran.common.ui.core.QuranIcons
 import com.quran.mobile.feature.downloadmanager.R
 import com.quran.mobile.feature.downloadmanager.ui.common.DownloadManagerToolbar
 
@@ -35,7 +34,7 @@ fun SheikhDownloadToolbar(
     if (removeIcon) {
       IconButton(onClick = eraseAction) {
         Icon(
-          imageVector = Icons.Filled.Close,
+          imageVector = QuranIcons.Close,
           contentDescription = stringResource(id = R.string.audio_manager_delete_selection)
         )
       }

--- a/feature/downloadmanager/src/main/kotlin/com/quran/mobile/feature/downloadmanager/ui/sheikhdownload/SheikhEntryRow.kt
+++ b/feature/downloadmanager/src/main/kotlin/com/quran/mobile/feature/downloadmanager/ui/sheikhdownload/SheikhEntryRow.kt
@@ -6,8 +6,6 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -18,6 +16,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import com.quran.labs.androidquran.common.ui.core.QuranIcons
 import com.quran.mobile.feature.downloadmanager.R
 import com.quran.mobile.feature.downloadmanager.model.sheikhdownload.EntryForQari
 import com.quran.mobile.feature.downloadmanager.ui.common.DownloadCommonRow
@@ -51,7 +50,7 @@ fun SheikhEntryRow(
       onRowLongPressed = { onEntryLongClicked(sheikhEntryUiModel) }
     ) {
       Image(
-        imageVector = Icons.Filled.Close,
+        imageVector = QuranIcons.Close,
         contentDescription = stringResource(deleteEntryResourceId),
         colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.onError),
         modifier = Modifier
@@ -82,4 +81,3 @@ fun SheikhEntryRow(
     }
   }
 }
-

--- a/feature/qarilist/build.gradle
+++ b/feature/qarilist/build.gradle
@@ -24,7 +24,6 @@ dependencies {
   implementation libs.compose.animation
   implementation libs.compose.foundation
   implementation libs.compose.material
-  implementation libs.compose.material.icons
   implementation libs.compose.material3
   implementation libs.compose.ui
   implementation libs.compose.ui.tooling.preview

--- a/feature/qarilist/src/main/kotlin/com/quran/mobile/feature/qarilist/QariListWrapper.kt
+++ b/feature/qarilist/src/main/kotlin/com/quran/mobile/feature/qarilist/QariListWrapper.kt
@@ -7,8 +7,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.displayCutoutPadding
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.BottomSheetScaffold
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -32,6 +30,7 @@ import androidx.compose.ui.unit.dp
 import com.quran.data.model.SuraAyah
 import com.quran.labs.androidquran.common.audio.model.QariItem
 import com.quran.labs.androidquran.common.audio.repository.CurrentQariManager
+import com.quran.labs.androidquran.common.ui.core.QuranIcons
 import com.quran.labs.androidquran.common.ui.core.QuranTheme
 import com.quran.mobile.feature.qarilist.di.QariListWrapperInjector
 import com.quran.mobile.feature.qarilist.presenter.QariListPresenter
@@ -116,7 +115,7 @@ class QariListWrapper(
               navigationIcon = {
                 IconButton(onClick = { closeDialog() }) {
                   Icon(
-                    imageVector = Icons.Filled.Close,
+                    imageVector = QuranIcons.Close,
                     contentDescription = stringResource(R.string.qarilist_dismiss)
                   )
                 }

--- a/feature/qarilist/src/main/kotlin/com/quran/mobile/feature/qarilist/ui/QariRow.kt
+++ b/feature/qarilist/src/main/kotlin/com/quran/mobile/feature/qarilist/ui/QariRow.kt
@@ -4,8 +4,6 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Check
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -15,6 +13,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.quran.labs.androidquran.common.audio.model.QariItem
+import com.quran.labs.androidquran.common.ui.core.QuranIcons
 import com.quran.mobile.feature.qarilist.R
 
 @Composable
@@ -38,7 +37,7 @@ fun QariRow(
 
     if (isSelected) {
       Icon(
-        imageVector = Icons.Filled.Check,
+        imageVector = QuranIcons.Check,
         contentDescription = stringResource(R.string.qarilist_selected),
         tint = MaterialTheme.colorScheme.primary,
         modifier = Modifier.align(Alignment.CenterVertically)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -107,7 +107,6 @@ compose-foundation = { module = "androidx.compose.foundation:foundation" }
 compose-animation = { module = "androidx.compose.animation:animation" }
 compose-material = { module = "androidx.compose.material:material" }
 compose-material3 = { module = "androidx.compose.material3:material3" }
-compose-material-icons = { module = "androidx.compose.material:material-icons-extended" }
 compose-runtime = { module = "androidx.compose.runtime:runtime" }
 compose-ui = { module = "androidx.compose.ui:ui" }
 compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling" }


### PR DESCRIPTION
The Android team recommends no longer using material-icons-extended, so
this patch extracts the icons used from it and removes the dependency.
