### PR TITLE
Fix audio player getting stuck in paused state

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/service/AudioService.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/service/AudioService.kt
@@ -1060,20 +1060,6 @@ class AudioService : Service(), Player.Listener {
     }
   }
 
-  // Called when the player starts or stops playing
-  override fun onIsPlayingChanged(isPlaying: Boolean) {
-    // Ensure UI stays in sync with actual ExoPlayer state changes
-    // Only update state if it's a legitimate transition
-    if (isPlaying && state == State.Paused) {
-      state = State.Playing
-      updateAudioPlaybackStatus()
-    } else if (!isPlaying && state == State.Playing) {
-      // Handle automatic pause (audio focus loss, etc.)
-      state = State.Paused
-      updateAudioPlaybackStatus()
-    }
-  }
-
   private fun onSeekCompleted() {
     val player = player ?: return
     Timber.d("seek complete! position: %d", player.currentPosition)


### PR DESCRIPTION
Fixes #3702

### Problem

After the MediaPlayer→ExoPlayer migration (`3ed8555e`), pausing audio sometimes leaves the player unable to resume: the audio bar goes unresponsive except for **Stop**, while pages still turn. Happens intermittently, more often with streaming recitations — consistent with a race.

### Cause

The `onIsPlayingChanged` listener mutates the service `state` from ExoPlayer's transient `isPlaying` flag, creating a second source of truth that races the explicit pause/resume command handlers and the `onPlaybackStateChanged` lifecycle. ExoPlayer reports `isPlaying = false` during buffering/seeking, which the listener misreads as a user pause and writes `state = Paused` (or back to `Playing`), desyncing it. Once desynced, a resume tap routes into `processTogglePlaybackRequest()` → `processPauseRequest()`, which no-ops for non-`Playing`/`Stopped` states, while `Stop` keeps working because `processStopRequest()` is unconditional. The branch's comment cites "audio focus loss," but the service requests no audio focus, so it never serves that purpose.

### Fix

Remove the `onIsPlayingChanged` override. `state` is then driven solely by the explicit command handlers (`processPauseRequest`/`processPlayRequest`) and the player lifecycle (`onPlaybackStateChanged` → `onPlayerBuffering`/`onPlayerReady`/`onPlayerCompleted`/`STATE_IDLE`) — the single-source-of-truth model from before the migration. External pauses (headset unplug, notification/MediaSession) continue to flow through `ACTION_PAUSE` → `processPauseRequest()` and never depended on this listener.

### Testing

- `./gradlew assembleMadaniDebug` and `./gradlew lintMadaniDebug` pass.
- Manual: stream an un-downloaded qari and pause/resume repeatedly (including during buffering); resume stays reliable and the bar no longer gets stuck. Additional on-device verification from maintainers is welcome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)