### PR TITLE
feat(audio): migrate AudioService to MediaLibraryService

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -134,13 +134,6 @@
           android:resource="@xml/file_paths"/>
     </provider>
 
-    <receiver android:name="androidx.media.session.MediaButtonReceiver"
-        android:exported="true">
-      <intent-filter>
-        <action android:name="android.intent.action.MEDIA_BUTTON"/>
-      </intent-filter>
-    </receiver>
-
     <activity android:name=".QuranImportActivity"
         android:exported="true">
       <intent-filter>
@@ -177,9 +170,6 @@
         android:exported="false"
         android:name=".service.AudioService"
         android:foregroundServiceType="mediaPlayback">
-      <intent-filter>
-        <action android:name="android.intent.action.MEDIA_BUTTON"/>
-      </intent-filter>
     </service>
 
     <service

--- a/app/src/main/java/com/quran/labs/androidquran/service/AudioService.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/service/AudioService.kt
@@ -2,7 +2,6 @@ package com.quran.labs.androidquran.service
 
 import android.app.NotificationManager
 import android.app.PendingIntent
-import android.app.Service
 import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
@@ -13,7 +12,6 @@ import android.net.Uri
 import android.os.Build
 import android.os.Handler
 import android.os.HandlerThread
-import android.os.IBinder
 import android.os.Looper
 import android.os.Message
 import android.os.Process
@@ -52,6 +50,8 @@ import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 import androidx.media3.exoplayer.metadata.MetadataOutput
 import androidx.media3.exoplayer.text.TextOutput
 import androidx.media3.exoplayer.video.VideoRendererEventListener
+import androidx.media3.session.MediaLibraryService
+import androidx.media3.session.MediaSession
 import com.quran.data.core.QuranInfo
 import com.quran.labs.androidquran.QuranApplication
 import com.quran.labs.androidquran.R
