### PR TITLE
Play basmallah when a gapless surah repeats back to ayah 1

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/service/AudioService.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/service/AudioService.kt
@@ -1112,8 +1112,13 @@ class AudioService : Service(), Player.Listener {
         if (localAudioRequest.isGapless() && beforeSura == localAudioQueue.getCurrentSura()
         ) {
           // we're actually repeating, but we reached the end of the file before we could
-          // seek to the proper place. so let's seek anyway.
-          player?.seekTo(gaplessSuraData.ayahTimings[localAudioQueue.getCurrentAyah()])
+          // seek to the proper place. so let's seek anyway. route through getSeekPosition
+          // so that when we loop back to ayah 1 of a surah, the basmallah (ayahTimings[0])
+          // is played instead of skipping straight to ayah 1 (ayahTimings[1]).
+          val seekPosition = getSeekPosition(false)
+          if (seekPosition > -1) {
+            player?.seekTo(seekPosition)
+          }
         } else {
           // we actually switched to a different ayah - so if the
           // sura changed, then play the basmala if the ayah is


### PR DESCRIPTION
Fixes #3697.

When a gapless surah is played on range repeat, the basmallah is skipped every time playback loops back to ayah 1. Reproducible with reciters such as Saud Ash-Shuraym; Husary and Minshawi Murattal are unaffected.

The end of a gapless surah is handled by whichever fires first: the position polling in updateAudioPlayPosition, or onPlayerCompleted on ExoPlayer STATE_ENDED. The polling path detects the end when the playback position reaches ayahTimings[999] and seeks to the basmallah for ayah 1. onPlayerCompleted seeks straight to ayahTimings[getCurrentAyah()], which for ayah 1 is ayahTimings[1] — the start of ayah 1 after the basmallah — so it skips it.

Every other gapless path that begins ayah 1 routes through getSeekPosition(false), which returns ayahTimings[0] (the basmallah) when ayah == 1 and we are not repeating a single ayah. onPlayerCompleted is the only gapless same-sura path that bypasses it.

The race explains the qari dependency. Reciters whose surah files are trimmed to end exactly at the 999 marker leave no window for the polling path, so STATE_ENDED always wins and the basmallah is always skipped. Reciters with audio past the 999 marker let polling handle it and are unaffected.

The fix routes the onPlayerCompleted seek through getSeekPosition(false), so the basmallah plays regardless of which handler wins the race or how the reciter's file is encoded.

Tested with Saud Ash-Shuraym (gapless), Surat As-Saffat 1→182, range repeat = infinity: the basmallah now plays on every loop-back. Before the fix it was skipped on every loop.