### PR TITLE
Emit word audio playback position when applicable

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/ui/PagerActivity.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/PagerActivity.kt
@@ -1592,17 +1592,7 @@ class PagerActivity : AppCompatActivity(), AudioBarListener, OnBookmarkTagsUpdat
   override fun setPlaybackSpeed(speed: Float) {
     val lastAudioRequest = audioStatusRepositoryBridge.audioRequest()
     if (lastAudioRequest != null) {
-      val updatedAudioRequest = AudioRequest(
-        lastAudioRequest.start,
-        lastAudioRequest.end,
-        lastAudioRequest.qari,
-        lastAudioRequest.repeatInfo,
-        lastAudioRequest.rangeRepeatInfo,
-        lastAudioRequest.enforceBounds,
-        speed,
-        lastAudioRequest.shouldStream,
-        lastAudioRequest.audioPathInfo
-      )
+      val updatedAudioRequest = lastAudioRequest.copy(playbackSpeed = speed)
 
       val i = Intent(this, AudioService::class.java)
       i.setAction(AudioService.ACTION_UPDATE_SETTINGS)
@@ -1666,16 +1656,11 @@ class PagerActivity : AppCompatActivity(), AudioBarListener, OnBookmarkTagsUpdat
   ): Boolean {
     val lastAudioRequest = audioStatusRepositoryBridge.audioRequest()
     if (lastAudioRequest != null) {
-      val updatedAudioRequest = AudioRequest(
-        lastAudioRequest.start,
-        lastAudioRequest.end,
-        lastAudioRequest.qari,
-        verseRepeat,
-        rangeRepeat,
-        enforceRange,
-        playbackSpeed,
-        lastAudioRequest.shouldStream,
-        lastAudioRequest.audioPathInfo
+      val updatedAudioRequest = lastAudioRequest.copy(
+        repeatInfo = verseRepeat,
+        rangeRepeatInfo = rangeRepeat,
+        enforceBounds = enforceRange,
+        playbackSpeed = playbackSpeed
       )
       val i = Intent(this, AudioService::class.java)
       i.setAction(AudioService.ACTION_UPDATE_SETTINGS)
@@ -1690,17 +1675,7 @@ class PagerActivity : AppCompatActivity(), AudioBarListener, OnBookmarkTagsUpdat
   override fun setRepeatCount(repeatCount: Int) {
     val lastAudioRequest = audioStatusRepositoryBridge.audioRequest()
     if (lastAudioRequest != null) {
-      val updatedAudioRequest = AudioRequest(
-        lastAudioRequest.start,
-        lastAudioRequest.end,
-        lastAudioRequest.qari,
-        repeatCount,
-        lastAudioRequest.rangeRepeatInfo,
-        lastAudioRequest.enforceBounds,
-        lastAudioRequest.playbackSpeed,
-        lastAudioRequest.shouldStream,
-        lastAudioRequest.audioPathInfo
-      )
+      val updatedAudioRequest = lastAudioRequest.copy(repeatInfo = repeatCount)
 
       val i = Intent(this, AudioService::class.java)
       i.setAction(AudioService.ACTION_UPDATE_SETTINGS)

--- a/common/audio/src/main/java/com/quran/labs/androidquran/common/audio/model/playback/AudioRequest.kt
+++ b/common/audio/src/main/java/com/quran/labs/androidquran/common/audio/model/playback/AudioRequest.kt
@@ -14,7 +14,8 @@ data class AudioRequest(val start: SuraAyah,
                         val enforceBounds: Boolean,
                         val playbackSpeed: Float = 1f,
                         val shouldStream: Boolean,
-                        val audioPathInfo: AudioPathInfo
+                        val audioPathInfo: AudioPathInfo,
+                        val wordHighlighting: Boolean = false
 ) : Parcelable {
   fun isGapless() = qari.isGapless
   fun needsIsti3athaAudio() =

--- a/common/audio/src/main/java/com/quran/labs/androidquran/common/audio/model/playback/AudioStatus.kt
+++ b/common/audio/src/main/java/com/quran/labs/androidquran/common/audio/model/playback/AudioStatus.kt
@@ -7,7 +7,8 @@ sealed class AudioStatus {
   data class Playback(
     val currentAyah: SuraAyah,
     val audioRequest: AudioRequest,
-    val playbackStatus: PlaybackStatus
+    val playbackStatus: PlaybackStatus,
+    val currentWord: Int? = null
   ) : AudioStatus()
 }
 


### PR DESCRIPTION
This is gated by a flag when starting playback that indicates whether or
not word highlights are possible or not. When they're not possible, this
should do nothing. When they are, this will emit word positions if they
are available for the current qari.
