### PR TITLE
fix: Make QariList BottomSheetScaffold container color transparent

### DIFF
--- a/feature/qarilist/src/main/kotlin/com/quran/mobile/feature/qarilist/QariListWrapper.kt
+++ b/feature/qarilist/src/main/kotlin/com/quran/mobile/feature/qarilist/QariListWrapper.kt
@@ -24,6 +24,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -101,6 +102,7 @@ class QariListWrapper(
         sheetPeekHeight = 0.dp,
         sheetDragHandle = null,
         sheetShape = RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp),
+        containerColor = Color.Transparent,
         sheetContainerColor = MaterialTheme.colorScheme.surface,
         sheetContentColor = MaterialTheme.colorScheme.contentColorFor(MaterialTheme.colorScheme.background),
         sheetContent = {


### PR DESCRIPTION
After the dependency upgrade here #3388, the Qari list started leaving the container background when closed. This change fixed it for me but I'm unsure why this happened so this might not be the best solution

<img width="523" height="914" alt="image" src="https://github.com/user-attachments/assets/c7085e51-b783-4c54-bef8-7b4584fd069c" />

<img width="535" height="911" alt="image" src="https://github.com/user-attachments/assets/d3976f9b-e4c8-4c59-a41b-0583da044d63" />