@@ -93,7 +93,9 @@ import androidx.core.net.toUri
  * (which come from our main activity, [PagerActivity], which signal
  * the service to perform specific operations: Play, Pause, Rewind, Skip, etc.
  */
-class AudioService : Service(), Player.Listener {
+class AudioService : MediaLibraryService(), Player.Listener {
+
+  private var mediaLibrarySession: MediaLibrarySession? = null
 
   // our exo player
   private var player: ExoPlayer? = null
@@ -154,6 +156,7 @@ class AudioService : Service(), Player.Listener {
   private var currentWord: Int? = null
   private val compositeDisposable = CompositeDisposable()
   private lateinit var scope: CoroutineScope
+  private val quranServiceCallback = QuranServiceCallback()
 
   @Inject
   lateinit var quranInfo: QuranInfo
@@ -277,6 +280,7 @@ class AudioService : Service(), Player.Listener {
   }
 
   override fun onCreate() {
+    super.onCreate()
     Timber.i("debug: Creating service")
     val thread = HandlerThread(
       "AyahAudioService",
@@ -321,7 +325,19 @@ class AudioService : Service(), Player.Listener {
           .subscribeOn(Schedulers.io())
           .subscribe { bitmap: Bitmap? -> notificationIcon = bitmap })
     }
+
+    // init the mediaLibrarySession
+    serviceHandler.post {
+      // Initialize ExoPlayer
+      val player = makeOrResetExoPlayer()
+
+      // Initialize MediaLibrarySession
+      mediaLibrarySession = MediaLibrarySession.Builder(this, player, quranServiceCallback)
+        .build()
+    }
   }
+
+  override fun onGetSession(controllerInfo: MediaSession.ControllerInfo): MediaLibrarySession? = mediaLibrarySession
 
   private inner class MediaSessionCallback : MediaSessionCompat.Callback() {
     override fun onPlay() {
@@ -346,6 +362,7 @@ class AudioService : Service(), Player.Listener {
   }
 
   override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+    super.onStartCommand(intent, flags, startId)
     if (intent == null) {
       // handle a crash that occurs where intent comes in as null
       if (State.Stopped == state) {
@@ -1327,22 +1344,25 @@ class AudioService : Service(), Player.Listener {
   }
 
   override fun onDestroy() {
-    compositeDisposable.clear()
+    Timber.i("debug: destroying the service")
     // Service is being killed, so make sure we release our resources
-    serviceHandler.removeCallbacksAndMessages(null)
-    serviceLooper.quitSafely()
+    compositeDisposable.clear()
     state = State.Stopped
     relaxResources(true, true)
     mediaSession.release()
     timingRepository.clear()
     scope.cancel()
+    serviceHandler.post {
+      mediaLibrarySession?.run {
+        player.release()
+        release()
+        mediaLibrarySession = null
+      }
+      serviceHandler.removeCallbacksAndMessages(null)
+      serviceLooper.quitSafely()
+    }
     super.onDestroy()
   }
-
-  override fun onBind(arg0: Intent): IBinder? {
-    return null
-  }
-
 
   companion object {
     // These are the Intent actions that we are prepared to handle.

--- a/app/src/main/java/com/quran/labs/androidquran/service/AudioService.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/service/AudioService.kt
@@ -2,24 +2,19 @@ package com.quran.labs.androidquran.service
 
 import android.app.NotificationManager
 import android.app.PendingIntent
-import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.graphics.Canvas
 import android.net.Uri
-import android.os.Build
 import android.os.Handler
-import android.support.v4.media.MediaMetadataCompat
 import android.support.v4.media.session.MediaSessionCompat
-import android.support.v4.media.session.PlaybackStateCompat
 import androidx.annotation.OptIn
 import androidx.core.app.NotificationCompat
 import androidx.core.content.ContextCompat
 import androidx.core.graphics.createBitmap
 import androidx.core.graphics.drawable.toDrawable
-import androidx.media.session.MediaButtonReceiver
 import androidx.media3.common.AudioAttributes
 import androidx.media3.common.C
 import androidx.media3.common.MediaItem
@@ -136,8 +131,6 @@ class AudioService : MediaLibraryService(), Player.Listener {
 
 
   private lateinit var notificationManager: NotificationManager
-  private lateinit var mediaSession: MediaSessionCompat
-
   private var notificationBuilder: NotificationCompat.Builder? = null
   private var pausedNotificationBuilder: NotificationCompat.Builder? = null
   private var didSetNotificationIconOnNotificationBuilder = false
@@ -170,9 +163,9 @@ class AudioService : MediaLibraryService(), Player.Listener {
   @Inject
   lateinit var timingRepository: TimingRepository
 
-<<<<<<< HEAD
   @Inject
   lateinit var quranSettings: QuranSettings
+
   /**
    * Makes sure the ExoPlayer exists and has been reset. This will make
    * the ExoPlayer if needed, or reset the existing player if one
@@ -208,6 +201,7 @@ class AudioService : MediaLibraryService(), Player.Listener {
         .setWakeMode(C.WAKE_MODE_NETWORK)
         .build()
       player = localPlayer
+      mediaLibrarySession?.setPlayer(localPlayer)
 
       // Set up listener for playback events
       localPlayer.addListener(this)
@@ -219,7 +213,6 @@ class AudioService : MediaLibraryService(), Player.Listener {
         .build()
       localPlayer.setAudioAttributes(audioAttributes, true)
 
-      mediaSession.isActive = true
       localPlayer
     } else {
       Timber.d("resetting player...")
@@ -276,9 +269,6 @@ class AudioService : MediaLibraryService(), Player.Listener {
       appContext.getSystemService(NOTIFICATION_SERVICE) as NotificationManager
 
 
-    val receiver = ComponentName(this, MediaButtonReceiver::class.java)
-    mediaSession = MediaSessionCompat(appContext, "QuranMediaSession", receiver, null)
-    mediaSession.setCallback(MediaSessionCallback(), null)
     val channelName = getString(R.string.notification_channel_audio)
     setupNotificationChannel(
       notificationManager, NOTIFICATION_CHANNEL_ID, channelName
@@ -314,27 +304,6 @@ class AudioService : MediaLibraryService(), Player.Listener {
 
   override fun onGetSession(controllerInfo: MediaSession.ControllerInfo): MediaLibrarySession? = mediaLibrarySession
 
-  private inner class MediaSessionCallback : MediaSessionCompat.Callback() {
-    override fun onPlay() {
-      processPlayRequest()
-    }
-
-    override fun onSkipToNext() {
-      processSkipRequest()
-    }
-
-    override fun onSkipToPrevious() {
-      processRewindRequest()
-    }
-
-    override fun onPause() {
-      processPauseRequest()
-    }
-
-    override fun onStop() {
-      processStopRequest()
-    }
-  }
 
   override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
     if (intent == null) {
@@ -400,8 +369,6 @@ class AudioService : MediaLibraryService(), Player.Listener {
         audioRequest = playInfo
         updateAudioPlaybackStatus()
       }
-    } else {
-      MediaButtonReceiver.handleIntent(mediaSession, intent)
     }
   }
 
@@ -458,7 +425,6 @@ class AudioService : MediaLibraryService(), Player.Listener {
       val ayah = localAudioQueue.getCurrentAyah()
       val maxAyahs = quranInfo.getNumberOfAyahs(sura)
 
-      setState(PlaybackStateCompat.STATE_PLAYING)
       val pos = localPlayer.currentPosition
       val currentAyahTime = gaplessSuraData.ayahTimings[ayah]
 
@@ -642,7 +608,6 @@ class AudioService : MediaLibraryService(), Player.Listener {
       state = State.Paused
       stopUpdateAudioPositionJob()
       player?.pause()
-      setState(PlaybackStateCompat.STATE_PAUSED)
       // on jellybean and above, stay in the foreground and
       // update the notification.
       relaxResources(releaseExoPlayer = false, stopForeground = false)
@@ -651,7 +616,6 @@ class AudioService : MediaLibraryService(), Player.Listener {
     } else if (State.Stopped == state) {
       // if we get a pause while we're already stopped, it means we likely woke up because
       // of AudioIntentReceiver, so just stop in this case.
-      setState(PlaybackStateCompat.STATE_STOPPED)
       updateAudioPlaybackStatus()
       stopSelf()
     }
@@ -659,7 +623,6 @@ class AudioService : MediaLibraryService(), Player.Listener {
 
   private fun processRewindRequest() {
     if (State.Playing == state || State.Paused == state) {
-      setState(PlaybackStateCompat.STATE_REWINDING)
       val localPlayer = player ?: return
       val localAudioQueue = audioQueue ?: return
       val localAudioRequest = audioRequest ?: return
@@ -703,7 +666,6 @@ class AudioService : MediaLibraryService(), Player.Listener {
       return
     }
     if (State.Playing == state || State.Paused == state) {
-      setState(PlaybackStateCompat.STATE_SKIPPING_TO_NEXT)
       if (playerOverride) {
         playAudio(false)
       } else {
@@ -728,7 +690,6 @@ class AudioService : MediaLibraryService(), Player.Listener {
   }
 
   private fun processStopRequest(force: Boolean = false) {
-    setState(PlaybackStateCompat.STATE_STOPPED)
     stopUpdateAudioPositionJob()
     currentWord = null
     if (State.Preparing == state) {
@@ -743,7 +704,6 @@ class AudioService : MediaLibraryService(), Player.Listener {
       relaxResources(releaseExoPlayer = true, stopForeground = true)
 
       // service is no longer necessary. Will be started again if needed.
-      stopUpdateAudioPositionJob()
       stopSelf()
     }
   }
@@ -751,25 +711,6 @@ class AudioService : MediaLibraryService(), Player.Listener {
   private fun notifyAyahChanged() {
     val localAudioRequest = audioRequest ?: return
     updateAudioPlaybackStatus()
-
-    val metadataBuilder = MediaMetadataCompat.Builder()
-      .putString(MediaMetadataCompat.METADATA_KEY_TITLE, getTitle())
-      .putString(MediaMetadataCompat.METADATA_KEY_ARTIST, localAudioRequest.qari.name)
-    val localPlayer = player
-    if (localPlayer?.isPlaying == true) {
-      metadataBuilder.putLong(
-        MediaMetadataCompat.METADATA_KEY_DURATION,
-        localPlayer.duration
-      )
-    }
-
-    if (displayIcon != null) {
-      metadataBuilder.putBitmap(
-        MediaMetadataCompat.METADATA_KEY_DISPLAY_ICON,
-        displayIcon
-      )
-    }
-    mediaSession.setMetadata(metadataBuilder.build())
   }
 
   private fun updateAudioPlaybackStatus() {
@@ -824,7 +765,6 @@ class AudioService : MediaLibraryService(), Player.Listener {
         // nothing to do here  ¯\_(ツ)_/¯
       }
       player = null
-      mediaSession.isActive = false
     }
 
   }
@@ -936,7 +876,6 @@ class AudioService : MediaLibraryService(), Player.Listener {
       Timber.d("okay, we are preparing to play - streaming is: %b", isStreaming)
 
       val localPlayer = makeOrResetExoPlayer()
-      setState(PlaybackStateCompat.STATE_CONNECTING)
       try {
         val mediaUri = if (overrideResource != 0) {
           // For raw resources, we need to create a URI pointing to the resource
@@ -975,57 +914,6 @@ class AudioService : MediaLibraryService(), Player.Listener {
     }
   }
 
-  private fun setState(state: Int) {
-    var position: Long = 0
-    val localPlayer = player
-    if (localPlayer != null && localPlayer.isPlaying) {
-      position = localPlayer.currentPosition
-    }
-    val builder = PlaybackStateCompat.Builder()
-    builder.setState(state, position, 1.0f)
-
-    val actions = when (state) {
-      PlaybackStateCompat.STATE_PLAYING -> {
-        PlaybackStateCompat.ACTION_PAUSE or
-            PlaybackStateCompat.ACTION_STOP or
-            PlaybackStateCompat.ACTION_REWIND or
-            PlaybackStateCompat.ACTION_FAST_FORWARD or
-            PlaybackStateCompat.ACTION_SKIP_TO_PREVIOUS or
-            PlaybackStateCompat.ACTION_SKIP_TO_NEXT
-      }
-      PlaybackStateCompat.STATE_PAUSED -> {
-        PlaybackStateCompat.ACTION_PLAY or
-            PlaybackStateCompat.ACTION_STOP or
-            PlaybackStateCompat.ACTION_REWIND or
-            PlaybackStateCompat.ACTION_FAST_FORWARD or
-            PlaybackStateCompat.ACTION_SKIP_TO_PREVIOUS or
-            PlaybackStateCompat.ACTION_SKIP_TO_NEXT
-      }
-      PlaybackStateCompat.STATE_STOPPED -> {
-        PlaybackStateCompat.ACTION_PLAY
-      }
-      PlaybackStateCompat.STATE_CONNECTING -> {
-        PlaybackStateCompat.ACTION_STOP
-      }
-      PlaybackStateCompat.STATE_REWINDING -> {
-        PlaybackStateCompat.ACTION_STOP or
-            PlaybackStateCompat.ACTION_REWIND or
-            PlaybackStateCompat.ACTION_FAST_FORWARD or
-            PlaybackStateCompat.ACTION_SKIP_TO_PREVIOUS or
-            PlaybackStateCompat.ACTION_SKIP_TO_NEXT
-      }
-      PlaybackStateCompat.STATE_SKIPPING_TO_NEXT -> {
-        PlaybackStateCompat.ACTION_STOP or
-            PlaybackStateCompat.ACTION_SKIP_TO_PREVIOUS or
-            PlaybackStateCompat.ACTION_SKIP_TO_NEXT or
-            PlaybackStateCompat.ACTION_FAST_FORWARD or
-            PlaybackStateCompat.ACTION_REWIND
-      }
-      else -> { PlaybackStateCompat.ACTION_STOP }
-    }
-    builder.setActions(actions)
-    mediaSession.setPlaybackState(builder.build())
-  }
 
   override fun onPlaybackStateChanged(playbackState: Int) {
     when (playbackState) {
@@ -1047,7 +935,11 @@ class AudioService : MediaLibraryService(), Player.Listener {
         Timber.d("Player idle")
         if (state != State.Stopped) {
           state = State.Stopped
+          stopUpdateAudioPositionJob()
+          currentWord = null
           updateAudioPlaybackStatus()
+          relaxResources(releaseExoPlayer = true, stopForeground = true)
+          stopSelf()
         }
       }
     }
@@ -1072,9 +964,16 @@ class AudioService : MediaLibraryService(), Player.Listener {
     if (isPlaying && state == State.Paused) {
       state = State.Playing
       updateAudioPlaybackStatus()
+      // Restart position updates for gapless audio in case we were paused
+      // by audio focus loss or an external controller
+      if (audioRequest?.isGapless() == true && !playerOverride) {
+        startUpdateAudioPositionJob(200)
+      }
     } else if (!isPlaying && state == State.Playing) {
-      // Handle automatic pause (audio focus loss, etc.)
+      // Handle automatic pause (audio focus loss, external controller, etc.)
       state = State.Paused
+      stopUpdateAudioPositionJob()
+      pauseNotification()
       updateAudioPlaybackStatus()
     }
   }
@@ -1209,6 +1108,7 @@ class AudioService : MediaLibraryService(), Player.Listener {
    * (such as playing music), and must appear to the user as a notification.
    * That's why we create the notification here.
    */
+  @OptIn(UnstableApi::class)
   private fun setUpAsForeground() {
     // clear the "downloading complete" notification (if it exists)
     notificationManager.cancel(QuranDownloadNotifier.DOWNLOADING_COMPLETE_NOTIFICATION)
@@ -1249,7 +1149,7 @@ class AudioService : MediaLibraryService(), Player.Listener {
         .setStyle(
           androidx.media.app.NotificationCompat.MediaStyle()
             .setShowActionsInCompactView(0, 1, 2)
-            .setMediaSession(mediaSession.sessionToken)
+            .setMediaSession(MediaSessionCompat.Token.fromToken(mediaLibrarySession!!.platformToken))
         )
       didSetNotificationIconOnNotificationBuilder = icon != null
       notificationBuilder = builder
@@ -1264,6 +1164,7 @@ class AudioService : MediaLibraryService(), Player.Listener {
     isSetupAsForeground = true
   }
 
+  @OptIn(UnstableApi::class)
   private fun getPausedNotificationBuilder(): NotificationCompat.Builder {
     val appContext = applicationContext
 
@@ -1296,7 +1197,7 @@ class AudioService : MediaLibraryService(), Player.Listener {
         .setStyle(
           androidx.media.app.NotificationCompat.MediaStyle()
             .setShowActionsInCompactView(0, 1)
-            .setMediaSession(mediaSession.sessionToken)
+            .setMediaSession(MediaSessionCompat.Token.fromToken(mediaLibrarySession!!.platformToken))
         )
       pausedNotificationBuilder = builder
       builder
@@ -1337,7 +1238,6 @@ class AudioService : MediaLibraryService(), Player.Listener {
     compositeDisposable.clear()
     state = State.Stopped
     relaxResources(true, true)
-    mediaSession.release()
     timingRepository.clear()
     scope.cancel()
     mediaLibrarySession?.release()

--- a/app/src/main/java/com/quran/labs/androidquran/service/AudioService.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/service/AudioService.kt
@@ -11,10 +11,6 @@ import android.graphics.Canvas
 import android.net.Uri
 import android.os.Build
 import android.os.Handler
-import android.os.HandlerThread
-import android.os.Looper
-import android.os.Message
-import android.os.Process
 import android.support.v4.media.MediaMetadataCompat
 import android.support.v4.media.session.MediaSessionCompat
 import android.support.v4.media.session.PlaybackStateCompat
@@ -77,9 +73,12 @@ import io.reactivex.rxjava3.core.Maybe
 import io.reactivex.rxjava3.disposables.CompositeDisposable
 import io.reactivex.rxjava3.schedulers.Schedulers
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.android.asCoroutineDispatcher
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import timber.log.Timber
 import java.io.File
@@ -139,9 +138,6 @@ class AudioService : MediaLibraryService(), Player.Listener {
   private lateinit var notificationManager: NotificationManager
   private lateinit var mediaSession: MediaSessionCompat
 
-  private lateinit var serviceLooper: Looper
-  private lateinit var serviceHandler: ServiceHandler
-
   private var notificationBuilder: NotificationCompat.Builder? = null
   private var pausedNotificationBuilder: NotificationCompat.Builder? = null
   private var didSetNotificationIconOnNotificationBuilder = false
@@ -155,8 +151,9 @@ class AudioService : MediaLibraryService(), Player.Listener {
   private var gaplessSuraData: SuraTimings = SuraTimings.EMPTY
   private var currentWord: Int? = null
   private val compositeDisposable = CompositeDisposable()
-  private lateinit var scope: CoroutineScope
+  internal lateinit var scope: CoroutineScope
   private val quranServiceCallback = QuranServiceCallback()
+  private var updateAudioPositionJob: Job? = null
 
   @Inject
   lateinit var quranInfo: QuranInfo
@@ -173,20 +170,9 @@ class AudioService : MediaLibraryService(), Player.Listener {
   @Inject
   lateinit var timingRepository: TimingRepository
 
+<<<<<<< HEAD
   @Inject
   lateinit var quranSettings: QuranSettings
-
-  private inner class ServiceHandler(looper: Looper) : Handler(looper) {
-    override fun handleMessage(msg: Message) {
-      if (msg.what == MSG_INCOMING && msg.obj != null) {
-        val intent = msg.obj as Intent
-        handleIntent(intent)
-      } else if (msg.what == MSG_UPDATE_AUDIO_POS) {
-        updateAudioPlayPosition()
-      }
-    }
-  }
-
   /**
    * Makes sure the ExoPlayer exists and has been reset. This will make
    * the ExoPlayer if needed, or reset the existing player if one
@@ -282,16 +268,7 @@ class AudioService : MediaLibraryService(), Player.Listener {
   override fun onCreate() {
     super.onCreate()
     Timber.i("debug: Creating service")
-    val thread = HandlerThread(
-      "AyahAudioService",
-      Process.THREAD_PRIORITY_BACKGROUND
-    )
-    thread.start()
-
-    // Get the HandlerThread's Looper and use it for our Handler
-    serviceLooper = thread.looper
-    serviceHandler = ServiceHandler(serviceLooper)
-    scope = CoroutineScope(serviceHandler.asCoroutineDispatcher() + SupervisorJob())
+    scope = CoroutineScope(Dispatchers.Main.immediate + SupervisorJob())
 
     val appContext = applicationContext
     (appContext as QuranApplication).applicationComponent.inject(this)
@@ -301,7 +278,7 @@ class AudioService : MediaLibraryService(), Player.Listener {
 
     val receiver = ComponentName(this, MediaButtonReceiver::class.java)
     mediaSession = MediaSessionCompat(appContext, "QuranMediaSession", receiver, null)
-    mediaSession.setCallback(MediaSessionCallback(), serviceHandler)
+    mediaSession.setCallback(MediaSessionCallback(), null)
     val channelName = getString(R.string.notification_channel_audio)
     setupNotificationChannel(
       notificationManager, NOTIFICATION_CHANNEL_ID, channelName
@@ -326,15 +303,13 @@ class AudioService : MediaLibraryService(), Player.Listener {
           .subscribe { bitmap: Bitmap? -> notificationIcon = bitmap })
     }
 
-    // init the mediaLibrarySession
-    serviceHandler.post {
-      // Initialize ExoPlayer
-      val player = makeOrResetExoPlayer()
+    // Initialize ExoPlayer
+    val player = makeOrResetExoPlayer()
 
-      // Initialize MediaLibrarySession
-      mediaLibrarySession = MediaLibrarySession.Builder(this, player, quranServiceCallback)
-        .build()
-    }
+    // Initialize MediaLibrarySession
+
+    mediaLibrarySession = MediaLibrarySession.Builder(this, player, quranServiceCallback)
+      .build()
   }
 
   override fun onGetSession(controllerInfo: MediaSession.ControllerInfo): MediaLibrarySession? = mediaLibrarySession
@@ -362,11 +337,10 @@ class AudioService : MediaLibraryService(), Player.Listener {
   }
 
   override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
-    super.onStartCommand(intent, flags, startId)
     if (intent == null) {
       // handle a crash that occurs where intent comes in as null
       if (State.Stopped == state) {
-        serviceHandler.removeCallbacksAndMessages(null)
+        stopUpdateAudioPositionJob()
         stopSelf()
       }
     } else {
@@ -375,10 +349,9 @@ class AudioService : MediaLibraryService(), Player.Listener {
         // go to the foreground as quickly as possible.
         setUpAsForeground()
       }
-      val message = serviceHandler.obtainMessage(MSG_INCOMING, intent)
-      serviceHandler.sendMessage(message)
+      handleIntent(intent)
     }
-    return START_NOT_STICKY
+    return super.onStartCommand(intent, flags, startId)
   }
 
   private fun handleIntent(intent: Intent) {
@@ -422,7 +395,7 @@ class AudioService : MediaLibraryService(), Player.Listener {
         audioQueue = localAudioQueue.withUpdatedAudioRequest(playInfo)
         if (playInfo.playbackSpeed != audioRequest?.playbackSpeed) {
           processUpdatePlaybackSpeed(playInfo.playbackSpeed)
-          serviceHandler.sendEmptyMessageDelayed(MSG_UPDATE_AUDIO_POS, 200)
+          startUpdateAudioPositionJob(200)
         }
         audioRequest = playInfo
         updateAudioPlaybackStatus()
@@ -455,6 +428,21 @@ class AudioService : MediaLibraryService(), Player.Listener {
       } else time
     }
     return -1
+  }
+
+  private fun startUpdateAudioPositionJob(delayMs: Long) {
+    stopUpdateAudioPositionJob()
+    updateAudioPositionJob = scope.launch {
+      delay(delayMs)
+      if (isActive) {
+        updateAudioPlayPosition()
+      }
+    }
+  }
+
+  private fun stopUpdateAudioPositionJob() {
+    updateAudioPositionJob?.cancel()
+    updateAudioPositionJob = null
   }
 
   private fun updateAudioPlayPosition() {
@@ -500,7 +488,7 @@ class AudioService : MediaLibraryService(), Player.Listener {
         val ayahTime = gaplessSuraData.ayahTimings[ayah]
         if (abs(pos - ayahTime) < 150) {
           // shouldn't change ayahs if the delta is just 150ms...
-          serviceHandler.sendEmptyMessageDelayed(MSG_UPDATE_AUDIO_POS, 150)
+          startUpdateAudioPositionJob(150)
           return
         }
         val success = localAudioQueue.playAt(sura, updatedAyah, false)
@@ -512,7 +500,7 @@ class AudioService : MediaLibraryService(), Player.Listener {
           return
         } else if (nextSura != sura || nextAyah != updatedAyah) {
           // remove any messages currently in the queue
-          serviceHandler.removeMessages(MSG_UPDATE_AUDIO_POS)
+          stopUpdateAudioPositionJob()
           currentWord = null
 
           // if the ayah hasn't changed, we're repeating the ayah,
@@ -541,7 +529,7 @@ class AudioService : MediaLibraryService(), Player.Listener {
           val success = localAudioQueue.playAt(sura + 1, 1, false)
           if (success && localAudioQueue.getCurrentSura() == sura) {
             // remove any messages currently in the queue
-            serviceHandler.removeMessages(MSG_UPDATE_AUDIO_POS)
+            stopUpdateAudioPositionJob()
 
             // jump back to the ayah we should repeat and play it
             val seekPos = getSeekPosition(false)
@@ -596,7 +584,7 @@ class AudioService : MediaLibraryService(), Player.Listener {
 
       // schedule next the update
       if (nextUpdateDelay != null) {
-        serviceHandler.sendEmptyMessageDelayed(MSG_UPDATE_AUDIO_POS, nextUpdateDelay)
+        startUpdateAudioPositionJob(nextUpdateDelay)
       } else if (maxAyahs >= updatedAyah + 1) {
         val timeDelta = gaplessSuraData.ayahTimings[updatedAyah + 1] - localPlayer.currentPosition
         val t = timeDelta.coerceIn(100, 10000)
@@ -607,9 +595,9 @@ class AudioService : MediaLibraryService(), Player.Listener {
             t, tAccountingForSpeed, audioRequest?.playbackSpeed
           )
         }
-        serviceHandler.sendEmptyMessageDelayed(MSG_UPDATE_AUDIO_POS, tAccountingForSpeed.toLong())
+        startUpdateAudioPositionJob(tAccountingForSpeed.toLong())
       } else if (maxAyahs == updatedAyah) {
-        serviceHandler.sendEmptyMessageDelayed(MSG_UPDATE_AUDIO_POS, 150)
+        startUpdateAudioPositionJob(150)
       }
       // if we're on the last ayah, don't do anything - let the file
       // complete on its own to avoid getCurrentPosition() bugs.
@@ -652,7 +640,7 @@ class AudioService : MediaLibraryService(), Player.Listener {
     if (State.Playing == state) {
       // Pause exo player and cancel the 'foreground service' state.
       state = State.Paused
-      serviceHandler.removeMessages(MSG_UPDATE_AUDIO_POS)
+      stopUpdateAudioPositionJob()
       player?.pause()
       setState(PlaybackStateCompat.STATE_PAUSED)
       // on jellybean and above, stay in the foreground and
@@ -741,7 +729,7 @@ class AudioService : MediaLibraryService(), Player.Listener {
 
   private fun processStopRequest(force: Boolean = false) {
     setState(PlaybackStateCompat.STATE_STOPPED)
-    serviceHandler.removeMessages(MSG_UPDATE_AUDIO_POS)
+    stopUpdateAudioPositionJob()
     currentWord = null
     if (State.Preparing == state) {
       shouldStop = true
@@ -755,7 +743,7 @@ class AudioService : MediaLibraryService(), Player.Listener {
       relaxResources(releaseExoPlayer = true, stopForeground = true)
 
       // service is no longer necessary. Will be started again if needed.
-      serviceHandler.removeCallbacksAndMessages(null)
+      stopUpdateAudioPositionJob()
       stopSelf()
     }
   }
@@ -867,7 +855,7 @@ class AudioService : MediaLibraryService(), Player.Listener {
 
     if (audioRequest?.isGapless() == true && !playerOverride) {
       Timber.d("configAndStartExoPlayer: restarting position updates")
-      serviceHandler.sendEmptyMessageDelayed(MSG_UPDATE_AUDIO_POS, 200)
+      startUpdateAudioPositionJob(200)
     }
   }
 
@@ -1101,7 +1089,7 @@ class AudioService : MediaLibraryService(), Player.Listener {
     }
     updateAudioPlaybackStatus()
     Timber.d("onSeekComplete: restarting position updates")
-    serviceHandler.sendEmptyMessageDelayed(MSG_UPDATE_AUDIO_POS, 200)
+    startUpdateAudioPositionJob(200)
   }
 
   private fun onPlayerBuffering() {
@@ -1352,15 +1340,9 @@ class AudioService : MediaLibraryService(), Player.Listener {
     mediaSession.release()
     timingRepository.clear()
     scope.cancel()
-    serviceHandler.post {
-      mediaLibrarySession?.run {
-        player.release()
-        release()
-        mediaLibrarySession = null
-      }
-      serviceHandler.removeCallbacksAndMessages(null)
-      serviceLooper.quitSafely()
-    }
+    mediaLibrarySession?.release()
+    mediaLibrarySession = null
+    stopUpdateAudioPositionJob()
     super.onDestroy()
   }
 
@@ -1387,8 +1369,6 @@ class AudioService : MediaLibraryService(), Player.Listener {
     // so user can pass in a serializable LegacyAudioRequest to the intent
     const val EXTRA_PLAY_INFO = "com.quran.labs.androidquran.PLAY_INFO"
     private const val NOTIFICATION_CHANNEL_ID = Constants.AUDIO_CHANNEL
-    private const val MSG_INCOMING = 1
-    private const val MSG_UPDATE_AUDIO_POS = 2
     private const val DEBUG_TIMINGS = false
 
     // 5 minutes

--- a/app/src/main/java/com/quran/labs/androidquran/service/QuranServiceCallback.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/service/QuranServiceCallback.kt
@@ -1,0 +1,9 @@
+package com.quran.labs.androidquran.service
+
+import androidx.media3.session.MediaLibraryService
+
+/**
+ * Empty callback implementation, to be extended to support media items and allow controller requests
+ * from other apps (like android auto or google assistant)
+ */
+class QuranServiceCallback : MediaLibraryService.MediaLibrarySession.Callback

--- a/app/src/main/java/com/quran/labs/androidquran/service/QuranServiceCallback.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/service/QuranServiceCallback.kt
@@ -3,7 +3,13 @@ package com.quran.labs.androidquran.service
 import androidx.media3.session.MediaLibraryService
 
 /**
- * Empty callback implementation, to be extended to support media items and allow controller requests
- * from other apps (like android auto or google assistant)
+ * Callback for the [MediaLibraryService.MediaLibrarySession] to support media browsing
+ * from external controllers (Android Auto, Google Assistant, etc.).
+ *
+ * Note: In Media3, transport controls (play/pause/stop/skip) are handled by the
+ * [Player][androidx.media3.common.Player] directly and don't require callback overrides.
+ * This callback exists for library-specific operations like
+ * [onGetItem][MediaLibraryService.MediaLibrarySession.Callback.onGetItem],
+ * [onGetChildren][MediaLibraryService.MediaLibrarySession.Callback.onGetChildren], etc.
  */
 class QuranServiceCallback : MediaLibraryService.MediaLibrarySession.Callback


### PR DESCRIPTION
Migrates the `AudioService` from the legacy `Service` to `androidx.media3.session.MediaLibraryService`.

This change introduces `MediaLibrarySession` to handle media playback, replacing parts of the older `MediaSessionCompat` implementation. A new `QuranServiceCallback` class is also added for future integration with media controllers like Android Auto.

The motivation behind this migration is to build on top of it to enable a better android auto support (check the issue #1086), the end goal is to use the same audio service to sync the player items (surahs) and playback state with android auto, similar to other media playback apps.

