### PR TITLE
feat(focus-mode): add Do Not Disturb for distraction-free reading

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,6 +16,9 @@
   <!-- required for posting notifications on Android 13+ (Api 33+) -->
   <uses-permission-sdk-23 android:name="android.permission.POST_NOTIFICATIONS"/>
 
+  <!-- required for Focus Mode (Do Not Disturb) to modify notification policy -->
+  <uses-permission android:name="android.permission.ACCESS_NOTIFICATION_POLICY"/>
+
   <!-- required for foreground service types on Android 14+ (Api 34+) -->
   <uses-permission-sdk-23 android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
   <uses-permission-sdk-23 android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />

--- a/app/src/main/java/com/quran/labs/androidquran/data/Constants.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/data/Constants.kt
@@ -89,6 +89,7 @@ object Constants {
   const val PREF_SHOW_SIDELINES = "showSidelines"
   const val PREF_SHOW_LINE_DIVIDERS = "showLineDividers"
   const val PREF_APP_THEME = "appTheme"
+  const val PREF_FOCUS_MODE = "focusMode"
 
   // Themes
   const val THEME_LIGHT = "light"

--- a/app/src/main/java/com/quran/labs/androidquran/ui/PagerActivity.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/PagerActivity.kt
@@ -103,6 +103,7 @@ import com.quran.labs.androidquran.ui.listener.AudioBarListener
 import com.quran.labs.androidquran.ui.util.ToastCompat.makeText
 import com.quran.labs.androidquran.ui.util.TranslationsSpinnerAdapter
 import com.quran.labs.androidquran.util.AudioUtils
+import com.quran.labs.androidquran.util.FocusModeManager
 import com.quran.labs.androidquran.util.QuranAppUtils
 import com.quran.labs.androidquran.util.QuranFileUtils
 import com.quran.labs.androidquran.util.QuranScreenInfo
@@ -208,6 +209,8 @@ class PagerActivity : AppCompatActivity(), AudioBarListener, OnBookmarkTagsUpdat
   private var lastSelectedTranslationAyah: QuranAyahInfo? = null
   private var lastActivatedLocalTranslations: Array<LocalTranslation> = emptyArray()
 
+  private lateinit var focusModeManager: FocusModeManager
+
   @Inject lateinit var bookmarksDao: BookmarksDao
   @Inject lateinit var recentPagePresenter: RecentPagePresenter
   @Inject lateinit var quranSettings: QuranSettings
@@ -278,6 +281,8 @@ class PagerActivity : AppCompatActivity(), AudioBarListener, OnBookmarkTagsUpdat
     isFoldableDeviceOpenAndVertical =
       savedInstanceState?.getBoolean(LAST_FOLDING_STATE, isFoldableDeviceOpenAndVertical)
         ?: isFoldableDeviceOpenAndVertical
+
+    focusModeManager = FocusModeManager(this)
 
     lifecycleScope.launch {
       lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
@@ -876,6 +881,10 @@ class PagerActivity : AppCompatActivity(), AudioBarListener, OnBookmarkTagsUpdat
     audioPresenter.bind(this)
     recentPagePresenter.bind(currentPageFlow)
 
+    if (QuranSettings.getInstance(this).isFocusModeEnabled()) {
+      focusModeManager.enableFocusMode()
+    }
+
     if (shouldReconnect) {
       foregroundDisposable.add(
         Completable.timer(500, TimeUnit.MILLISECONDS)
@@ -1072,6 +1081,8 @@ class PagerActivity : AppCompatActivity(), AudioBarListener, OnBookmarkTagsUpdat
     promptDialog = null
     recentPagePresenter.unbind()
     quranSettings.wasShowingTranslation = pagerAdapter.isShowingTranslation
+
+    focusModeManager.restorePreviousDndState()
 
     super.onPause()
   }

--- a/app/src/main/java/com/quran/labs/androidquran/ui/fragment/QuranSettingsFragment.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/fragment/QuranSettingsFragment.kt
@@ -1,6 +1,8 @@
 package com.quran.labs.androidquran.ui.fragment
 
 import android.content.Intent
+import android.provider.Settings
+import android.widget.Toast
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -21,6 +23,8 @@ import com.quran.labs.androidquran.R
 import com.quran.labs.androidquran.data.Constants
 import com.quran.labs.androidquran.pageselect.PageSelectActivity
 import com.quran.labs.androidquran.ui.TranslationManagerActivity
+import com.quran.labs.androidquran.util.FocusModeManager
+import com.quran.labs.androidquran.util.QuranSettings
 import com.quran.labs.androidquran.util.QuranUtils
 import com.quran.labs.androidquran.util.ThemeUtil
 import com.quran.mobile.di.ExtraPreferencesProvider
@@ -67,6 +71,27 @@ class QuranSettingsFragment : PreferenceFragmentCompat() {
     val themePref: Preference? = findPreference(Constants.PREF_APP_THEME)
     themePref?.onPreferenceChangeListener = Preference.OnPreferenceChangeListener { _, newValue ->
       ThemeUtil.setTheme(newValue as String)
+      true
+    }
+
+    // handle Focus Mode preference
+    val focusModePref: Preference? = findPreference(Constants.PREF_FOCUS_MODE)
+    focusModePref?.onPreferenceChangeListener = Preference.OnPreferenceChangeListener { preference, newValue ->
+      if (newValue == true) {
+        val focusModeManager = FocusModeManager(requireContext())
+        if (!focusModeManager.isPermissionGranted()) {
+          // Show explanation and open settings
+          Toast.makeText(
+            requireContext(),
+            R.string.focus_mode_permission_required,
+            Toast.LENGTH_LONG
+          ).show()
+          focusModeManager.requestPermission(requireActivity())
+          // Don't actually enable yet - user needs to grant permission first
+          (preference as? CheckBoxPreference)?.isChecked = false
+          return@OnPreferenceChangeListener false
+        }
+      }
       true
     }
 

--- a/app/src/main/java/com/quran/labs/androidquran/util/FocusModeManager.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/util/FocusModeManager.kt
@@ -1,0 +1,47 @@
+package com.quran.labs.androidquran.util
+
+import android.app.Activity
+import android.app.NotificationManager
+import android.content.Context
+import android.content.Intent
+import android.provider.Settings
+
+class FocusModeManager(private val context: Context) {
+
+  private val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+  private var previousInterruptionFilter: Int = NotificationManager.INTERRUPTION_FILTER_ALL
+  private var focusModeActivatedByApp: Boolean = false
+
+  fun isPermissionGranted(): Boolean = notificationManager.isNotificationPolicyAccessGranted
+
+  fun requestPermission(activity: Activity) {
+    val intent = Intent(Settings.ACTION_NOTIFICATION_POLICY_ACCESS_SETTINGS)
+    activity.startActivity(intent)
+  }
+
+  fun saveCurrentDndState() {
+    previousInterruptionFilter = notificationManager.currentInterruptionFilter
+  }
+
+  fun enableFocusMode(): Boolean {
+    if (!isPermissionGranted()) return false
+    if (focusModeActivatedByApp) return true
+
+    previousInterruptionFilter = notificationManager.currentInterruptionFilter
+    notificationManager.setInterruptionFilter(NotificationManager.INTERRUPTION_FILTER_ALARMS)
+    focusModeActivatedByApp = true
+    return true
+  }
+
+  fun restorePreviousDndState() {
+    if (!isPermissionGranted()) return
+    if (!focusModeActivatedByApp) return
+
+    notificationManager.setInterruptionFilter(previousInterruptionFilter)
+    focusModeActivatedByApp = false
+  }
+
+  fun isFocusModeActive(): Boolean {
+    return focusModeActivatedByApp
+  }
+}

--- a/app/src/main/java/com/quran/labs/androidquran/util/NotificationChannelUtil.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/util/NotificationChannelUtil.kt
@@ -3,12 +3,16 @@ package com.quran.labs.androidquran.util
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.os.Build
+import com.quran.labs.androidquran.data.Constants
 
 object NotificationChannelUtil {
 
   fun setupNotificationChannel(notificationManager: NotificationManager, channelId: String, channelName: String) {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
       val notificationChannel = NotificationChannel(channelId, channelName, NotificationManager.IMPORTANCE_LOW)
+      if (channelId == Constants.AUDIO_CHANNEL) {
+        notificationChannel.setBypassDnd(true)
+      }
       if (notificationManager.getNotificationChannel(channelId) == null) {
         notificationManager.createNotificationChannel(notificationChannel)
       }

--- a/app/src/main/java/com/quran/labs/androidquran/util/NotificationChannelUtil.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/util/NotificationChannelUtil.kt
@@ -10,9 +10,6 @@ object NotificationChannelUtil {
   fun setupNotificationChannel(notificationManager: NotificationManager, channelId: String, channelName: String) {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
       val notificationChannel = NotificationChannel(channelId, channelName, NotificationManager.IMPORTANCE_LOW)
-      if (channelId == Constants.AUDIO_CHANNEL) {
-        notificationChannel.setBypassDnd(true)
-      }
       if (notificationManager.getNotificationChannel(channelId) == null) {
         notificationManager.createNotificationChannel(notificationChannel)
       }

--- a/app/src/main/java/com/quran/labs/androidquran/util/QuranSettings.java
+++ b/app/src/main/java/com/quran/labs/androidquran/util/QuranSettings.java
@@ -57,6 +57,10 @@ public class QuranSettings {
     return prefs.getBoolean(Constants.PREF_USE_VOLUME_KEY_NAV, false);
   }
 
+  public boolean isFocusModeEnabled() {
+    return prefs.getBoolean(Constants.PREF_FOCUS_MODE, false);
+  }
+
   public boolean shouldStream() {
     return prefs.getBoolean(Constants.PREF_PREFER_STREAMING, false);
   }

--- a/app/src/main/res/values/preferences_keys.xml
+++ b/app/src/main/res/values/preferences_keys.xml
@@ -25,6 +25,7 @@
   <string translatable="false" name="prefs_prefer_streaming">preferStreaming</string>
   <string translatable="false" name="prefs_download_amount">preferredDownloadAmount</string>
   <string translatable="false" name="prefs_volume_key_navigation">volumeKeyNavigation</string>
+  <string translatable="false" name="prefs_focus_mode">focusMode</string>
   <string translatable="false" name="prefs_app_location">appLocation</string>
   <string translatable="false" name="prefs_display_category_key">displayCategoryKey</string>
   <string translatable="false" name="prefs_download_category_key">downloadCategoryKey</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -160,6 +160,9 @@
   <string name="prefs_volume_key_navigation_title">Volume key navigation</string>
   <string name="prefs_volume_key_navigation_summary">Navigate between pages using volume keys</string>
   <string name="prefs_category_reading">Reading Preferences</string>
+  <string name="prefs_focus_mode_title">Focus Mode</string>
+  <string name="prefs_focus_mode_summary">Enable Do Not Disturb while reading</string>
+  <string name="focus_mode_permission_required">Focus Mode requires Do Not Disturb access. Please grant permission in settings.</string>
   <string name="prefs_category_translation">Translation Preferences</string>
   <string name="prefs_category_display_settings">Display Settings</string>
   <string name="prefs_use_arabic_title">Arabic mode (الوضع العربي)</string>

--- a/app/src/main/res/xml/quran_preferences.xml
+++ b/app/src/main/res/xml/quran_preferences.xml
@@ -109,6 +109,14 @@
         android:summary="@string/prefs_volume_key_navigation_summary"
         android:title="@string/prefs_volume_key_navigation_title"
         app:iconSpaceReserved="false"/>
+
+    <CheckBoxPreference
+        android:defaultValue="false"
+        android:key="@string/prefs_focus_mode"
+        android:persistent="true"
+        android:summary="@string/prefs_focus_mode_summary"
+        android:title="@string/prefs_focus_mode_title"
+        app:iconSpaceReserved="false"/>
   </PreferenceCategory>
 
   <PreferenceCategory


### PR DESCRIPTION
**Summary**
Add a Focus Mode feature that automatically enables Do Not Disturb (Alarms Only) when the user opens the Quran to read, providing a distraction-free reading experience - free from notifications that interrupt your focus.

**Changes**
- New permission: ACCESS_NOTIFICATION_POLICY - required to modify DND settings
- New FocusModeManager: Handles enabling/disabling DND and restoring previous state
- New settings toggle: Settings → Reading → Focus Mode
- Automatic activation: DND enables when opening Quran, restores when leaving
- Quran audio exemption: App's own audio notifications bypass DND

**How it works**
1. User enables Focus Mode in Settings → Reading → Focus Mode
2. User grants Do Not Disturb access permission (one-time)
3. When user opens Quran to read, DND (Alarms Only) automatically activates
4. When user leaves reading, their previous DND state is restored
5. Quran app's own audio playback notifications remain functional during Focus Mode