### PR TITLE
Handle various line images not downloaded cases

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/util/SettingsImpl.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/util/SettingsImpl.kt
@@ -77,6 +77,10 @@ class SettingsImpl @Inject constructor(private val quranSettings: QuranSettings)
     return quranSettings.pageType
   }
 
+  override suspend fun setPageType(pageType: String) {
+    quranSettings.pageType = pageType
+  }
+
   override suspend fun showSidelines(): Boolean {
     return quranSettings.isSidelines
   }

--- a/common/data/src/main/java/com/quran/data/dao/Settings.kt
+++ b/common/data/src/main/java/com/quran/data/dao/Settings.kt
@@ -12,6 +12,7 @@ interface Settings {
   suspend fun shouldShowHeaderFooter(): Boolean
   suspend fun shouldShowBookmarks(): Boolean
   suspend fun pageType(): String
+  suspend fun setPageType(pageType: String)
   suspend fun showSidelines(): Boolean
   suspend fun setShowSidelines(show: Boolean)
   suspend fun showLineDividers(): Boolean

--- a/feature/linebyline/build.gradle.kts
+++ b/feature/linebyline/build.gradle.kts
@@ -23,6 +23,7 @@ dependencies {
   implementation(libs.androidx.core.ktx)
   implementation(libs.androidx.appcompat)
   implementation(libs.material)
+  implementation(libs.timber)
 
   implementation(libs.compose.ui)
   implementation(libs.compose.material)

--- a/feature/linebyline/src/main/java/com/quran/labs/androidquran/extra/feature/linebyline/model/MissingLineByLineImagesException.kt
+++ b/feature/linebyline/src/main/java/com/quran/labs/androidquran/extra/feature/linebyline/model/MissingLineByLineImagesException.kt
@@ -1,0 +1,3 @@
+package com.quran.labs.androidquran.extra.feature.linebyline.model
+
+class MissingLineByLineImagesException(message: String) : IllegalStateException(message)


### PR DESCRIPTION
Today, if someone freshly installs and launches the app from a widget or
a shortcut, the app will insta-crash because the line by line images are
not available and the fallback did not kick in.

This PR fixes it by resetting to the default type of images (when
available) and restarting the activity. Unfortunately, this only helps
the main app and does not help the naskh app today (which does not have
a fallback set of images).
