### PR TITLE
Fix Compose previews for single variant aars

### DIFF
--- a/build-logic/convention/src/main/kotlin/AndroidApplicationConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidApplicationConventionPlugin.kt
@@ -4,6 +4,7 @@ import com.quran.labs.androidquran.buildutil.applyBoms
 import com.quran.labs.androidquran.buildutil.applyComposeCommon
 import com.quran.labs.androidquran.buildutil.applyJavaCommon
 import com.quran.labs.androidquran.buildutil.applyKotlinCommon
+import com.quran.labs.androidquran.buildutil.excludeComposeUiToolingFromRelease
 import com.quran.labs.androidquran.buildutil.withLibraries
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -30,6 +31,7 @@ class AndroidApplicationConventionPlugin : Plugin<Project> {
       applyJavaCommon()
       applyKotlinCommon()
       applyBoms()
+      excludeComposeUiToolingFromRelease()
     }
   }
 }

--- a/build-logic/convention/src/main/kotlin/com/quran/labs/androidquran/buildutil/ComposeCommon.kt
+++ b/build-logic/convention/src/main/kotlin/com/quran/labs/androidquran/buildutil/ComposeCommon.kt
@@ -48,3 +48,16 @@ fun CommonExtension<*, *, *, *, *, *>.applyComposeCommon(project: Project) {
     }
   }
 }
+
+private const val ComposeUiGroup = "androidx.compose.ui"
+private const val ComposeUiTooling = "ui-tooling"
+private const val ComposeUiToolingData = "ui-tooling-data"
+
+fun Project.excludeComposeUiToolingFromRelease() {
+  configurations
+    .matching { it.name.contains("release", ignoreCase = true) }
+    .configureEach {
+      exclude(mapOf("group" to ComposeUiGroup, "module" to ComposeUiTooling))
+      exclude(mapOf("group" to ComposeUiGroup, "module" to ComposeUiToolingData))
+    }
+}

--- a/common/linebyline/ui/build.gradle
+++ b/common/linebyline/ui/build.gradle
@@ -11,7 +11,8 @@ dependencies {
 
   implementation libs.compose.ui
   implementation libs.compose.material
-  implementation libs.compose.ui.tooling.preview
 
-  debugImplementation libs.compose.ui.tooling
+  // implementation but removed for release builds
+  implementation libs.compose.ui.tooling.preview
+  implementation libs.compose.ui.tooling
 }

--- a/common/ui/core/build.gradle
+++ b/common/ui/core/build.gradle
@@ -9,6 +9,8 @@ dependencies {
   implementation libs.compose.material
   implementation libs.compose.material3
   implementation libs.compose.ui
+
+  // implementation but removed for release builds
   implementation libs.compose.ui.tooling.preview
-  debugImplementation libs.compose.ui.tooling
+  implementation libs.compose.ui.tooling
 }

--- a/feature/audiobar/build.gradle.kts
+++ b/feature/audiobar/build.gradle.kts
@@ -24,8 +24,10 @@ dependencies {
   implementation(libs.compose.material)
   implementation(libs.compose.material3)
   implementation(libs.compose.ui)
+
+  // implementation but removed for release builds
   implementation(libs.compose.ui.tooling.preview)
-  debugImplementation(libs.compose.ui.tooling)
+  implementation(libs.compose.ui.tooling)
 
   // dagger
   implementation(libs.dagger.runtime)

--- a/feature/downloadmanager/build.gradle.kts
+++ b/feature/downloadmanager/build.gradle.kts
@@ -31,8 +31,10 @@ dependencies {
   implementation(libs.compose.material)
   implementation(libs.compose.material3)
   implementation(libs.compose.ui)
+
+  // implementation but removed for release builds
   implementation(libs.compose.ui.tooling.preview)
-  debugImplementation(libs.compose.ui.tooling)
+  implementation(libs.compose.ui.tooling)
 
   // immutable collections
   implementation(libs.kotlinx.collections.immutable)

--- a/feature/linebyline/build.gradle.kts
+++ b/feature/linebyline/build.gradle.kts
@@ -35,6 +35,9 @@ dependencies {
 
   implementation(libs.compose.ui)
   implementation(libs.compose.material)
+
+  // implementation but removed for release builds
+  implementation(libs.compose.ui.tooling)
   implementation(libs.compose.ui.tooling.preview)
 
   implementation(libs.kotlinx.collections.immutable)
@@ -46,5 +49,5 @@ dependencies {
   implementation(libs.kotlinx.coroutines.core)
   implementation(libs.kotlinx.coroutines.android)
 
-  debugImplementation(libs.compose.ui.tooling)
+  implementation(libs.compose.ui.tooling)
 }

--- a/feature/qarilist/build.gradle
+++ b/feature/qarilist/build.gradle
@@ -26,8 +26,10 @@ dependencies {
   implementation libs.compose.material
   implementation libs.compose.material3
   implementation libs.compose.ui
+
+  // implementation but removed for release builds
+  implementation libs.compose.ui.tooling
   implementation libs.compose.ui.tooling.preview
-  debugImplementation libs.compose.ui.tooling
 
   // immutable collections
   implementation libs.kotlinx.collections.immutable


### PR DESCRIPTION
The Android library modules are all single variant (since the debug
variant is intentionally disabled). This causes issues with Compose
previews, since the tooling is only available for debug builds. This
patch changes these to vanilla implementation, and removes them from
release builds instead.
