### PR TITLE
Fix audio playback on Android Auto

### DIFF
--- a/autoquran/src/main/java/com/quran/labs/autoquran/di/ServiceBindings.kt
+++ b/autoquran/src/main/java/com/quran/labs/autoquran/di/ServiceBindings.kt
@@ -1,11 +1,10 @@
 package com.quran.labs.autoquran.di
 
 import android.content.Context
-import com.quran.data.model.audio.Qari
 import com.quran.data.source.PageProvider
 import com.quran.data.source.QuranDataSource
-import com.quran.labs.androidquran.common.audio.model.QariItem
 import com.quran.labs.androidquran.common.audio.util.AudioExtensionDecider
+import com.quran.labs.androidquran.common.audio.util.QuranAudioExtensionDecider
 import com.quran.mobile.di.qualifier.ApplicationContext
 import dev.zacsweers.metro.BindingContainer
 import dev.zacsweers.metro.Provides
@@ -30,12 +29,6 @@ class ServiceBindings(private val appContext: Context) {
   }
 
   @Provides
-  fun provideAudioExtensionDecider(): AudioExtensionDecider {
-    return object : AudioExtensionDecider {
-      override fun audioExtensionForQari(qari: Qari): String = "mp3"
-      override fun audioExtensionForQari(qariItem: QariItem): String = "mp3"
-      override fun allowedAudioExtensions(qari: Qari): List<String> = listOf("mp3")
-      override fun allowedAudioExtensions(qariItem: QariItem): List<String> = listOf("mp3")
-    }
-  }
+  fun provideAudioExtensionDecider(quranAudioExtensionDecider: QuranAudioExtensionDecider): AudioExtensionDecider =
+    quranAudioExtensionDecider
 }

--- a/common/audio/src/main/java/com/quran/labs/androidquran/common/audio/util/QuranAudioExtensionDecider.kt
+++ b/common/audio/src/main/java/com/quran/labs/androidquran/common/audio/util/QuranAudioExtensionDecider.kt
@@ -1,9 +1,8 @@
-package com.quran.labs.androidquran.data
+package com.quran.labs.androidquran.common.audio.util
 
 import com.quran.data.di.AppScope
 import com.quran.data.model.audio.Qari
 import com.quran.labs.androidquran.common.audio.model.QariItem
-import com.quran.labs.androidquran.common.audio.util.AudioExtensionDecider
 import dev.zacsweers.metro.ContributesBinding
 import dev.zacsweers.metro.Inject
 

--- a/feature/autoquran/src/main/java/com/quran/labs/feature/autoquran/common/BrowsableSurahBuilder.kt
+++ b/feature/autoquran/src/main/java/com/quran/labs/feature/autoquran/common/BrowsableSurahBuilder.kt
@@ -14,7 +14,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
 class BrowsableSurahBuilder @Inject constructor(
-  @ApplicationContext private val appContext: Context,
+  @param:ApplicationContext private val appContext: Context,
   private val pageProvider: PageProvider,
   private val audioExtensionDecider: AudioExtensionDecider
 ) {
@@ -136,6 +136,12 @@ class BrowsableSurahBuilder @Inject constructor(
   private fun makeSuraMediaItem(qari: Qari, sura: Int): MediaItem {
     val suraName = getSuraName(appContext, sura, wantPrefix = true, wantTranslation = false)
     val extension = audioExtensionDecider.audioExtensionForQari(qari)
+    val (baseUrl, mimeType) = if (extension == "opus" && qari.opusUrl != null) {
+      qari.opusUrl to MimeTypes.AUDIO_OPUS
+    } else {
+      qari.url to MimeTypes.AUDIO_MPEG
+    }
+
     return MediaItem.Builder()
       .setMediaId("sura_${sura}_${qari.id}")
       .setMediaMetadata(
@@ -149,8 +155,8 @@ class BrowsableSurahBuilder @Inject constructor(
           .setArtist(appContext.getString(qari.nameResource))
           .build()
       )
-      .setMimeType(MimeTypes.AUDIO_MPEG)
-      .setUri(qari.url + makeThreeDigit(sura) + ".$extension")
+      .setMimeType(mimeType)
+      .setUri(baseUrl + makeThreeDigit(sura) + ".$extension")
       .build()
   }
 

--- a/feature/autoquran/src/main/java/com/quran/labs/feature/autoquran/service/QuranBrowsableAudioPlaybackService.kt
+++ b/feature/autoquran/src/main/java/com/quran/labs/feature/autoquran/service/QuranBrowsableAudioPlaybackService.kt
@@ -95,7 +95,7 @@ class QuranBrowsableAudioPlaybackService : MediaSessionService() {
   override fun onGetSession(controllerInfo: MediaSession.ControllerInfo): MediaSession? =
     mediaSession
 
-  private inner class PlayerEventListener : Player.Listener
+  private class PlayerEventListener : Player.Listener
 
   private inner class QuranServiceCallback : MediaLibrarySession.Callback {
 


### PR DESCRIPTION
When opus is the decided format, use the proper base url on Android Auto
to avoid playback errors.
