### PR TITLE
Improve behavior of double page mode on foldables

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/ui/PagerActivity.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/PagerActivity.kt
@@ -287,8 +287,9 @@ class PagerActivity : AppCompatActivity(), AudioBarListener, OnBookmarkTagsUpdat
           .collectLatest {
             val foldingFeatures = it.filterIsInstance<FoldingFeature>().firstOrNull()
             if (foldingFeatures != null) {
-              val localState = foldingFeatures.state == FoldingFeature.State.FLAT &&
-                  foldingFeatures.orientation == FoldingFeature.Orientation.VERTICAL
+              val localState =
+                foldingFeatures.orientation == FoldingFeature.Orientation.VERTICAL &&
+                    (foldingFeatures.state == FoldingFeature.State.FLAT || foldingFeatures.state == FoldingFeature.State.HALF_OPENED)
               if (isFoldableDeviceOpenAndVertical != localState) {
                 isFoldableDeviceOpenAndVertical = localState
                 updateDualPageMode()


### PR DESCRIPTION
When a foldable is partially folded, the app would switch to single page
mode. The guidance from Google for handling "book posture" is to handle
both half opened and flat states, so that dual page mode can remain
until the device is fully closed.

Fixes #3526.
