### PR TITLE
Hide lock orientation on large Android 16 devices

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/ui/PagerActivity.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/PagerActivity.kt
@@ -105,6 +105,7 @@ import com.quran.labs.androidquran.ui.listener.AudioBarListener
 import com.quran.labs.androidquran.ui.util.ToastCompat.makeText
 import com.quran.labs.androidquran.ui.util.TranslationsSpinnerAdapter
 import com.quran.labs.androidquran.util.AudioUtils
+import com.quran.labs.androidquran.util.OrientationLockUtils
 import com.quran.labs.androidquran.util.QuranAppUtils
 import com.quran.labs.androidquran.util.QuranFileUtils
 import com.quran.labs.androidquran.util.QuranScreenInfo
@@ -601,7 +602,9 @@ class PagerActivity : AppCompatActivity(), AudioBarListener, OnBookmarkTagsUpdat
     shouldReconnect = true
 
     // enforce orientation lock
-    if (quranSettings.isLockOrientation) {
+    if (quranSettings.isLockOrientation &&
+      OrientationLockUtils.isOrientationLockSupported(resources.configuration)
+    ) {
       val current = resources.configuration.orientation
       if (quranSettings.isLandscapeOrientation) {
         if (current == Configuration.ORIENTATION_PORTRAIT) {

--- a/app/src/main/java/com/quran/labs/androidquran/ui/fragment/QuranSettingsFragment.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/fragment/QuranSettingsFragment.kt
@@ -21,6 +21,7 @@ import com.quran.labs.androidquran.R
 import com.quran.labs.androidquran.data.Constants
 import com.quran.labs.androidquran.pageselect.PageSelectActivity
 import com.quran.labs.androidquran.ui.TranslationManagerActivity
+import com.quran.labs.androidquran.util.OrientationLockUtils
 import com.quran.labs.androidquran.util.QuranUtils
 import com.quran.labs.androidquran.util.ThemeUtil
 import com.quran.mobile.di.ExtraPreferencesProvider
@@ -42,6 +43,10 @@ class QuranSettingsFragment : PreferenceFragmentCompat() {
 
     // field injection
     (appContext as QuranApplication).applicationComponent.inject(this)
+
+    if (!OrientationLockUtils.isOrientationLockSupported(resources.configuration)) {
+      hideUnsupportedOrientationPreferences()
+    }
 
     // handle Arabic names preference
     val arabicPref: Preference? = findPreference(ARABIC_KEY)
@@ -142,6 +147,19 @@ class QuranSettingsFragment : PreferenceFragmentCompat() {
   private fun isCurrentlyArabic(): Boolean {
     val locale = QuranUtils.getCurrentLocale()
     return locale.language == "ar"
+  }
+
+  private fun hideUnsupportedOrientationPreferences() {
+    val displayPrefs = findPreference<PreferenceGroup>(getString(R.string.prefs_display_category_key))
+    val lockOrientationPref = findPreference<Preference>(Constants.PREF_LOCK_ORIENTATION)
+    val landscapeOrientationPref = findPreference<Preference>(Constants.PREF_LANDSCAPE_ORIENTATION)
+
+    if (displayPrefs != null && lockOrientationPref != null) {
+      displayPrefs.removePreference(lockOrientationPref)
+    }
+    if (displayPrefs != null && landscapeOrientationPref != null) {
+      displayPrefs.removePreference(landscapeOrientationPref)
+    }
   }
 
   companion object {

--- a/app/src/main/java/com/quran/labs/androidquran/util/OrientationLockUtils.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/util/OrientationLockUtils.kt
@@ -1,0 +1,16 @@
+package com.quran.labs.androidquran.util
+
+import android.content.res.Configuration
+import android.os.Build
+
+object OrientationLockUtils {
+  private const val ANDROID_16_API_LEVEL = 36
+  private const val LARGE_SCREEN_SMALLEST_WIDTH_DP = 600
+
+  @JvmStatic
+  fun isOrientationLockSupported(configuration: Configuration): Boolean {
+    // Android 16+ ignores app-requested orientation locks on large screens.
+    return Build.VERSION.SDK_INT < ANDROID_16_API_LEVEL ||
+      configuration.smallestScreenWidthDp < LARGE_SCREEN_SMALLEST_WIDTH_DP
+  }
+}


### PR DESCRIPTION
This patch hides lock orientation on large Android 16 devices, since the
settings won't work there anyhow. Google wants apps to stop using this
and aim for adaptive app experiences instead, so they make these no-ops
on sw600dp devices running Android 16+.
