### PR TITLE
Remove lock portrait/landscape flags

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/data/Constants.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/data/Constants.kt
@@ -45,8 +45,6 @@ object Constants {
   // Settings Key (some of these have corresponding values in preference_keys.xml)
   const val PREF_APP_LOCATION = "appLocation"
   const val PREF_LAST_PAGE = "lastPage"
-  const val PREF_LOCK_ORIENTATION = "lockOrientation"
-  const val PREF_LANDSCAPE_ORIENTATION = "landscapeOrientation"
   const val PREF_AYAH_TEXT_SIZE = "ayahTextSize"
   const val PREF_TRANSLATION_TEXT_SIZE = "translationTextSize"
   const val PREF_ACTIVE_TRANSLATION = "activeTranslation"

--- a/app/src/main/java/com/quran/labs/androidquran/presenter/data/QuranEventLogger.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/presenter/data/QuranEventLogger.kt
@@ -13,20 +13,12 @@ class QuranEventLogger @Inject constructor(
 ) {
 
   fun logAnalytics(isDualPages: Boolean, showingTranslations: Boolean, isSplitScreen: Boolean) {
-    val isLockOrientation = quranSettings.isLockOrientation
-    val lockingOrientation =  when {
-      isLockOrientation && quranSettings.isLandscapeOrientation -> "landscape"
-      isLockOrientation -> "portrait"
-      else -> "no"
-    }
-
     val params : Map<String, Any> = mapOf(
         "mode" to getScreenMode(isDualPages, showingTranslations, isSplitScreen),
         "pageType" to quranSettings.pageType,
         "isNightMode" to quranSettings.isNightMode,
         "isArabic" to (QuranUtils.getCurrentLocale().language == "ar"),
         "background" to if (quranSettings.useNewBackground()) "default" else "legacy",
-        "isLockingOrientation" to lockingOrientation,
         "overlayInfo" to quranSettings.shouldOverlayPageInfo(),
         "markerPopups" to quranSettings.shouldDisplayMarkerPopup(),
         "navigation" to if (quranSettings.navigateWithVolumeKeys()) "with_volume" else "default",

--- a/app/src/main/java/com/quran/labs/androidquran/ui/PagerActivity.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/PagerActivity.kt
@@ -6,8 +6,6 @@ import android.app.SearchManager
 import android.content.ComponentName
 import android.content.DialogInterface
 import android.content.Intent
-import android.content.pm.ActivityInfo
-import android.content.res.Configuration
 import android.os.Build
 import android.os.Bundle
 import android.os.Handler
@@ -599,20 +597,7 @@ class PagerActivity : AppCompatActivity(), AudioBarListener, OnBookmarkTagsUpdat
     // just got created, need to reconnect to service
     shouldReconnect = true
 
-    // enforce orientation lock
-    if (quranSettings.isLockOrientation) {
-      val current = resources.configuration.orientation
-      if (quranSettings.isLandscapeOrientation) {
-        if (current == Configuration.ORIENTATION_PORTRAIT) {
-          requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
-          return
-        }
-      } else if (current == Configuration.ORIENTATION_LANDSCAPE) {
-        requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
-        return
-      }
-    }
-
+    // log analytics
     quranEventLogger.logAnalytics(isDualPages, showingTranslation, isSplitScreen)
 
     // Setup recitation (if enabled)

--- a/app/src/main/java/com/quran/labs/androidquran/util/QuranSettings.java
+++ b/app/src/main/java/com/quran/labs/androidquran/util/QuranSettings.java
@@ -53,14 +53,6 @@ public class QuranSettings {
     prefs.unregisterOnSharedPreferenceChangeListener(listener);
   }
 
-  public boolean isLockOrientation() {
-    return prefs.getBoolean(Constants.PREF_LOCK_ORIENTATION, false);
-  }
-
-  public boolean isLandscapeOrientation() {
-    return prefs.getBoolean(Constants.PREF_LANDSCAPE_ORIENTATION, false);
-  }
-
   public boolean navigateWithVolumeKeys() {
     return prefs.getBoolean(Constants.PREF_USE_VOLUME_KEY_NAV, false);
   }
@@ -252,11 +244,13 @@ public class QuranSettings {
         setVersion(BuildConfig.VERSION_CODE);
       }
 
-      // remove debug info that is no longer needed
+      // remove debug info and other preferences that are no longer needed
       perInstallationPrefs.edit().remove("debugDidDownloadPages")
           .remove("debugPageDownloadedPath")
           .remove("debugPagesDownloadedTime")
           .remove("debugPagesDownloaded")
+          .remove("lockOrientation")
+          .remove("landscapeOrientation")
           .apply();
     }
   }

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -76,12 +76,6 @@
   <string name="prefs_category_translation">إعدادات التفسير والترجمة</string>
   <string name="prefs_category_display_settings">إعدادات العرض</string>
   <string name="prefs_new_background_title">الخلفية الجديدة</string>
-  <string name="prefs_lock_orientation_title">اﻹبقاء على وضع العرض</string>
-  <string name="prefs_lock_orientation_summary_on">وضع العرض سيتم الحفاظ عليه</string>
-  <string name="prefs_lock_orientation_summary_off">وضع العرض يتغير تلقائيا</string>
-  <string name="prefs_landscape_orientation_title">الوضع اﻷفقي</string>
-  <string name="prefs_landscape_orientation_summary_on">سيتم استخدام الوضع اﻷفقي</string>
-  <string name="prefs_landscape_orientation_summary_off">سيتم استخدام الوضع الرأسي</string>
   <string name="prefs_night_mode_title">القراءة الليلية</string>
   <string name="prefs_night_mode_summary">الخلفية باللون اﻷسود والخطوط باللون اﻷبيض</string>
   <string name="prefs_night_mode_text_brightness_title">إضاءة الخط</string>

--- a/app/src/main/res/values-az/strings.xml
+++ b/app/src/main/res/values-az/strings.xml
@@ -94,12 +94,6 @@
   <string name="prefs_category_display_settings">Görüntüleme ayarları</string>
   <string name="prefs_use_arabic_title">Arapça modu (الوضع العربي)</string>
   <string name="prefs_use_arabic_summary_on">Uygulama Arapça olarak çalışacak</string>
-  <string name="prefs_lock_orientation_title">Ekran döndürmeyi kapat</string>
-  <string name="prefs_lock_orientation_summary_on">"Kur'an sayfları döndürme özellikleri olmadan gösterilecek"</string>
-  <string name="prefs_lock_orientation_summary_off">Otomatik döndürme özellikleri çalışır vaziyette</string>
-  <string name="prefs_landscape_orientation_title">Yatay düzen yönelimli</string>
-  <string name="prefs_landscape_orientation_summary_on">Yatay yönelimi açık</string>
-  <string name="prefs_landscape_orientation_summary_off">Dikey yönelimi açık</string>
   <string name="prefs_night_mode_title">Gece modu</string>
   <string name="prefs_night_mode_summary">Karanlık arkaplan ve parlak fontlar kullanılacak</string>
   <string name="prefs_display_marker_title">"Kur'an kısımlarını gösteren uyarı göster"</string>

--- a/app/src/main/res/values-bs/strings.xml
+++ b/app/src/main/res/values-bs/strings.xml
@@ -117,12 +117,6 @@
   <string name="prefs_use_arabic_title">Arapski (الوضع العربي)</string>
   <string name="prefs_use_arabic_summary_on">Koristite aplikaciju na arapskom</string>
   <string name="prefs_new_background_title">Nova pozadina</string>
-  <string name="prefs_lock_orientation_title">Zabranite rotaciju zaslona u aplikaciji</string>
-  <string name="prefs_lock_orientation_summary_on">Koristite fiksni način orijentacije</string>
-  <string name="prefs_lock_orientation_summary_off">Prilagodite trenutnom načinu orijentacije</string>
-  <string name="prefs_landscape_orientation_title">Horizontalna orijentacija</string>
-  <string name="prefs_landscape_orientation_summary_on">Uvijek koristi horizontalni način orijentacije</string>
-  <string name="prefs_landscape_orientation_summary_off">Uvijek koristi vertikalni način orijentacije</string>
   <string name="prefs_night_mode_title">Noćni način </string>
   <string name="prefs_night_mode_summary">Koristite tamnu podlogu i svjetle fontove</string>
   <string name="prefs_night_mode_text_brightness_title">Osvijetljenost teksta</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -115,16 +115,6 @@
   <string name="prefs_use_arabic_title">Arabischer Modus (الوضع العربي)</string>
   <string name="prefs_use_arabic_summary_on">Das Programm wird ins Arabische umgestellt</string>
   <string name="prefs_new_background_title">Neuen Hintergrund verwenden</string>
-  <string name="prefs_lock_orientation_title">Bildschirmausrichtung sperren</string>
-  <string name="prefs_lock_orientation_summary_on">Die Quranseiten werden immer in einer bestimmten
-    Bildschirmausrichtung angezeigt.
-  </string>
-  <string name="prefs_lock_orientation_summary_off">Verwendet für die Bildschirmausrichtung die
-    aktuellen System-Einstellungen.
-  </string>
-  <string name="prefs_landscape_orientation_title">Querformat</string>
-  <string name="prefs_landscape_orientation_summary_on">Querformat wird genutzt.</string>
-  <string name="prefs_landscape_orientation_summary_off">Hochformat wird genutzt.</string>
   <string name="prefs_night_mode_title">Nachtmodus</string>
   <string name="prefs_night_mode_summary">Es werden ein dunkler Hintergrund und eine helle Schrift
     benutzt.

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -50,12 +50,6 @@
   <string name="prefs_use_arabic_title">Modo Árabe (الوضع العربي)</string>
   <string name="prefs_use_arabic_summary_on">La aplicación se mostrará en Árabe </string>
   <string name="prefs_new_background_title">Nuevo fondo</string>
-  <string name="prefs_lock_orientation_title">Bloquear orientación de la pantalla</string>
-  <string name="prefs_lock_orientation_summary_on">La Página del Corán estará en modo de orientación fija</string>
-  <string name="prefs_lock_orientation_summary_off">Adaptable a la orientación actual</string>
-  <string name="prefs_landscape_orientation_title">Orientación horizontal</string>
-  <string name="prefs_landscape_orientation_summary_on">Se utilizará orientación horizontal</string>
-  <string name="prefs_landscape_orientation_summary_off">Se utilizará la orientación vertical</string>
   <string name="prefs_night_mode_title">Modo nocturno</string>
   <string name="prefs_night_mode_summary">Se utilizará fondo oscuro y fuentes claras</string>
   <string name="prefs_night_mode_text_brightness_title">Texto Brillante</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -71,12 +71,6 @@
   <string name="prefs_category_display_settings">تنظیمات نمایش</string>
   <string name="prefs_use_arabic_title">حالت عربی (الوضع العربي)</string>
   <string name="prefs_use_arabic_summary_on">تغییر زبان برنامه به عربی</string>
-  <string name="prefs_lock_orientation_title">حفظ جهت نمایش</string>
-  <string name="prefs_lock_orientation_summary_on">عدم تغییر خودکار جهت نمایش</string>
-  <string name="prefs_lock_orientation_summary_off">تطبیق خودکار با جهت دستگاه</string>
-  <string name="prefs_landscape_orientation_title">جهت افقی</string>
-  <string name="prefs_landscape_orientation_summary_on">استفاده در جهت افقی</string>
-  <string name="prefs_landscape_orientation_summary_off">استفاده در جهت عمودی</string>
   <string name="prefs_night_mode_title">نمایش شبانه</string>
   <string name="prefs_night_mode_summary">استفاده از پس‌زمینه تاریک و نوشته‌های روشن</string>
   <string name="prefs_night_mode_text_brightness_title">روشنایی متن</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -91,12 +91,6 @@
   <string name="prefs_use_arabic_title">Mode arabe (الوضع العربي)</string>
   <string name="prefs_use_arabic_summary_on">L\'application sera traduite en arabe</string>
   <string name="prefs_new_background_title">Nouvel arrière-plan</string>
-  <string name="prefs_lock_orientation_title">Verrouiller l\'orientation de l\'écran</string>
-  <string name="prefs_lock_orientation_summary_on">L\'affichage du coran ne s\'adaptera pas au changement d\'orientation de l\'écran.</string>
-  <string name="prefs_lock_orientation_summary_off">L\'affichage du coran s\'adaptera au changement d\'orientation de l\'écran.</string>
-  <string name="prefs_landscape_orientation_title">Mode paysage</string>
-  <string name="prefs_landscape_orientation_summary_on">L\'orientation paysage sera utilisée.</string>
-  <string name="prefs_landscape_orientation_summary_off">L\'orientation portrait sera utilisée.</string>
   <string name="prefs_night_mode_title">Mode nuit</string>
   <string name="prefs_night_mode_summary">Un fond sombre et des polices lumineuses seront utilisés.</string>
   <string name="prefs_night_mode_text_brightness_title">Luminosité du texte</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -117,12 +117,6 @@
   <string name="prefs_use_arabic_title">Arapski (الوضع العربي)</string>
   <string name="prefs_use_arabic_summary_on">Koristite aplikaciju na arapskom</string>
   <string name="prefs_new_background_title">Nova pozadina</string>
-  <string name="prefs_lock_orientation_title">Zabranite rotaciju zaslona u aplikaciji</string>
-  <string name="prefs_lock_orientation_summary_on">Koristite fiksni način orijentacije</string>
-  <string name="prefs_lock_orientation_summary_off">Prilagodite trenutnom načinu orijentacije</string>
-  <string name="prefs_landscape_orientation_title">Horizontalna orijentacija</string>
-  <string name="prefs_landscape_orientation_summary_on">Uvijek koristi horizontalni način orijentacije</string>
-  <string name="prefs_landscape_orientation_summary_off">Uvijek koristi vertikalni način orijentacije</string>
   <string name="prefs_night_mode_title">Noćni način </string>
   <string name="prefs_night_mode_summary">Koristite tamnu podlogu i svjetle fontove</string>
   <string name="prefs_night_mode_text_brightness_title">Osvijetljenost teksta</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -88,13 +88,7 @@
     <string name="prefs_use_arabic_title">Arab mód (الوضع العربي)</string>
     <string name="prefs_use_arabic_summary_on">Az alkalmazás arab nyelvű lesz</string>
     <string name="prefs_new_background_title">Új háttér</string>
-    <string name="prefs_lock_orientation_title">Képernyőtájolás zárolása</string>
-    <string name="prefs_lock_orientation_summary_on">A Korán oldal rögzített tájolási módban lesz</string>
-    <string name="prefs_lock_orientation_summary_off">Alkalmazkodás a jelenlegi tájolási módhoz</string>
-    <string name="prefs_landscape_orientation_title">Fekvő tájolás</string>
-    <string name="prefs_landscape_orientation_summary_on">Fekvő tájolás lesz használva</string>
-    <string name="prefs_landscape_orientation_summary_off">Álló tájolás lesz használva</string>
-    <string name="prefs_night_mode_title">Éjszakai mód</string>
+  <string name="prefs_night_mode_title">Éjszakai mód</string>
     <string name="prefs_night_mode_summary">Sötét háttér és világos betűk lesznek használva</string>
     <string name="prefs_night_mode_text_brightness_title">Szöveg fényerőssége</string>
     <string name="prefs_night_mode_text_brightness_summary">A szöveg fényerőssége éjszakai mód bekapcsolásánál</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -115,12 +115,6 @@
   <string name="prefs_use_arabic_title">Mode bahasa Arab (الوضع العربي)</string>
   <string name="prefs_use_arabic_summary_on">Menggunakan bahasa Arab untuk antarmuka aplikasi</string>
   <string name="prefs_new_background_title">Latar baru</string>
-  <string name="prefs_lock_orientation_title">Kunci orientasi layar</string>
-  <string name="prefs_lock_orientation_summary_on">Menggunakan mode tampilan tetap</string>
-  <string name="prefs_lock_orientation_summary_off">Mengikuti orientasi perangkat</string>
-  <string name="prefs_landscape_orientation_title">Orientasi mendatar</string>
-  <string name="prefs_landscape_orientation_summary_on">Selalu gunakan mode mendatar</string>
-  <string name="prefs_landscape_orientation_summary_off">Selalu gunakan mode tegak</string>
   <string name="prefs_night_mode_title">Mode malam</string>
   <string name="prefs_night_mode_summary">Menggunkan latar gelap dan tulisan terang</string>
   <string name="prefs_night_mode_text_brightness_title">Kecerahan teks</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -66,12 +66,6 @@
   <string name="about_data_sources">Fonti di dati</string>
   <string name="about_contributors">Collaboratori</string>
   <string name="prefs_new_background_title">Nuovo sfondo</string>
-  <string name="prefs_lock_orientation_title">Orientamento della schermata di blocco</string>
-  <string name="prefs_lock_orientation_summary_on">Utilizzare la modalità di orientamento fisso</string>
-  <string name="prefs_lock_orientation_summary_off">Adattabile alla modalità di orientamento corrente</string>
-  <string name="prefs_landscape_orientation_title">Orientamento orizzontale</string>
-  <string name="prefs_landscape_orientation_summary_on">Usa sempre la modalità orizzontale</string>
-  <string name="prefs_landscape_orientation_summary_off">Usa sempre la modalità ritratto</string>
   <string name="prefs_night_mode_summary">Usa uno sfondo scuro e caratteri chiari</string>
   <string name="prefs_night_mode_text_brightness_title">Luminosità del testo</string>
   <string name="prefs_overlay_page_info_title">Mostra informazioni sulla pagina</string>

--- a/app/src/main/res/values-kk/strings.xml
+++ b/app/src/main/res/values-kk/strings.xml
@@ -121,12 +121,6 @@
   <string name="prefs_use_arabic_title">Арабша режим (الوضع العربي)</string>
   <string name="prefs_use_arabic_summary_on">Бағдарлама араб тілінде істейді </string>
   <string name="prefs_new_background_title">Жаңа фон</string>
-  <string name="prefs_lock_orientation_title">Экран бағытын құлыптау</string>
-  <string name="prefs_lock_orientation_summary_on">Құран беттері экранның белгіленген бағытында ұсталады</string>
-  <string name="prefs_lock_orientation_summary_off">Ағымдық бағытта пайдалану</string>
-  <string name="prefs_landscape_orientation_title">Көлденең бағыт</string>
-  <string name="prefs_landscape_orientation_summary_on">Көлденең бағытта пайдалану</string>
-  <string name="prefs_landscape_orientation_summary_off">Тік бағытта пайдалану</string>
   <string name="prefs_night_mode_title">Түнгі режим</string>
   <string name="prefs_night_mode_summary">Қара фон мен ашық түсті шрифт қолданылады</string>
   <string name="prefs_night_mode_text_brightness_title">Мәтін ашықтығы</string>

--- a/app/src/main/res/values-ku/strings.xml
+++ b/app/src/main/res/values-ku/strings.xml
@@ -74,12 +74,6 @@
   <string name="prefs_use_arabic_title">شێوازی عەرەبی (الوضع العربي)</string>
   <string name="prefs_use_arabic_summary_on">زمانی بەرنامەکە ئەبێت بە عەرەبی </string>
   <string name="prefs_new_background_title">پشت شاشەی نوێ</string>
-  <string name="prefs_lock_orientation_title">قفڵکردنی گۆڕینی ئاڕاستەی شاشە</string>
-  <string name="prefs_lock_orientation_summary_on">پەڕەکانی قورئان تەنها بەیەک ئاڕاستە پیشان ئەدرێن</string>
-  <string name="prefs_lock_orientation_summary_off">گونجاندن بۆ شێوازی ئاڕاستەی ئێستا</string>
-  <string name="prefs_landscape_orientation_title">ئاڕاستەی لەسەرلا (ئاسۆیی)</string>
-  <string name="prefs_landscape_orientation_summary_on">شێوازی ئاسۆیی بەکاردێت</string>
-  <string name="prefs_landscape_orientation_summary_off">شێوازی ستوونی بەکاردێت</string>
   <string name="prefs_night_mode_title">شێوازی شەو (تاریک)</string>
   <string name="prefs_night_mode_summary">پشت شاشەی ڕەش و نوسینی سپی </string>
   <string name="prefs_night_mode_text_brightness_title">ڕووناکی نوسین</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -97,12 +97,6 @@
   <string name="prefs_use_arabic_title">Mod Aplikasi Arab (الوضع العربي)</string>
   <string name="prefs_use_arabic_summary_on">Aplikasi keseluruhan akan menggunakan tulisan dan bahasa Arab</string>
   <string name="prefs_new_background_title">Latar beakang baru</string>
-  <string name="prefs_lock_orientation_title">Kunci orientasi layar</string>
-  <string name="prefs_lock_orientation_summary_on">Halaman Quran akan berada dalam mod orientasi tetap</string>
-  <string name="prefs_lock_orientation_summary_off">Penyesuaian orientasi layar secara automatik</string>
-  <string name="prefs_landscape_orientation_title">Orientasi Landscape</string>
-  <string name="prefs_landscape_orientation_summary_on">Menggunakan orientasi layar landscape (melintang)</string>
-  <string name="prefs_landscape_orientation_summary_off">Menggunakan orientasi layar portrait (tegak)</string>
   <string name="prefs_night_mode_title">Mod malam</string>
   <string name="prefs_night_mode_summary">Menggunakan latar belakang gelap dan teks terang</string>
   <string name="prefs_night_mode_text_brightness_title">Kecerahan teks</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -178,12 +178,6 @@
   <string name="prefs_use_arabic_title">Arabische modus (الوضع العربي)</string>
   <string name="prefs_use_arabic_summary_on">Gebruik Arabisch voor de toepassingsinterface</string>
   <string name="prefs_new_background_title">Nieuwe achtergrond</string>
-  <string name="prefs_lock_orientation_title">Schermoriëntatie vergrendelen</string>
-  <string name="prefs_lock_orientation_summary_on">Gebruik de modus voor vaste oriëntatie</string>
-  <string name="prefs_lock_orientation_summary_off">Aanpasbare oriëntatiemodus</string>
-  <string name="prefs_landscape_orientation_title">Liggende modus</string>
-  <string name="prefs_landscape_orientation_summary_on">Gebruik altijd de liggende modus</string>
-  <string name="prefs_landscape_orientation_summary_off">Gebruik altijd de staande modus</string>
   <string name="prefs_night_mode_title">Nachtmodus</string>
   <string name="prefs_night_mode_summary">Gebruik een donkere achtergrond en lichte lettertypen</string>
   <string name="prefs_night_mode_text_brightness_title">Teksthelderheid</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -104,12 +104,6 @@
   <string name="prefs_use_arabic_title">Tryb arabski (الوضع العربي)</string>
   <string name="prefs_use_arabic_summary_on">Użyj języka arabskiego jako interfejsu aplikacji</string>
   <string name="prefs_new_background_title">Nowe tło (bielsze)</string>
-  <string name="prefs_lock_orientation_title">Zablokuj orientację ekranu</string>
-  <string name="prefs_lock_orientation_summary_on">Używana jest jedna, stała orientacja ekranu</string>
-  <string name="prefs_lock_orientation_summary_off">Używana jest systemowa orientacja ekranu</string>
-  <string name="prefs_landscape_orientation_title">Stała orientacja ekranu</string>
-  <string name="prefs_landscape_orientation_summary_on">Zawsze używaj orientacji poziomej</string>
-  <string name="prefs_landscape_orientation_summary_off">Zawsze używaj orientacji pionowej</string>
   <string name="prefs_night_mode_title">Tryb nocny</string>
   <string name="prefs_night_mode_summary">Użyj ciemnego tła i jasnych czcionek</string>
   <string name="prefs_night_mode_text_brightness_title">Jasność tekstu</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -89,12 +89,6 @@ escolher um leitor-qari diferente. Clique play para baixar e reproduzir a págin
   <string name="prefs_use_arabic_title">Modo de Árabe (الوضع العربي)</string>
   <string name="prefs_use_arabic_summary_on">Aplicação irá ser alterada para Árabe (Requer reinicialização)</string>
   <string name="prefs_new_background_title">New background</string>
-  <string name="prefs_lock_orientation_title">Lock screen orientation</string>
-  <string name="prefs_lock_orientation_summary_on">Quran page will be in fixed orientation mode</string>
-  <string name="prefs_lock_orientation_summary_off">Adaptive to current orientation mode</string>
-  <string name="prefs_landscape_orientation_title">Landscape orientation</string>
-  <string name="prefs_landscape_orientation_summary_on">Landscape orientation will be used</string>
-  <string name="prefs_landscape_orientation_summary_off">Portrait orientation will be used</string>
   <string name="prefs_night_mode_title">Night mode</string>
   <string name="prefs_night_mode_summary">Dark background and light fonts will be used</string>
   <string name="prefs_night_mode_text_brightness_title">Text Brightness</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -145,12 +145,6 @@
   <string name="prefs_use_arabic_title">Режим арабского (الوضع العربي)</string>
   <string name="prefs_use_arabic_summary_on">Приложение будет локализовано под арабский язык </string>
   <string name="prefs_new_background_title">Новый фон</string>
-  <string name="prefs_lock_orientation_title">Удерживать ориентацию экрана</string>
-  <string name="prefs_lock_orientation_summary_on">Страницы Корана будут удерживаться в выбранном режиме</string>
-  <string name="prefs_lock_orientation_summary_off">Адаптировать под текущую ориентацию</string>
-  <string name="prefs_landscape_orientation_title">Альбомный режим</string>
-  <string name="prefs_landscape_orientation_summary_on">Использовать альбомный режим</string>
-  <string name="prefs_landscape_orientation_summary_off">Использовать портретный режим</string>
   <string name="prefs_night_mode_title">Ночной режим</string>
   <string name="prefs_night_mode_summary">Будет использован темный фон и светлый шрифт</string>
   <string name="prefs_night_mode_text_brightness_title">Яркость текста</string>

--- a/app/src/main/res/values-sq/strings.xml
+++ b/app/src/main/res/values-sq/strings.xml
@@ -105,12 +105,6 @@
   <string name="prefs_use_arabic_title">Modaliteti arab (الوضع العربي)</string>
   <string name="prefs_use_arabic_summary_on">Përdor arabisht për ndërfaqen e aplikimit</string>
   <string name="prefs_new_background_title">Sfond i ri</string>
-  <string name="prefs_lock_orientation_title">Kyçi orientimin e ekranit</string>
-  <string name="prefs_lock_orientation_summary_on">Përdor modalitetin e orientimit fiks</string>
-  <string name="prefs_lock_orientation_summary_off">Përshtatës me mënyrën aktuale të orientimit</string>
-  <string name="prefs_landscape_orientation_title">Orientimi i peizazhit</string>
-  <string name="prefs_landscape_orientation_summary_on">Përdor gjithmonë mënyrën e peizazhit</string>
-  <string name="prefs_landscape_orientation_summary_off">Përdor gjithmonë modalitetin e portretit</string>
   <string name="prefs_night_mode_title">Modaliteti i natës</string>
   <string name="prefs_night_mode_summary">Përdor gërmat e sfondit të errët dhe të dritës</string>
   <string name="prefs_night_mode_text_brightness_title">Shkëlqimi i tekstit</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -117,12 +117,6 @@
   <string name="prefs_use_arabic_title">Arapski (الوضع العربي)</string>
   <string name="prefs_use_arabic_summary_on">Koristite aplikaciju na arapskom</string>
   <string name="prefs_new_background_title">Nova pozadina</string>
-  <string name="prefs_lock_orientation_title">Zabranite rotaciju zaslona u aplikaciji</string>
-  <string name="prefs_lock_orientation_summary_on">Koristite fiksni način orentacije</string>
-  <string name="prefs_lock_orientation_summary_off">Prilagodite trenutnom načinu orentacije</string>
-  <string name="prefs_landscape_orientation_title">Horizontalna orentacija</string>
-  <string name="prefs_landscape_orientation_summary_on">Uvek koristi horizontalni način orentacije</string>
-  <string name="prefs_landscape_orientation_summary_off">Uvek koristi vertikalni način orentacije</string>
   <string name="prefs_night_mode_title">Noćni način </string>
   <string name="prefs_night_mode_summary">Koristite tamnu podlogu i svetle fontove</string>
   <string name="prefs_night_mode_text_brightness_title">Osvetljenost teksta</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -104,12 +104,6 @@
   <string name="prefs_use_arabic_title">Arabiskt läge (الوضع العربي)</string>
   <string name="prefs_use_arabic_summary_on">Använd arabiska för tillämpningsgränssnittet.</string>
   <string name="prefs_new_background_title">Ny bakgrund</string>
-  <string name="prefs_lock_orientation_title">Orientering av låsskärmen</string>
-  <string name="prefs_lock_orientation_summary_on">Använd läget för fast orientering</string>
-  <string name="prefs_lock_orientation_summary_off">Anpassar sig till det aktuella orienteringsläget</string>
-  <string name="prefs_landscape_orientation_title">Landskapsorientering</string>
-  <string name="prefs_landscape_orientation_summary_on">Använd alltid liggande läge</string>
-  <string name="prefs_landscape_orientation_summary_off">Använd alltid porträttläge</string>
   <string name="prefs_night_mode_title">Nattläge</string>
   <string name="prefs_night_mode_summary">Använd mörk bakgrund och ljusa typsnitt</string>
   <string name="prefs_night_mode_text_brightness_title">Textens ljusstyrka</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -96,12 +96,6 @@
   <string name="prefs_use_arabic_title">โหมดอาหรับ (الوضع العربي)</string>
   <string name="prefs_use_arabic_summary_on">ใช้ภาษาอาหรับสําหรับอินเทอร์เฟซโปรแกรมประยุกต์</string>
   <string name="prefs_new_background_title">พื้นหลังใหม่</string>
-  <string name="prefs_lock_orientation_title">การวางแนวหน้าจอเมื่อล็อก</string>
-  <string name="prefs_lock_orientation_summary_on">ใช้โหมดการวางแนวคงที่</string>
-  <string name="prefs_lock_orientation_summary_off">ปรับให้เข้ากับโหมดการวางแนวปัจจุบัน</string>
-  <string name="prefs_landscape_orientation_title">การวางแนวในแนวนอน</string>
-  <string name="prefs_landscape_orientation_summary_on">ใช้โหมดแนวนอนเสมอ</string>
-  <string name="prefs_landscape_orientation_summary_off">ใช้โหมดแนวตั้งเสมอ</string>
   <string name="prefs_night_mode_title">โหมดกลางคืน</string>
   <string name="prefs_night_mode_summary">ใช้พื้นหลังสีเข้มและแบบอักษรสีอ่อน</string>
   <string name="prefs_night_mode_text_brightness_title">ความสว่างของข้อความ</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -94,12 +94,6 @@
   <string name="prefs_category_display_settings">Görüntüleme ayarları</string>
   <string name="prefs_use_arabic_title">Arapça modu (الوضع العربي)</string>
   <string name="prefs_use_arabic_summary_on">Uygulama Arapça olarak çalışacak</string>
-  <string name="prefs_lock_orientation_title">Ekran döndürmeyi kapat</string>
-  <string name="prefs_lock_orientation_summary_on">"Kur'an sayfları döndürme özellikleri olmadan gösterilecek"</string>
-  <string name="prefs_lock_orientation_summary_off">Otomatik döndürme özellikleri çalışır vaziyette</string>
-  <string name="prefs_landscape_orientation_title">Yatay düzen yönelimli</string>
-  <string name="prefs_landscape_orientation_summary_on">Yatay yönelimi açık</string>
-  <string name="prefs_landscape_orientation_summary_off">Dikey yönelimi açık</string>
   <string name="prefs_night_mode_title">Gece modu</string>
   <string name="prefs_night_mode_summary">Karanlık arkaplan ve parlak fontlar kullanılacak</string>
   <string name="prefs_display_marker_title">"Kur'an kısımlarını gösteren uyarı göster"</string>

--- a/app/src/main/res/values-ug/strings.xml
+++ b/app/src/main/res/values-ug/strings.xml
@@ -76,12 +76,6 @@
   <string name="prefs_use_arabic_title">ئەرەبچە ھالەت (الوضع العربي)</string>
   <string name="prefs_use_arabic_summary_on">ئەپ ئارا يۈزىگە ئەرەبچە ئىشلىتىدۇ</string>
   <string name="prefs_new_background_title">يېڭى تەگلىك</string>
-  <string name="prefs_lock_orientation_title">قۇلۇپ ئېكران يۆنىلىشى</string>
-  <string name="prefs_lock_orientation_summary_on">مۇقىم يۆنىلىش ھالىتىنى ئىشلىتىدۇ</string>
-  <string name="prefs_lock_orientation_summary_off">نۆۋەتتىكى يۆنىلىش ھالىتىگە ماسلىشىدۇ</string>
-  <string name="prefs_landscape_orientation_title">توغرىسىغا يۆنىلىش</string>
-  <string name="prefs_landscape_orientation_summary_on">ھەمىشە توغرىسىغا يۆنىلىش ھالىتىنى ئىشلىتىدۇ</string>
-  <string name="prefs_landscape_orientation_summary_off">ھەمىشە بويىغا يۆنىلىش ھالىتىنى ئىشلىتىدۇ</string>
   <string name="prefs_night_mode_title">كېچە ھالىتى</string>
   <string name="prefs_night_mode_summary">قارا تەگلىك يورۇق خەت نۇسخىسى ئىشلىتىدۇ</string>
   <string name="prefs_night_mode_text_brightness_title">تېكىست يورۇقلۇقى</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -105,12 +105,6 @@
   <string name="prefs_use_arabic_title">Арабський режим (الوضع العربي)</string>
   <string name="prefs_use_arabic_summary_on">Використовуйте арабську мову для інтерфейсу програми</string>
   <string name="prefs_new_background_title">Нове тло</string>
-  <string name="prefs_lock_orientation_title">Орієнтація екрана блокування</string>
-  <string name="prefs_lock_orientation_summary_on">Використання режиму фіксованої орієнтації</string>
-  <string name="prefs_lock_orientation_summary_off">Адаптивний до поточного режиму орієнтації</string>
-  <string name="prefs_landscape_orientation_title">Альбомна орієнтація</string>
-  <string name="prefs_landscape_orientation_summary_on">Завжди використовувати альбомний режим</string>
-  <string name="prefs_landscape_orientation_summary_off">Завжди використовувати книжковий режим</string>
   <string name="prefs_night_mode_title">Нічний режим</string>
   <string name="prefs_night_mode_summary">Використання темного фону та світлих шрифтів</string>
   <string name="prefs_night_mode_text_brightness_title">Яскравість тексту</string>

--- a/app/src/main/res/values-uz/strings.xml
+++ b/app/src/main/res/values-uz/strings.xml
@@ -124,12 +124,6 @@
   <string name="prefs_use_arabic_title">Arabcha rejim (الوضع العربي)</string>
   <string name="prefs_use_arabic_summary_on">Ilova arab tilida ishlaydi </string>
   <string name="prefs_new_background_title">Yangi fon</string>
-  <string name="prefs_lock_orientation_title">Ekran oriyentatsiyasini qulflash</string>
-  <string name="prefs_lock_orientation_summary_on">Qurʼon sahifalari doim belgilangan oriyentatsiyada boʻladi</string>
-  <string name="prefs_lock_orientation_summary_off">Joriy oriyentatsiyadan foydalaniladi</string>
-  <string name="prefs_landscape_orientation_title">Landshaft rejim</string>
-  <string name="prefs_landscape_orientation_summary_on">Yotiq oriyentatsiyadan foydalaniladi</string>
-  <string name="prefs_landscape_orientation_summary_off">Tik oriyentatsiyadan foydalaniladi</string>
   <string name="prefs_night_mode_title">Tungi rejim</string>
   <string name="prefs_night_mode_summary">Qora fon va porloq shriftlardan foydalaniladi</string>
   <string name="prefs_night_mode_text_brightness_title">Matn porloqliligi</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -124,12 +124,6 @@
   <string name="prefs_use_arabic_title">Chế độ Ả Rập (الوضع العربي)</string>
   <string name="prefs_use_arabic_summary_on">Dùng tiếng Ả Rập cho giao diện ứng dụng</string>
   <string name="prefs_new_background_title">Màu nền mới</string>
-  <string name="prefs_lock_orientation_title">Khóa hướng màn hình</string>
-  <string name="prefs_lock_orientation_summary_on">Khóa một hướng cố định</string>
-  <string name="prefs_lock_orientation_summary_off">Tự chuyển hướng cùng thiết bị</string>
-  <string name="prefs_landscape_orientation_title">Hướng ngang</string>
-  <string name="prefs_landscape_orientation_summary_on">Luôn dùng chế độ nằm ngang</string>
-  <string name="prefs_landscape_orientation_summary_off">Luôn dùng chế độ nằm dọc</string>
   <string name="prefs_night_mode_title">Chế độ Tối</string>
   <string name="prefs_night_mode_summary">Dùng nền tối và phông chữ sáng</string>
   <string name="prefs_night_mode_text_brightness_title">Độ sáng của chữ</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -74,12 +74,6 @@
   <string name="prefs_use_arabic_title">阿拉伯语模式 (الوضع العربي)</string>
   <string name="prefs_use_arabic_summary_on">应用程序将采用阿拉伯语界面</string>
   <string name="prefs_new_background_title">新的壁纸</string>
-  <string name="prefs_lock_orientation_title">屏幕旋转方向</string>
-  <string name="prefs_lock_orientation_summary_on">古兰经页面的屏幕旋转方向</string>
-  <string name="prefs_lock_orientation_summary_off">跟随系统</string>
-  <string name="prefs_landscape_orientation_title">锁屏方向</string>
-  <string name="prefs_landscape_orientation_summary_on">锁定横屏</string>
-  <string name="prefs_landscape_orientation_summary_off">锁定竖屏</string>
   <string name="prefs_night_mode_title">夜间模式</string>
   <string name="prefs_night_mode_summary">黑色背景和白色字体</string>
   <string name="prefs_night_mode_text_brightness_title">Text Brightness</string>

--- a/app/src/main/res/values/preferences_keys.xml
+++ b/app/src/main/res/values/preferences_keys.xml
@@ -17,8 +17,6 @@
   <string translatable="false" name="prefs_overlay_page_info">overlayPageInfo</string>
   <string translatable="false" name="prefs_display_marker_popup">displayMarkerPopup</string>
   <string translatable="false" name="prefs_highlight_bookmarks">highlightBookmarks</string>
-  <string translatable="false" name="prefs_lock_orientation">lockOrientation</string>
-  <string translatable="false" name="prefs_landscape_orientation">landscapeOrientation</string>
   <string translatable="false" name="prefs_ayah_text_size">ayahTextSize</string>
   <string translatable="false" name="prefs_translation_text_size">translationTextSize</string>
   <string translatable="false" name="prefs_ayah_before_translation">ayahBeforeTranslation</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -165,12 +165,6 @@
   <string name="prefs_use_arabic_title">Arabic mode (الوضع العربي)</string>
   <string name="prefs_use_arabic_summary_on">Use Arabic for application interface</string>
   <string name="prefs_new_background_title">New background</string>
-  <string name="prefs_lock_orientation_title">Lock screen orientation</string>
-  <string name="prefs_lock_orientation_summary_on">Use fixed orientation mode</string>
-  <string name="prefs_lock_orientation_summary_off">Adaptive to current orientation mode</string>
-  <string name="prefs_landscape_orientation_title">Landscape orientation</string>
-  <string name="prefs_landscape_orientation_summary_on">Always use landscape mode</string>
-  <string name="prefs_landscape_orientation_summary_off">Always use portrait mode</string>
   <string name="prefs_night_mode_title">Night mode</string>
   <string name="prefs_night_mode_summary">Use dark background and light fonts</string>
   <string name="prefs_night_mode_text_brightness_title">Text brightness</string>

--- a/app/src/main/res/xml/quran_preferences.xml
+++ b/app/src/main/res/xml/quran_preferences.xml
@@ -35,25 +35,6 @@
         app:iconSpaceReserved="false"/>
 
     <CheckBoxPreference
-        android:defaultValue="false"
-        android:disableDependentsState="false"
-        android:key="@string/prefs_lock_orientation"
-        android:persistent="true"
-        android:summaryOff="@string/prefs_lock_orientation_summary_off"
-        android:summaryOn="@string/prefs_lock_orientation_summary_on"
-        android:title="@string/prefs_lock_orientation_title"
-        app:iconSpaceReserved="false"/>
-
-    <CheckBoxPreference
-        android:dependency="@string/prefs_lock_orientation"
-        android:key="@string/prefs_landscape_orientation"
-        android:persistent="true"
-        android:summaryOff="@string/prefs_landscape_orientation_summary_off"
-        android:summaryOn="@string/prefs_landscape_orientation_summary_on"
-        android:title="@string/prefs_landscape_orientation_title"
-        app:iconSpaceReserved="false"/>
-
-    <CheckBoxPreference
         android:key="@string/prefs_sura_translated_name"
         android:persistent="true"
         android:summary="@string/prefs_sura_translated_name_summary"

--- a/common/linebyline/ui/src/main/java/com/quran/mobile/linebyline/ui/renderer/composable/QuranLineLayout.kt
+++ b/common/linebyline/ui/src/main/java/com/quran/mobile/linebyline/ui/renderer/composable/QuranLineLayout.kt
@@ -55,7 +55,7 @@ fun QuranPageLayoutPreview() {
   MaterialTheme {
     QuranLineLayout(
       lineHeightWidthRatio = 174f / 1080f,
-      allowLinesToOverlap = true,
+      allowLinesToOverlap = false,
       modifier = Modifier.fillMaxSize()
     ) {
       repeat(15) {


### PR DESCRIPTION
Android 16 ignores requested orientation calls on larger screens, and
this will likely extend to other devices in the future. The reader can
continue setting these using Android settings for the overall device
orientation (and some devices likely have per-app specific orientation
settings as well).
