### PR TITLE
Switch to string identifiers

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/dao/bookmark/BookmarkRawResult.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/dao/bookmark/BookmarkRawResult.kt
@@ -4,5 +4,5 @@ import com.quran.data.model.bookmark.Tag
 
 data class BookmarkRawResult(
   val rows: List<BookmarkRowData>,
-  val tagMap: Map<Long, Tag>
+  val tagMap: Map<String, Tag>
 )

--- a/app/src/main/java/com/quran/labs/androidquran/dao/bookmark/BookmarkResult.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/dao/bookmark/BookmarkResult.kt
@@ -3,4 +3,4 @@ package com.quran.labs.androidquran.dao.bookmark
 import com.quran.data.model.bookmark.Tag
 import com.quran.labs.androidquran.ui.helpers.QuranRow
 
-data class BookmarkResult(val rows: List<QuranRow>, val tagMap: Map<Long, Tag>)
+data class BookmarkResult(val rows: List<QuranRow>, val tagMap: Map<String, Tag>)

--- a/app/src/main/java/com/quran/labs/androidquran/dao/bookmark/BookmarkRowData.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/dao/bookmark/BookmarkRowData.kt
@@ -7,7 +7,7 @@ sealed class BookmarkRowData {
   data class RecentPageHeader(val count: Int) : BookmarkRowData()
   data class RecentPage(val recentPage: com.quran.data.model.bookmark.RecentPage) : BookmarkRowData()
   data class TagHeader(val tag: Tag) : BookmarkRowData()
-  data class BookmarkItem(val bookmark: Bookmark, val tagId: Long? = null) : BookmarkRowData()
+  data class BookmarkItem(val bookmark: Bookmark, val tagId: String? = null) : BookmarkRowData()
   object PageBookmarksHeader : BookmarkRowData()
   object AyahBookmarksHeader : BookmarkRowData()
   object NotTaggedHeader : BookmarkRowData()

--- a/app/src/main/java/com/quran/labs/androidquran/database/BookmarksDBAdapter.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/database/BookmarksDBAdapter.kt
@@ -3,7 +3,6 @@ package com.quran.labs.androidquran.database
 import androidx.core.util.Pair
 import com.quran.data.di.AppScope
 import com.quran.data.model.bookmark.Bookmark
-import com.quran.data.model.bookmark.BookmarkData
 import com.quran.data.model.bookmark.RecentPage
 import com.quran.data.model.bookmark.Tag
 import com.quran.labs.androidquran.BookmarksDatabase
@@ -162,27 +161,6 @@ class BookmarksDBAdapter @Inject constructor(bookmarksDatabase: BookmarksDatabas
         for (bookmarkId in bookmarkIds) {
           bookmarkTagQueries.replaceBookmarkTag(bookmarkId, tagId)
         }
-      }
-    }
-    return true
-  }
-
-  fun importBookmarks(data: BookmarkData): Boolean {
-    bookmarkQueries.transaction {
-      bookmarkTagQueries.deleteAll()
-      tagQueries.deleteAll()
-      bookmarkQueries.deleteAll()
-
-      data.tags.forEach { tagQueries.restoreTag(it.id, it.name, System.currentTimeMillis()) }
-      data.bookmarks.forEach { bookmark ->
-        bookmarkQueries.restoreBookmark(
-          bookmark.id,
-          bookmark.sura,
-          bookmark.ayah,
-          bookmark.page,
-          bookmark.timestamp
-        )
-        bookmark.tags.forEach { tagId -> bookmarkTagQueries.addBookmarkTag(bookmark.id, tagId) }
       }
     }
     return true

--- a/app/src/main/java/com/quran/labs/androidquran/model/bookmark/BookmarkJsonModel.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/model/bookmark/BookmarkJsonModel.kt
@@ -2,6 +2,9 @@ package com.quran.labs.androidquran.model.bookmark
 
 import com.quran.data.model.bookmark.BookmarkData
 import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.JsonDataException
+import com.squareup.moshi.JsonReader
+import com.squareup.moshi.JsonWriter
 import com.squareup.moshi.Moshi
 import dev.zacsweers.metro.Inject
 import okio.BufferedSink
@@ -12,7 +15,9 @@ internal class BookmarkJsonModel @Inject constructor() {
   private val jsonAdapter: JsonAdapter<BookmarkData>
 
   init {
-    val moshi = Moshi.Builder().build()
+    val moshi = Moshi.Builder()
+      .add(String::class.java, LegacyBackupStringAdapter)
+      .build()
     jsonAdapter = moshi.adapter(BookmarkData::class.java)
   }
 
@@ -29,5 +34,28 @@ internal class BookmarkJsonModel @Inject constructor() {
   @Throws(IOException::class)
   fun fromJson(jsonSource: BufferedSource): BookmarkData {
     return jsonAdapter.fromJson(jsonSource)!!
+  }
+
+  /**
+   * Old bookmark backup JSON encoded IDs as numbers. Runtime bookmark/tag IDs are strings now, so
+   * this adapter lets Moshi's generated adapters keep parsing the old numeric tokens.
+   */
+  private object LegacyBackupStringAdapter : JsonAdapter<String>() {
+    override fun fromJson(reader: JsonReader): String? {
+      return when (reader.peek()) {
+        JsonReader.Token.NULL -> reader.nextNull()
+        JsonReader.Token.STRING -> reader.nextString()
+        JsonReader.Token.NUMBER -> reader.nextLong().toString()
+        else -> throw JsonDataException("Expected string or number at ${reader.path}")
+      }
+    }
+
+    override fun toJson(writer: JsonWriter, value: String?) {
+      if (value == null) {
+        writer.nullValue()
+      } else {
+        writer.value(value)
+      }
+    }
   }
 }

--- a/app/src/main/java/com/quran/labs/androidquran/model/bookmark/BookmarkModel.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/model/bookmark/BookmarkModel.kt
@@ -7,6 +7,7 @@ import com.quran.data.model.bookmark.BookmarkData
 import com.quran.data.model.bookmark.Tag
 import com.quran.labs.androidquran.database.BookmarksDBAdapter
 import com.quran.labs.androidquran.ui.helpers.QuranRow
+import com.quran.mobile.bookmark.model.isDefaultBookmarkCollectionId
 import dev.zacsweers.metro.Inject
 import dev.zacsweers.metro.SingleIn
 import io.reactivex.rxjava3.core.Completable
@@ -65,18 +66,20 @@ open class BookmarkModel @Inject constructor(
       val size = itemsToRemoveRef.size
       while (i < size) {
         val row = itemsToRemoveRef[i]
-        if (row.isBookmarkHeader && row.tagId > 0) {
-          tagsToDelete.add(row.tagId)
-        } else if (row.isBookmark && row.bookmarkId > 0) {
-          if (row.tagId > 0) {
+        val tagId = row.oldDatabaseTagId()
+        val bookmarkId = row.bookmarkId?.oldDatabaseIdToLongOrNull()
+        if (row.isBookmarkHeader && tagId != null) {
+          tagsToDelete.add(tagId)
+        } else if (row.isBookmark && bookmarkId != null) {
+          if (tagId != null) {
             untag.add(
               Pair(
-                row.bookmarkId,
-                row.tagId
+                bookmarkId,
+                tagId
               )
             )
           } else {
-            bookmarksToDelete.add(row.bookmarkId)
+            bookmarksToDelete.add(bookmarkId)
           }
         }
         i++
@@ -100,7 +103,9 @@ open class BookmarkModel @Inject constructor(
 
   fun updateTag(tag: Tag): Completable {
     return Completable.fromCallable {
-      val result = bookmarksDBAdapter.updateTag(tag.id, tag.name)
+      val result = tag.id.oldDatabaseIdToLongOrNull()
+        ?.let { tagId -> bookmarksDBAdapter.updateTag(tagId, tag.name) }
+        ?: false
       if (result) {
         tagPublishSubject.onNext(true)
       }
@@ -162,13 +167,11 @@ open class BookmarkModel @Inject constructor(
       .subscribeOn(Schedulers.io())
   }
 
-  fun importBookmarksObservable(data: BookmarkData): Observable<Boolean> {
-    return Observable.fromCallable {
-      val result = bookmarksDBAdapter.importBookmarks(data)
-      if (result) {
-        bookmarksPublishSubject.onNext(true)
-      }
-      result
-    }.subscribeOn(Schedulers.io()).cache()
+  private fun QuranRow.oldDatabaseTagId(): Long? {
+    return tagId
+      ?.takeUnless { tagId -> tagId.isDefaultBookmarkCollectionId() }
+      ?.oldDatabaseIdToLongOrNull()
   }
+
+  private fun String.oldDatabaseIdToLongOrNull(): Long? = toLongOrNull()
 }

--- a/app/src/main/java/com/quran/labs/androidquran/presenter/bookmark/AddTagDialogPresenter.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/presenter/bookmark/AddTagDialogPresenter.kt
@@ -23,7 +23,7 @@ internal constructor(private val bookmarksDao: BookmarksDao) : Presenter<AddTagD
     }
   }
 
-  fun validate(tagName: String, tagId: Long): Boolean {
+  fun validate(tagName: String, tagId: String?): Boolean {
     tags = runBlocking { bookmarksDao.tags() }
     if (tagName.isBlank()) {
       dialog?.onBlankTagName()

--- a/app/src/main/java/com/quran/labs/androidquran/presenter/bookmark/BookmarkPresenter.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/presenter/bookmark/BookmarkPresenter.kt
@@ -20,6 +20,7 @@ import com.quran.labs.androidquran.presenter.Presenter
 import com.quran.labs.androidquran.ui.fragment.BookmarksFragment
 import com.quran.labs.androidquran.ui.helpers.QuranRow
 import com.quran.labs.androidquran.util.QuranSettings
+import com.quran.mobile.bookmark.model.isDefaultBookmarkCollectionId
 import dev.zacsweers.metro.Inject
 import dev.zacsweers.metro.Provider
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
@@ -119,7 +120,7 @@ open class BookmarkPresenter @Inject internal constructor(
   fun shouldShowInlineTags(): Boolean = !isGroupedByTags
 
   fun getContextualOperationsForItems(rows: List<QuranRow>): BooleanArray {
-    val headers = rows.count { row -> row.isBookmarkHeader }
+    val headers = rows.count { row -> row.isBookmarkHeader && row.userTagId() != null }
     val bookmarks = rows.count { row -> row.isBookmark }
     return booleanArrayOf(
       headers == 1 && bookmarks == 0,
@@ -184,24 +185,26 @@ open class BookmarkPresenter @Inject internal constructor(
     val currentData = cachedData ?: return null
     val cachedRows = currentData.rows
 
-    val bookmarkIdsToRemove = mutableSetOf<Long>()
-    val tagIdsToUntag = mutableSetOf<Long>()
-    val bookmarkTagContext = mutableMapOf<Long, MutableSet<Long>>()
+    val bookmarkIdsToRemove = mutableSetOf<String>()
+    val tagIdsToUntag = mutableSetOf<String>()
+    val bookmarkTagContext = mutableMapOf<String, MutableSet<String>>()
 
     for (row in remove) {
+      val bookmarkId = row.bookmarkId
+      val tagId = row.userTagId()
       when {
-        row.isBookmark && row.bookmarkId > 0 -> {
-          if (isGroupedByTags && row.tagId > 0) {
-            val contextTags = bookmarkTagContext[row.bookmarkId] ?: mutableSetOf<Long>().also {
-              bookmarkTagContext[row.bookmarkId] = it
+        row.isBookmark && bookmarkId != null -> {
+          if (isGroupedByTags && tagId != null) {
+            val contextTags = bookmarkTagContext[bookmarkId] ?: mutableSetOf<String>().also {
+              bookmarkTagContext[bookmarkId] = it
             }
-            contextTags.add(row.tagId)
+            contextTags.add(tagId)
           } else {
-            bookmarkIdsToRemove.add(row.bookmarkId)
+            bookmarkIdsToRemove.add(bookmarkId)
           }
         }
 
-        row.isBookmarkHeader && row.tagId > 0 -> tagIdsToUntag.add(row.tagId)
+        row.isBookmarkHeader && tagId != null -> tagIdsToUntag.add(tagId)
       }
     }
 
@@ -213,7 +216,7 @@ open class BookmarkPresenter @Inject internal constructor(
       when (rowData) {
         is BookmarkItem -> {
           val bookmarkId = rowData.bookmark.id
-          val currentTagId = rowData.tagId
+          val currentTagId = rowData.tagId?.takeUnless { tagId -> tagId.isDefaultBookmarkCollectionId() }
           var shouldKeep = true
 
           if (bookmarkIdsToRemove.contains(bookmarkId)) {
@@ -293,17 +296,18 @@ open class BookmarkPresenter @Inject internal constructor(
       runBlocking {
         val tagsToDelete = mutableListOf<Tag>()
         val bookmarksToDelete = mutableListOf<Bookmark>()
-        val bookmarksToUntag = mutableListOf<Pair<Bookmark, Long>>()
+        val bookmarksToUntag = mutableListOf<Pair<Bookmark, String>>()
 
         items.forEach { row ->
+          val tagId = row.userTagId()
           when {
-            row.isBookmarkHeader && row.tagId > 0 -> {
-              tagsToDelete += Tag(row.tagId, row.text)
+            row.isBookmarkHeader && tagId != null -> {
+              tagsToDelete += Tag(tagId, row.text)
             }
 
             row.isBookmark && row.bookmark != null -> {
-              if (row.tagId > 0) {
-                bookmarksToUntag += row.bookmark to row.tagId
+              if (tagId != null) {
+                bookmarksToUntag += row.bookmark to tagId
               } else {
                 bookmarksToDelete += row.bookmark
               }
@@ -429,13 +433,13 @@ open class BookmarkPresenter @Inject internal constructor(
 
     for (tag in tags) {
       rows.add(TagHeader(tag))
-      val tagBookmarks = tagsMapping[tag.id].orEmpty()
+      val tagBookmarks = tagsMapping.byTagId[tag.id].orEmpty()
       for (bookmark in tagBookmarks) {
         rows.add(BookmarkItem(bookmark, tag.id))
       }
     }
 
-    val untagged = tagsMapping[BOOKMARKS_WITHOUT_TAGS_ID].orEmpty()
+    val untagged = tagsMapping.bookmarksWithoutUserTags
     if (untagged.isNotEmpty()) {
       rows.add(NotTaggedHeader)
       for (bookmark in untagged) {
@@ -460,9 +464,9 @@ open class BookmarkPresenter @Inject internal constructor(
   private fun generateTagsMapping(
     tags: List<Tag>,
     bookmarks: List<Bookmark>
-  ): Map<Long, List<Bookmark>> {
-    val seenBookmarks = mutableSetOf<Long>()
-    val tagMappings = mutableMapOf<Long, MutableList<Bookmark>>()
+  ): TagsMapping {
+    val seenBookmarks = mutableSetOf<String>()
+    val tagMappings = mutableMapOf<String, MutableList<Bookmark>>()
 
     for (tag in tags) {
       val matchingBookmarks = mutableListOf<Bookmark>()
@@ -481,13 +485,16 @@ open class BookmarkPresenter @Inject internal constructor(
         untaggedBookmarks.add(bookmark)
       }
     }
-    tagMappings[BOOKMARKS_WITHOUT_TAGS_ID] = untaggedBookmarks
 
-    return tagMappings
+    return TagsMapping(tagMappings, untaggedBookmarks)
   }
 
-  private fun generateTagMap(tags: List<Tag>): Map<Long, Tag> {
+  private fun generateTagMap(tags: List<Tag>): Map<String, Tag> {
     return tags.associateByTo(mutableMapOf()) { it.id }
+  }
+
+  private fun QuranRow.userTagId(): String? {
+    return tagId?.takeUnless { tagId -> tagId.isDefaultBookmarkCollectionId() }
   }
 
   override fun bind(fragment: BookmarksFragment) {
@@ -504,6 +511,14 @@ open class BookmarkPresenter @Inject internal constructor(
   companion object {
     @BaseTransientBottomBar.Duration
     const val DELAY_DELETION_DURATION_IN_MS: Int = 4 * 1000 // 4 seconds
-    private const val BOOKMARKS_WITHOUT_TAGS_ID: Long = -1
   }
+
+  private data class TagsMapping(
+    val byTagId: Map<String, List<Bookmark>>,
+    /**
+     * The default collection is not exposed as a user tag, so this is the visible "no user tags"
+     * section rather than a persisted collection ID.
+     */
+    val bookmarksWithoutUserTags: List<Bookmark>
+  )
 }

--- a/app/src/main/java/com/quran/labs/androidquran/presenter/bookmark/TagBookmarkPresenter.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/presenter/bookmark/TagBookmarkPresenter.kt
@@ -3,7 +3,6 @@ package com.quran.labs.androidquran.presenter.bookmark
 import com.quran.data.dao.BookmarksDao
 import com.quran.data.di.AppScope
 import com.quran.data.model.SuraAyah
-import com.quran.data.model.bookmark.Bookmark
 import com.quran.data.model.bookmark.Tag
 import com.quran.labs.androidquran.presenter.Presenter
 import com.quran.labs.androidquran.ui.fragment.TagBookmarkDialog
@@ -22,16 +21,16 @@ import timber.log.Timber
 open class TagBookmarkPresenter @Inject internal constructor(
   private val bookmarksDao: BookmarksDao
 ) : Presenter<TagBookmarkDialog> {
-  private val checkedTags = HashSet<Long>()
+  private val checkedTags = HashSet<String>()
 
   private var dialog: TagBookmarkDialog? = null
 
   private var tags: List<Tag>? = null
-  private var bookmarkIds: LongArray? = null
+  private var bookmarkIds: Array<String>? = null
   private var madeChanges = false
   private var saveImmediate = false
   private var shouldRefreshTags = false
-  private var potentialAyahBookmark: Bookmark? = null
+  private var potentialAyahBookmark: PotentialAyahBookmark? = null
   private val presenterScope = MainScope()
 
   init {
@@ -52,15 +51,15 @@ open class TagBookmarkPresenter @Inject internal constructor(
     }
   }
 
-  fun setBookmarksMode(bookmarkIds: LongArray?) {
+  fun setBookmarksMode(bookmarkIds: Array<String>?) {
     setMode(bookmarkIds, null)
   }
 
   fun setAyahBookmarkMode(sura: Int, ayah: Int, page: Int) {
-    setMode(null, Bookmark(-1, sura, ayah, page))
+    setMode(null, PotentialAyahBookmark(SuraAyah(sura, ayah), page))
   }
 
-  private fun setMode(bookmarkIds: LongArray?, potentialAyahBookmark: Bookmark?) {
+  private fun setMode(bookmarkIds: Array<String>?, potentialAyahBookmark: PotentialAyahBookmark?) {
     this.bookmarkIds = bookmarkIds
     this.potentialAyahBookmark = potentialAyahBookmark
     saveImmediate = this.potentialAyahBookmark != null
@@ -72,33 +71,26 @@ open class TagBookmarkPresenter @Inject internal constructor(
     Single.zip(
       tagsObservable,
       bookmarkTagIdsObservable
-    ) { first: List<Tag>, second: List<Long> ->
+    ) { first: List<Tag>, second: List<String> ->
       Pair(first, second)
     }
       .subscribeOn(Schedulers.io())
       .observeOn(AndroidSchedulers.mainThread())
-      .subscribe({ data: Pair<List<Tag>, List<Long>> ->
+      .subscribe({ data: Pair<List<Tag>, List<String>> ->
         this.onRefreshedData(data)
       }, { throwable ->
         Timber.e(throwable, "Unable to refresh bookmark tags")
       })
   }
 
-  open fun onRefreshedData(data: Pair<List<Tag>, List<Long>>) {
-    val numberOfTags = data.first.size
-    val tags1 = if (numberOfTags == 0 || data.first[numberOfTags - 1].id != -1L) {
-      data.first + listOf(Tag(-1, ""))
-    } else {
-      data.first
-    }
-
+  open fun onRefreshedData(data: Pair<List<Tag>, List<String>>) {
     val bookmarkTags = data.second
-    val updatedCheckedTags = tags1.filter { tag: Tag -> bookmarkTags.contains(tag.id) }
+    val updatedCheckedTags = data.first.filter { tag: Tag -> bookmarkTags.contains(tag.id) }
     checkedTags.clear()
     checkedTags.addAll(updatedCheckedTags.map { it.id })
 
     madeChanges = false
-    this@TagBookmarkPresenter.tags = tags1
+    this@TagBookmarkPresenter.tags = data.first
     shouldRefreshTags = false
     dialog?.setData(this@TagBookmarkPresenter.tags, checkedTags)
   }
@@ -120,13 +112,13 @@ open class TagBookmarkPresenter @Inject internal constructor(
           val ayahBookmark = potentialAyahBookmark
           if (ayahBookmark != null) {
             bookmarksDao.updateAyahBookmarkTags(
-              suraAyah = SuraAyah(requireNotNull(ayahBookmark.sura), requireNotNull(ayahBookmark.ayah)),
+              suraAyah = ayahBookmark.suraAyah,
               page = ayahBookmark.page,
               tagIds = checkedTags,
               deleteNonTagged = true
             )
           } else {
-            val bookmarkIds = bookmarkIds ?: longArrayOf()
+            val bookmarkIds = bookmarkIds ?: emptyArray()
             bookmarksDao.updateBookmarkTags(
               bookmarkIds = bookmarkIds,
               tagIds = checkedTags,
@@ -149,21 +141,21 @@ open class TagBookmarkPresenter @Inject internal constructor(
     madeChanges = false
   }
 
-  fun toggleTag(id: Long): Boolean {
+  fun toggleTag(id: String): Boolean {
     var result = false
 
-    if (id > 0) {
-      if (checkedTags.contains(id)) {
-        checkedTags.remove(id)
-      } else {
-        checkedTags.add(id)
-        result = true
-      }
-      setMadeChanges()
+    if (checkedTags.contains(id)) {
+      checkedTags.remove(id)
     } else {
-      dialog?.showAddTagDialog()
+      checkedTags.add(id)
+      result = true
     }
+    setMadeChanges()
     return result
+  }
+
+  fun addTag() {
+    dialog?.showAddTagDialog()
   }
 
   fun setMadeChanges() {
@@ -173,14 +165,14 @@ open class TagBookmarkPresenter @Inject internal constructor(
     }
   }
 
-  private val bookmarkTagIdsObservable: Single<List<Long>>
+  private val bookmarkTagIdsObservable: Single<List<String>>
     get() {
       return Single.fromCallable {
         runBlocking {
           val ayahBookmark = potentialAyahBookmark
           if (ayahBookmark != null) {
             bookmarksDao.getAyahBookmarkTagIds(
-              SuraAyah(requireNotNull(ayahBookmark.sura), requireNotNull(ayahBookmark.ayah))
+              ayahBookmark.suraAyah
             )
           } else {
             val ids = bookmarkIds
@@ -207,4 +199,6 @@ open class TagBookmarkPresenter @Inject internal constructor(
       this.dialog = null
     }
   }
+
+  private data class PotentialAyahBookmark(val suraAyah: SuraAyah, val page: Int)
 }

--- a/app/src/main/java/com/quran/labs/androidquran/ui/QuranActivity.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/QuranActivity.kt
@@ -486,7 +486,7 @@ class QuranActivity : AppCompatActivity(),
     }
   }
 
-  fun editTag(id: Long, name: String?) {
+  fun editTag(id: String, name: String?) {
     if (!isPaused) {
       val fm = supportFragmentManager
       val addTagDialog = newInstance(id, name!!)
@@ -494,7 +494,7 @@ class QuranActivity : AppCompatActivity(),
     }
   }
 
-  fun tagBookmarks(ids: LongArray?) {
+  fun tagBookmarks(ids: Array<String>?) {
     if (ids != null && ids.size == 1) {
       tagBookmark(ids[0])
       return
@@ -507,7 +507,7 @@ class QuranActivity : AppCompatActivity(),
     }
   }
 
-  private fun tagBookmark(id: Long) {
+  private fun tagBookmark(id: String) {
     if (!isPaused) {
       val fm = supportFragmentManager
       val tagBookmarkDialog = TagBookmarkDialog.newInstance(id)

--- a/app/src/main/java/com/quran/labs/androidquran/ui/fragment/AddTagDialog.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/fragment/AddTagDialog.kt
@@ -40,11 +40,11 @@ class AddTagDialog : DialogFragment() {
     (dialog as AlertDialog).let {
       it.getButton(Dialog.BUTTON_POSITIVE)
           .setOnClickListener {
-            val id = arguments?.getLong(EXTRA_ID, -1) ?: -1
+            val id = arguments?.getString(EXTRA_ID)
             val name = textInputEditText?.text.toString()
             val success = addTagDialogPresenter.validate(name, id)
             if (success) {
-              if (id > -1) {
+              if (id != null) {
                 addTagDialogPresenter.updateTag(Tag(id, name))
               } else {
                 addTagDialogPresenter.addTag(name)
@@ -59,7 +59,7 @@ class AddTagDialog : DialogFragment() {
 
   override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
     val args = arguments
-    val id = args?.getLong(EXTRA_ID, -1) ?: -1
+    val id = args?.getString(EXTRA_ID)
     val originalName = args?.getString(EXTRA_NAME, "") ?: ""
 
     val activity = requireActivity()
@@ -72,7 +72,7 @@ class AddTagDialog : DialogFragment() {
     builder.setTitle(getString(R.string.tag_dlg_title))
 
     val text = layout.findViewById<TextInputEditText>(R.id.tag_name)
-    if (id > -1) {
+    if (id != null) {
       text.setText(originalName)
       text.setSelection(originalName.length)
     }
@@ -106,9 +106,9 @@ class AddTagDialog : DialogFragment() {
     private const val EXTRA_ID = "id"
     private const val EXTRA_NAME = "name"
 
-    fun newInstance(id: Long, name: String): AddTagDialog {
+    fun newInstance(id: String, name: String): AddTagDialog {
       val args = Bundle()
-      args.putLong(EXTRA_ID, id)
+      args.putString(EXTRA_ID, id)
       args.putString(EXTRA_NAME, name)
       val dialog = AddTagDialog()
       dialog.arguments = args

--- a/app/src/main/java/com/quran/labs/androidquran/ui/fragment/BookmarksFragment.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/fragment/BookmarksFragment.kt
@@ -27,6 +27,7 @@ import com.quran.labs.androidquran.ui.helpers.BookmarkUIConverter
 import com.quran.labs.androidquran.ui.helpers.QuranListAdapter
 import com.quran.labs.androidquran.ui.helpers.QuranListAdapter.QuranTouchListener
 import com.quran.labs.androidquran.ui.helpers.QuranRow
+import com.quran.mobile.bookmark.model.isDefaultBookmarkCollectionId
 import dev.zacsweers.metro.Inject
 
 class BookmarksFragment : Fragment(), QuranTouchListener {
@@ -223,7 +224,7 @@ class BookmarksFragment : Fragment(), QuranTouchListener {
   }
 
   private fun isValidSelection(selected: QuranRow): Boolean {
-    return selected.isBookmark || (selected.isBookmarkHeader && selected.tagId >= 0)
+    return selected.isBookmark || (selected.isBookmarkHeader && selected.userTagId() != null)
   }
 
   private val mOnUndoClickListener: View.OnClickListener = View.OnClickListener {
@@ -306,19 +307,17 @@ class BookmarksFragment : Fragment(), QuranTouchListener {
   private fun handleTagEdit(activity: QuranActivity, selected: List<QuranRow>) {
     if (selected.size == 1) {
       val row = selected[0]
-      activity.editTag(row.tagId, row.text)
+      row.userTagId()?.let { tagId -> activity.editTag(tagId, row.text) }
     }
   }
 
   private fun handleTagBookmarks(activity: QuranActivity, selected: List<QuranRow>) {
-    val ids = LongArray(selected.size)
-    var i = 0
-    val selectedItems = selected.size
-    while (i < selectedItems) {
-      ids[i] = selected[i].bookmarkId
-      i++
-    }
+    val ids = selected.mapNotNull { row -> row.bookmarkId }.toTypedArray()
     activity.tagBookmarks(ids)
+  }
+
+  private fun QuranRow.userTagId(): String? {
+    return tagId?.takeUnless { tagId -> tagId.isDefaultBookmarkCollectionId() }
   }
 
   companion object {

--- a/app/src/main/java/com/quran/labs/androidquran/ui/fragment/TagBookmarkDialog.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/fragment/TagBookmarkDialog.kt
@@ -44,7 +44,7 @@ open class TagBookmarkDialog : DialogFragment() {
     super.onCreate(savedInstanceState)
     val args = arguments
     if (args != null) {
-      val bookmarkIds = args.getLongArray(EXTRA_BOOKMARK_IDS)
+      val bookmarkIds = args.getStringArray(EXTRA_BOOKMARK_IDS)
       if (bookmarkIds != null) {
         tagBookmarkPresenter.setBookmarksMode(bookmarkIds)
       }
@@ -60,7 +60,11 @@ open class TagBookmarkDialog : DialogFragment() {
     listview.choiceMode = ListView.CHOICE_MODE_MULTIPLE
     listview.onItemClickListener =
       OnItemClickListener { _: AdapterView<*>?, view: View, position: Int, _: Long ->
-        val tag = adapter.getItem(position)
+        if (adapter.isAddTagPosition(position)) {
+          tagBookmarkPresenter.addTag()
+          return@OnItemClickListener
+        }
+        val tag = adapter.getItem(position) ?: return@OnItemClickListener
         val isChecked = tagBookmarkPresenter.toggleTag(tag.id)
         val viewTag = view.tag
         if (viewTag is ViewHolder) {
@@ -77,7 +81,7 @@ open class TagBookmarkDialog : DialogFragment() {
     }
   }
 
-  fun setData(tags: List<Tag>?, checkedTags: HashSet<Long>) {
+  fun setData(tags: List<Tag>?, checkedTags: HashSet<String>) {
     adapter?.setData(tags, checkedTags)
     adapter?.notifyDataSetChanged()
   }
@@ -129,18 +133,18 @@ open class TagBookmarkDialog : DialogFragment() {
     private val tagBookmarkPresenter: TagBookmarkPresenter = presenter
     private val newTagString: String = context.getString(R.string.new_tag)
     private var tags: List<Tag> = emptyList()
-    private var checkedTags = HashSet<Long>()
+    private var checkedTags = HashSet<String>()
 
-    fun setData(tags: List<Tag>?, checkedTags: HashSet<Long>) {
+    fun setData(tags: List<Tag>?, checkedTags: HashSet<String>) {
       this.tags = (tags ?: emptyList())
       this.checkedTags = checkedTags
     }
 
-    override fun getCount(): Int = tags.size
+    override fun getCount(): Int = tags.size + 1
 
-    override fun getItem(position: Int): Tag = tags[position]
+    override fun getItem(position: Int): Tag? = tags.getOrNull(position)
 
-    override fun getItemId(position: Int): Long = tags[position].id
+    override fun getItemId(position: Int): Long = position.toLong()
 
     override fun hasStableIds(): Boolean = false
 
@@ -159,15 +163,15 @@ open class TagBookmarkDialog : DialogFragment() {
         convertView
       }
 
-      val (id, name) = getItem(position)
       holder = view.tag as ViewHolder
-      if (id == -1L) {
+      if (isAddTagPosition(position)) {
         holder.apply {
           addImage.visibility = View.VISIBLE
           checkBox.visibility = View.GONE
           tagName.text = newTagString
         }
       } else {
+        val (id, name) = requireNotNull(getItem(position))
         holder.apply {
           addImage.visibility = View.GONE
           checkBox.visibility = View.VISIBLE
@@ -178,6 +182,8 @@ open class TagBookmarkDialog : DialogFragment() {
       }
       return view
     }
+
+    fun isAddTagPosition(position: Int): Boolean = position == tags.size
   }
 
   internal class ViewHolder {
@@ -193,13 +199,13 @@ open class TagBookmarkDialog : DialogFragment() {
   companion object {
     const val TAG = "TagBookmarkDialog"
     private const val EXTRA_BOOKMARK_IDS = "bookmark_ids"
-    fun newInstance(bookmarkId: Long): TagBookmarkDialog {
-      return newInstance(longArrayOf(bookmarkId))
+    fun newInstance(bookmarkId: String): TagBookmarkDialog {
+      return newInstance(arrayOf(bookmarkId))
     }
 
-    fun newInstance(bookmarkIds: LongArray?): TagBookmarkDialog {
+    fun newInstance(bookmarkIds: Array<String>?): TagBookmarkDialog {
       val args = Bundle()
-      args.putLongArray(EXTRA_BOOKMARK_IDS, bookmarkIds)
+      args.putStringArray(EXTRA_BOOKMARK_IDS, bookmarkIds)
       val dialog = TagBookmarkDialog()
       dialog.arguments = args
       return dialog

--- a/app/src/main/java/com/quran/labs/androidquran/ui/helpers/QuranListAdapter.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/helpers/QuranListAdapter.kt
@@ -31,7 +31,7 @@ class QuranListAdapter(
   private val inflater = LayoutInflater.from(context)
   private val checkedState = SparseBooleanArray()
   private val locale = QuranUtils.getCurrentLocale()
-  private var tagMap: Map<Long, Tag> = emptyMap()
+  private var tagMap: Map<String, Tag> = emptyMap()
   private var showTags = false
   private var showDate = false
 
@@ -115,7 +115,7 @@ class QuranListAdapter(
     touchListener = listener
   }
 
-  fun setElements(elements: Array<QuranRow>, tagMap: Map<Long, Tag>) {
+  fun setElements(elements: Array<QuranRow>, tagMap: Map<String, Tag>) {
     this.elements = elements
     this.tagMap = tagMap
   }

--- a/app/src/main/java/com/quran/labs/androidquran/ui/helpers/QuranRow.java
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/helpers/QuranRow.java
@@ -27,8 +27,8 @@ public class QuranRow {
   public long dateAddedInMillis;
 
   // For Bookmarks
-  public long tagId;
-  public long bookmarkId;
+  public String tagId;
+  public String bookmarkId;
   public Bookmark bookmark;
 
   public static class Builder {
@@ -40,8 +40,8 @@ public class QuranRow {
     private int rowType = NONE;
     private Integer imageResource;
     private Integer juzType;
-    private long tagId = -1;
-    private long bookmarkId = -1;
+    private String tagId;
+    private String bookmarkId;
     private String juzOverlayText;
     private long dateAddedInMillis;
     private Integer imageFilterColorResource;
@@ -103,7 +103,7 @@ public class QuranRow {
       return this;
     }
 
-    public Builder withTagId(long id) {
+    public Builder withTagId(String id) {
       tagId = id;
       return this;
     }
@@ -122,7 +122,7 @@ public class QuranRow {
 
   private QuranRow(String text, String metadata, int rowType,
       int sura, int ayah, int page, Integer imageResource, Integer filterColorResource,
-      Integer juzType, String juzOverlayText, long bookmarkId, long tagId, Bookmark bookmark,
+      Integer juzType, String juzOverlayText, String bookmarkId, String tagId, Bookmark bookmark,
                    long dateAddedInMillis) {
     this.text = text;
     this.rowType = rowType;

--- a/app/src/main/java/com/quran/labs/androidquran/ui/helpers/QuranRowFactory.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/helpers/QuranRowFactory.kt
@@ -46,7 +46,7 @@ class QuranRowFactory @Inject constructor(
   }
 
   @JvmOverloads
-  fun fromBookmark(context: Context, bookmark: Bookmark, tagId: Long? = null): QuranRow {
+  fun fromBookmark(context: Context, bookmark: Bookmark, tagId: String? = null): QuranRow {
     val builder = QuranRow.Builder()
 
     if (bookmark.isPageBookmark()) {

--- a/app/src/test/java/com/quran/labs/androidquran/model/bookmark/BookmarkImportExportModelTest.kt
+++ b/app/src/test/java/com/quran/labs/androidquran/model/bookmark/BookmarkImportExportModelTest.kt
@@ -10,6 +10,7 @@ import com.quran.data.dao.Settings
 import com.quran.data.model.bookmark.BackupReadingBookmark
 import com.quran.data.model.bookmark.Bookmark
 import com.quran.data.model.bookmark.BookmarkData
+import com.quran.data.model.bookmark.LegacyBookmarkIds
 import com.quran.data.model.bookmark.PageReadingBookmark
 import com.quran.data.model.bookmark.RecentPage
 import com.quran.data.model.bookmark.Tag
@@ -114,6 +115,8 @@ class BookmarkImportExportModelTest {
     testObserver.assertValueCount(1)
     testObserver.assertNoErrors()
     assertThat(testObserver.values()[0].readingBookmark).isNull()
+    assertThat(testObserver.values()[0].tags.map { tag -> tag.id })
+      .containsExactly("1", "2", "3")
   }
 
   @Test
@@ -132,12 +135,17 @@ class BookmarkImportExportModelTest {
 
   @Test
   fun testExportBookmarksWithDataProducesUri() {
-    val ayahBookmark = Bookmark(1L, 2, 255, 50, System.currentTimeMillis())
-    bookmarksDao.setTags(listOf(Tag(1L, "Export Tag"), Tag(2L, "Another Tag")))
+    val ayahBookmark = Bookmark(LegacyBookmarkIds.bookmarkId(1L), 2, 255, 50, System.currentTimeMillis())
+    bookmarksDao.setTags(
+      listOf(
+        Tag(LegacyBookmarkIds.tagId(1L), "Export Tag"),
+        Tag(LegacyBookmarkIds.tagId(2L), "Another Tag")
+      )
+    )
     bookmarksDao.setBookmarks(
       listOf(
         ayahBookmark,
-        Bookmark(2L, null, null, 51, System.currentTimeMillis())
+        Bookmark(LegacyBookmarkIds.bookmarkId(2L), null, null, 51, System.currentTimeMillis())
       )
     )
     recentPagesDao.setRecentPages(listOf(RecentPage(50, 1000), RecentPage(51, 900)))
@@ -169,9 +177,9 @@ class BookmarkImportExportModelTest {
 
   @Test
   fun testExportBookmarksCsvWithDataProducesUri() {
-    bookmarksDao.setTags(listOf(Tag(1L, "CSV Tag")))
+    bookmarksDao.setTags(listOf(Tag(LegacyBookmarkIds.tagId(1L), "CSV Tag")))
     bookmarksDao.setBookmarks(
-      listOf(Bookmark(1L, 1, 1, 1, System.currentTimeMillis()))
+      listOf(Bookmark(LegacyBookmarkIds.bookmarkId(1L), 1, 1, 1, System.currentTimeMillis()))
     )
     recentPagesDao.setRecentPages(listOf(RecentPage(12, 1000)))
     readingBookmarksDao.setReadingBookmark(PageReadingBookmark(12, timestamp = 999))
@@ -192,8 +200,17 @@ class BookmarkImportExportModelTest {
   fun testImportDeduplicatesTagNames() {
     importData(
       BookmarkData(
-        tags = listOf(Tag(99L, "Existing"), Tag(100L, "Existing")),
-        bookmarks = listOf(Bookmark(1L, 2, 255, 50, 1000, tags = listOf(100L)))
+        tags = listOf(Tag(LegacyBookmarkIds.tagId(99L), "Existing"), Tag(LegacyBookmarkIds.tagId(100L), "Existing")),
+        bookmarks = listOf(
+          Bookmark(
+            LegacyBookmarkIds.bookmarkId(1L),
+            2,
+            255,
+            50,
+            1000,
+            tags = listOf(LegacyBookmarkIds.tagId(100L))
+          )
+        )
       )
     )
 
@@ -207,8 +224,17 @@ class BookmarkImportExportModelTest {
   fun testImportCreatesMissingTagName() {
     importData(
       BookmarkData(
-        tags = listOf(Tag(99L, "Missing")),
-        bookmarks = listOf(Bookmark(1L, 2, 255, 50, 1000, tags = listOf(99L)))
+        tags = listOf(Tag(LegacyBookmarkIds.tagId(99L), "Missing")),
+        bookmarks = listOf(
+          Bookmark(
+            LegacyBookmarkIds.bookmarkId(1L),
+            2,
+            255,
+            50,
+            1000,
+            tags = listOf(LegacyBookmarkIds.tagId(99L))
+          )
+        )
       )
     )
 
@@ -231,15 +257,15 @@ class BookmarkImportExportModelTest {
 
     importData(
       BookmarkData(
-        tags = listOf(Tag(99L, "Imported Tag")),
+        tags = listOf(Tag(LegacyBookmarkIds.tagId(99L), "Imported Tag")),
         bookmarks = listOf(
           Bookmark(
-            id = 1L,
+            id = LegacyBookmarkIds.bookmarkId(1L),
             sura = null,
             ayah = null,
             page = page,
             timestamp = bookmarkTimestampMillis,
-            tags = listOf(99L)
+            tags = listOf(LegacyBookmarkIds.tagId(99L))
           )
         ),
         recentPages = listOf(RecentPage(page, recentTimestampMillis)),
@@ -275,8 +301,17 @@ class BookmarkImportExportModelTest {
 
     importData(
       BookmarkData(
-        tags = listOf(Tag(99L, originalTagName)),
-        bookmarks = listOf(Bookmark(1L, null, null, page, 1000, tags = listOf(99L)))
+        tags = listOf(Tag(LegacyBookmarkIds.tagId(99L), originalTagName)),
+        bookmarks = listOf(
+          Bookmark(
+            LegacyBookmarkIds.bookmarkId(1L),
+            null,
+            null,
+            page,
+            1000,
+            tags = listOf(LegacyBookmarkIds.tagId(99L))
+          )
+        )
       )
     )
 
@@ -295,6 +330,76 @@ class BookmarkImportExportModelTest {
       collectionsByName.getValue(oldPageBookmarksTagName).importId
     )
     assertThat(mobileSyncImporter.deleteExisting).isFalse()
+  }
+
+  @Test
+  fun testImportUsesBackupTagIdsOnlyAsLookupKeys() {
+    val page = 50
+    val backupTagId = "old-page-bookmarks"
+    val originalTagName = "Imported Tag"
+    val oldPageBookmarksTagName = context.getString(R.string.old_page_bookmarks)
+
+    importData(
+      BookmarkData(
+        tags = listOf(Tag(backupTagId, originalTagName)),
+        bookmarks = listOf(
+          Bookmark(
+            id = "1",
+            sura = null,
+            ayah = null,
+            page = page,
+            timestamp = 1000,
+            tags = listOf(backupTagId)
+          )
+        )
+      )
+    )
+
+    val importedData = importedData()
+    val collectionsByName = importedData.collections.associateBy { collection -> collection.name }
+    val originalTagCollection = collectionsByName.getValue(originalTagName)
+    val oldPageBookmarksCollection = collectionsByName.getValue(oldPageBookmarksTagName)
+
+    val collectionImportIds = importedData.collections.map { collection -> collection.importId }
+    assertThat(collectionImportIds).containsNoDuplicates()
+    assertThat(collectionImportIds).doesNotContain(backupTagId)
+    assertThat(originalTagCollection.importId).isNotEqualTo(backupTagId)
+    assertThat(importedData.collectionBookmarks.map { link -> link.collectionImportId }).containsExactly(
+      originalTagCollection.importId,
+      oldPageBookmarksCollection.importId
+    )
+  }
+
+  @Test
+  fun testImportGeneratedCollectionIdsDoNotReuseBackupTagIds() {
+    val backupTagIds = listOf("backup-collection-0", "backup-collection-1", "backup-collection-2")
+
+    importData(
+      BookmarkData(
+        tags = listOf(
+          Tag(backupTagIds[0], "First Imported Tag"),
+          Tag(backupTagIds[1], "Second Imported Tag"),
+          Tag(backupTagIds[2], "Third Imported Tag")
+        ),
+        bookmarks = listOf(
+          Bookmark(
+            id = "1",
+            sura = null,
+            ayah = null,
+            page = 50,
+            timestamp = 1000,
+            tags = backupTagIds
+          )
+        )
+      )
+    )
+
+    val collectionImportIds = importedData().collections.map { collection -> collection.importId }
+
+    assertThat(collectionImportIds).containsNoDuplicates()
+    backupTagIds.forEach { backupTagId ->
+      assertThat(collectionImportIds).doesNotContain(backupTagId)
+    }
   }
 
   @Test

--- a/app/src/test/java/com/quran/labs/androidquran/model/bookmark/BookmarkJsonModelTest.java
+++ b/app/src/test/java/com/quran/labs/androidquran/model/bookmark/BookmarkJsonModelTest.java
@@ -17,7 +17,8 @@ import okio.Buffer;
 
 public class BookmarkJsonModelTest {
   private static final List<Tag> TAGS =
-      Arrays.asList(new Tag(1, "First"), new Tag(2, "Second"), new Tag(3, "Third"));
+      Arrays.asList(new Tag("tag-1", "First"), new Tag("tag-2", "Second"),
+          new Tag("tag-3", "Third"));
 
   private BookmarkJsonModel jsonModel;
 

--- a/app/src/test/java/com/quran/labs/androidquran/model/bookmark/LegacyBookmarkMigrationNormalizerTest.kt
+++ b/app/src/test/java/com/quran/labs/androidquran/model/bookmark/LegacyBookmarkMigrationNormalizerTest.kt
@@ -5,6 +5,7 @@ import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.quran.data.core.QuranInfo
 import com.quran.data.model.bookmark.Bookmark
+import com.quran.data.model.bookmark.LegacyBookmarkIds
 import com.quran.data.model.bookmark.RecentPage
 import com.quran.labs.androidquran.R
 import com.quran.labs.androidquran.base.TestApplication
@@ -46,7 +47,14 @@ class LegacyBookmarkMigrationNormalizerTest {
           LegacyBookmarkTag(12L, oldPageBookmarksName, 300L)
         ),
         bookmarks = listOf(
-          Bookmark(1L, null, null, page, 1000L, tags = listOf(10L, 12L))
+          Bookmark(
+            LegacyBookmarkIds.bookmarkId(1L),
+            null,
+            null,
+            page,
+            1000L,
+            tags = listOf(LegacyBookmarkIds.tagId(10L), LegacyBookmarkIds.tagId(12L))
+          )
         ),
         recentPages = emptyList()
       )
@@ -59,8 +67,19 @@ class LegacyBookmarkMigrationNormalizerTest {
     assertThat(data.collections.map { collection -> collection.name })
       .containsExactly("Reading", oldPageBookmarksName)
       .inOrder()
+    val collectionsByName = data.collections.associateBy { collection -> collection.name }
+    val collectionImportIds = data.collections.map { collection -> collection.importId }
+    assertThat(collectionImportIds).doesNotContain(LegacyBookmarkIds.tagId(10L))
+    assertThat(collectionImportIds).doesNotContain(LegacyBookmarkIds.tagId(11L))
+    assertThat(collectionImportIds).doesNotContain(LegacyBookmarkIds.tagId(12L))
+    assertThat(collectionImportIds).doesNotContain("tag-10")
+    assertThat(collectionImportIds).doesNotContain("tag-11")
+    assertThat(collectionImportIds).doesNotContain("tag-12")
     assertThat(data.collectionBookmarks.map { link -> link.collectionImportId })
-      .containsExactly("tag-10", "tag-11")
+      .containsExactly(
+        collectionsByName.getValue("Reading").importId,
+        collectionsByName.getValue(oldPageBookmarksName).importId
+      )
   }
 
   @Test
@@ -72,8 +91,8 @@ class LegacyBookmarkMigrationNormalizerTest {
       LegacyBookmarksSnapshot(
         tags = emptyList(),
         bookmarks = listOf(
-          Bookmark(1L, null, null, page, 2000L),
-          Bookmark(2L, pageBounds[0], pageBounds[1], page, 1000L)
+          Bookmark(LegacyBookmarkIds.bookmarkId(1L), null, null, page, 2000L),
+          Bookmark(LegacyBookmarkIds.bookmarkId(2L), pageBounds[0], pageBounds[1], page, 1000L)
         ),
         recentPages = emptyList()
       )
@@ -121,7 +140,14 @@ class LegacyBookmarkMigrationNormalizerTest {
       LegacyBookmarksSnapshot(
         tags = listOf(LegacyBookmarkTag(10L, "Reading", timestampMillis)),
         bookmarks = listOf(
-          Bookmark(1L, 2, 255, page, timestampMillis, tags = listOf(10L))
+          Bookmark(
+            LegacyBookmarkIds.bookmarkId(1L),
+            2,
+            255,
+            page,
+            timestampMillis,
+            tags = listOf(LegacyBookmarkIds.tagId(10L))
+          )
         ),
         recentPages = listOf(RecentPage(page, timestampMillis))
       )

--- a/app/src/test/java/com/quran/labs/androidquran/model/bookmark/LegacyBookmarksMigratorTest.kt
+++ b/app/src/test/java/com/quran/labs/androidquran/model/bookmark/LegacyBookmarksMigratorTest.kt
@@ -5,6 +5,7 @@ import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.quran.data.core.QuranInfo
 import com.quran.data.model.bookmark.Bookmark
+import com.quran.data.model.bookmark.LegacyBookmarkIds
 import com.quran.labs.androidquran.base.TestApplication
 import com.quran.labs.androidquran.data.Constants
 import com.quran.labs.androidquran.pages.data.madani.MadaniDataSource
@@ -127,7 +128,7 @@ class LegacyBookmarksMigratorTest {
   private fun snapshotWithBookmark(): LegacyBookmarksSnapshot {
     return LegacyBookmarksSnapshot(
       tags = emptyList(),
-      bookmarks = listOf(Bookmark(1L, 2, 255, page = 50, timestamp = 1000L)),
+      bookmarks = listOf(Bookmark(LegacyBookmarkIds.bookmarkId(1L), 2, 255, page = 50, timestamp = 1000L)),
       recentPages = emptyList()
     )
   }

--- a/app/src/test/java/com/quran/labs/androidquran/model/translation/ArabicDatabaseUtilsTest.kt
+++ b/app/src/test/java/com/quran/labs/androidquran/model/translation/ArabicDatabaseUtilsTest.kt
@@ -48,9 +48,9 @@ class ArabicDatabaseUtilsTest {
     val arabicDatabaseUtils = getArabicDatabaseUtils()
 
     val bookmarks = mutableListOf(
-      Bookmark(1, 1, 1, 1),
-      Bookmark(2, null, null, 3),
-      Bookmark(3, 114, 6, 604),
+      Bookmark("bookmark-1", 1, 1, 1),
+      Bookmark("bookmark-2", null, null, 3),
+      Bookmark("bookmark-3", 114, 6, 604),
     )
 
     val result = arabicDatabaseUtils.hydrateAyahText(bookmarks)
@@ -67,7 +67,7 @@ class ArabicDatabaseUtilsTest {
   fun testHydrateAyahTextEmpty() {
     val arabicDatabaseUtils = getArabicDatabaseUtils()
 
-    val bookmarks = mutableListOf(Bookmark(1, null, null, 3))
+    val bookmarks = mutableListOf(Bookmark("bookmark-1", null, null, 3))
 
     val result = arabicDatabaseUtils.hydrateAyahText(bookmarks)
     assertThat(result).hasSize(1)

--- a/app/src/test/java/com/quran/labs/androidquran/presenter/bookmark/BookmarkPresenterTest.kt
+++ b/app/src/test/java/com/quran/labs/androidquran/presenter/bookmark/BookmarkPresenterTest.kt
@@ -15,6 +15,7 @@ import com.quran.labs.androidquran.ui.helpers.QuranRow
 import com.quran.labs.androidquran.util.QuranSettings
 import com.quran.labs.awaitTerminalEvent
 import com.quran.labs.test.RxSchedulerRule
+import com.quran.mobile.bookmark.model.DEFAULT_BOOKMARK_COLLECTION_ID
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
@@ -54,7 +55,7 @@ class BookmarkPresenterTest {
 
     val result = getBookmarkResultByDateAndValidate(makeBookmarkPresenter())
 
-    assertThat(result.tagMap).containsExactly(1L, TAGS[0], 2L, TAGS[1])
+    assertThat(result.tagMap).containsExactly("tag-1", TAGS[0], "tag-2", TAGS[1])
     assertThat(result.rows.first()).isInstanceOf(BookmarkRowData.AyahBookmarksHeader::class.java)
     assertThat(result.rows.filterIsInstance<BookmarkRowData.BookmarkItem>()).hasSize(2)
   }
@@ -93,9 +94,9 @@ class BookmarkPresenterTest {
 
     assertThat(result.rows).containsAtLeast(
       BookmarkRowData.TagHeader(TAGS[0]),
-      BookmarkRowData.BookmarkItem(AYAH_BOOKMARKS[0], 1),
+      BookmarkRowData.BookmarkItem(AYAH_BOOKMARKS[0], "tag-1"),
       BookmarkRowData.TagHeader(TAGS[1]),
-      BookmarkRowData.BookmarkItem(AYAH_BOOKMARKS[0], 2),
+      BookmarkRowData.BookmarkItem(AYAH_BOOKMARKS[0], "tag-2"),
       BookmarkRowData.NotTaggedHeader,
       BookmarkRowData.BookmarkItem(AYAH_BOOKMARKS[1], null),
     ).inOrder()
@@ -117,7 +118,7 @@ class BookmarkPresenterTest {
   fun `contextual actions allow editing one tag header and tagging bookmark rows`() {
     val presenter = makeBookmarkPresenter()
     val tagHeaderResult = presenter.getContextualOperationsForItems(
-      listOf(QuranRow.Builder().withType(QuranRow.BOOKMARK_HEADER).withTagId(1).build())
+      listOf(QuranRow.Builder().withType(QuranRow.BOOKMARK_HEADER).withTagId("tag-1").build())
     )
     val bookmarkResult = presenter.getContextualOperationsForItems(
       listOf(
@@ -130,18 +131,33 @@ class BookmarkPresenterTest {
   }
 
   @Test
+  fun `contextual actions ignore default collection header`() {
+    val presenter = makeBookmarkPresenter()
+    val result = presenter.getContextualOperationsForItems(
+      listOf(
+        QuranRow.Builder()
+          .withType(QuranRow.BOOKMARK_HEADER)
+          .withTagId(DEFAULT_BOOKMARK_COLLECTION_ID)
+          .build()
+      )
+    )
+
+    assertThat(result.asList()).containsExactly(false, false, false).inOrder()
+  }
+
+  @Test
   fun `location sort delegates to bookmarks dao`() {
     fakeBookmarksDao.setBookmarks(
       listOf(
-        Bookmark(1, 4, 1, 75, 2),
-        Bookmark(2, 2, 255, 42, 1)
+        Bookmark("bookmark-1", 4, 1, 75, 2),
+        Bookmark("bookmark-2", 2, 255, 42, 1)
       )
     )
 
     val result = getBookmarkResultAndValidate(makeBookmarkPresenter(), BookmarkSortOrder.SORT_LOCATION)
 
     assertThat(result.rows.filterIsInstance<BookmarkRowData.BookmarkItem>().map { it.bookmark.id })
-      .containsExactly(2L, 1L)
+      .containsExactly("bookmark-2", "bookmark-1")
       .inOrder()
   }
 
@@ -178,14 +194,14 @@ class BookmarkPresenterTest {
 
   private companion object {
     private val TAGS = listOf(
-      Tag(1, "Review"),
-      Tag(2, "Important")
+      Tag("tag-1", "Review"),
+      Tag("tag-2", "Important")
     )
     private val AYAH_BOOKMARKS = listOf(
-      Bookmark(42, 46, 1, 502, 200, listOf(1, 2)),
-      Bookmark(2, 2, 4, 2, 100)
+      Bookmark("bookmark-42", 46, 1, 502, 200, listOf("tag-1", "tag-2")),
+      Bookmark("bookmark-2", 2, 4, 2, 100)
     )
-    private val PAGE_BOOKMARK = Bookmark(23, null, null, 400, 300)
+    private val PAGE_BOOKMARK = Bookmark("bookmark-23", null, null, 400, 300)
     private val RECENT_PAGES = listOf(
       RecentPage(42, 200),
       RecentPage(43, 100)

--- a/app/src/test/java/com/quran/labs/androidquran/presenter/bookmark/TagBookmarkPresenterTest.kt
+++ b/app/src/test/java/com/quran/labs/androidquran/presenter/bookmark/TagBookmarkPresenterTest.kt
@@ -1,5 +1,7 @@
 package com.quran.labs.androidquran.presenter.bookmark
 
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.quran.data.dao.BookmarkSortOrder
 import com.quran.data.model.bookmark.Bookmark
@@ -7,6 +9,7 @@ import com.quran.data.model.bookmark.Tag
 import com.quran.labs.androidquran.base.TestApplication
 import com.quran.labs.androidquran.fakes.FakeBookmarksDao
 import com.quran.labs.androidquran.fakes.FakeTagBookmarkDialog
+import com.quran.labs.androidquran.ui.fragment.TagBookmarkDialog
 import com.quran.labs.test.RxSchedulerRule
 import kotlinx.coroutines.runBlocking
 import org.junit.Before
@@ -28,22 +31,22 @@ class TagBookmarkPresenterTest {
   @Before
   fun setupTest() {
     bookmarksDao = FakeBookmarksDao()
-    bookmarksDao.setTags(listOf(Tag(1, "Test")))
+    bookmarksDao.setTags(listOf(Tag(TAG_ID, "Test")))
   }
 
   @Test
   fun `change only saves explicitly for bookmark ids`() {
     runBlocking {
-      bookmarksDao.setBookmarks(listOf(Bookmark(1, 6, 76, 137)))
+      bookmarksDao.setBookmarks(listOf(Bookmark(BOOKMARK_ID, 6, 76, 137)))
       val presenter = TagBookmarkPresenter(bookmarksDao)
 
-      presenter.setBookmarksMode(longArrayOf(1))
-      assertThat(presenter.toggleTag(1)).isTrue()
-      assertThat(bookmarksDao.getBookmarkTagIds(1)).isEmpty()
+      presenter.setBookmarksMode(arrayOf(BOOKMARK_ID))
+      assertThat(presenter.toggleTag(TAG_ID)).isTrue()
+      assertThat(bookmarksDao.getBookmarkTagIds(BOOKMARK_ID)).isEmpty()
 
       presenter.saveChanges()
 
-      assertThat(bookmarksDao.getBookmarkTagIds(1)).containsExactly(1L)
+      assertThat(bookmarksDao.getBookmarkTagIds(BOOKMARK_ID)).containsExactly(TAG_ID)
     }
   }
 
@@ -53,29 +56,29 @@ class TagBookmarkPresenterTest {
       val presenter = TagBookmarkPresenter(bookmarksDao)
 
       presenter.setAyahBookmarkMode(6, 76, 137)
-      assertThat(presenter.toggleTag(1)).isTrue()
+      assertThat(presenter.toggleTag(TAG_ID)).isTrue()
 
       val bookmarks = bookmarksDao.bookmarks(BookmarkSortOrder.SORT_DATE_ADDED)
       assertThat(bookmarks).hasSize(1)
       assertThat(bookmarks.single().sura).isEqualTo(6)
       assertThat(bookmarks.single().ayah).isEqualTo(76)
-      assertThat(bookmarks.single().tags).containsExactly(1L)
+      assertThat(bookmarks.single().tags).containsExactly(TAG_ID)
     }
   }
 
   @Test
   fun `single bookmark mode replaces existing tags`() {
     runBlocking {
-      bookmarksDao.setTags(listOf(Tag(1, "First"), Tag(2, "Second")))
-      bookmarksDao.setBookmarks(listOf(Bookmark(1, 6, 76, 137, tags = listOf(1))))
+      bookmarksDao.setTags(listOf(Tag(TAG_ID, "First"), Tag(SECOND_TAG_ID, "Second")))
+      bookmarksDao.setBookmarks(listOf(Bookmark(BOOKMARK_ID, 6, 76, 137, tags = listOf(TAG_ID))))
       val presenter = TagBookmarkPresenter(bookmarksDao)
 
-      presenter.setBookmarksMode(longArrayOf(1))
-      assertThat(presenter.toggleTag(1)).isFalse()
-      assertThat(presenter.toggleTag(2)).isTrue()
+      presenter.setBookmarksMode(arrayOf(BOOKMARK_ID))
+      assertThat(presenter.toggleTag(TAG_ID)).isFalse()
+      assertThat(presenter.toggleTag(SECOND_TAG_ID)).isTrue()
       presenter.saveChanges()
 
-      assertThat(bookmarksDao.getBookmarkTagIds(1)).containsExactly(2L)
+      assertThat(bookmarksDao.getBookmarkTagIds(BOOKMARK_ID)).containsExactly(SECOND_TAG_ID)
     }
   }
 
@@ -86,9 +89,52 @@ class TagBookmarkPresenterTest {
 
     presenter.bind(bookmarkDialog)
 
-    assertThat(presenter.toggleTag(-1)).isFalse()
+    presenter.addTag()
+
     assertThat(bookmarkDialog.showAddTagDialogCallCount).isEqualTo(1)
 
     presenter.unbind(bookmarkDialog)
+  }
+
+  @Test
+  fun `tag id matching add row marker remains selectable`() {
+    runBlocking {
+      bookmarksDao.setTags(listOf(Tag(ADD_TAG_MARKER_COLLISION_ID, "Synced Tag")))
+      bookmarksDao.setBookmarks(listOf(Bookmark(BOOKMARK_ID, 6, 76, 137)))
+      val bookmarkDialog = FakeTagBookmarkDialog()
+      val presenter = TagBookmarkPresenter(bookmarksDao)
+
+      presenter.bind(bookmarkDialog)
+      presenter.setBookmarksMode(arrayOf(BOOKMARK_ID))
+
+      assertThat(presenter.toggleTag(ADD_TAG_MARKER_COLLISION_ID)).isTrue()
+      presenter.saveChanges()
+
+      assertThat(bookmarkDialog.showAddTagDialogCallCount).isEqualTo(0)
+      assertThat(bookmarksDao.getBookmarkTagIds(BOOKMARK_ID)).containsExactly(ADD_TAG_MARKER_COLLISION_ID)
+
+      presenter.unbind(bookmarkDialog)
+    }
+  }
+
+  @Test
+  fun `add tag row is position based and not a tag id`() {
+    val context = ApplicationProvider.getApplicationContext<Context>()
+    val adapter = TagBookmarkDialog.TagsAdapter(context, TagBookmarkPresenter(bookmarksDao))
+
+    adapter.setData(listOf(Tag(ADD_TAG_MARKER_COLLISION_ID, "Synced Tag")), hashSetOf())
+
+    assertThat(adapter.count).isEqualTo(2)
+    assertThat(adapter.isAddTagPosition(0)).isFalse()
+    assertThat(adapter.getItem(0)?.id).isEqualTo(ADD_TAG_MARKER_COLLISION_ID)
+    assertThat(adapter.isAddTagPosition(1)).isTrue()
+    assertThat(adapter.getItem(1)).isNull()
+  }
+
+  private companion object {
+    private const val BOOKMARK_ID = "bookmark-1"
+    private const val TAG_ID = "tag-1"
+    private const val SECOND_TAG_ID = "tag-2"
+    private const val ADD_TAG_MARKER_COLLISION_ID = "__quran_add_tag__"
   }
 }

--- a/app/src/test/kotlin/com/quran/labs/androidquran/fakes/FakeBookmarkModel.kt
+++ b/app/src/test/kotlin/com/quran/labs/androidquran/fakes/FakeBookmarkModel.kt
@@ -2,6 +2,7 @@ package com.quran.labs.androidquran.fakes
 
 import com.quran.data.model.bookmark.Bookmark
 import com.quran.data.model.bookmark.BookmarkData
+import com.quran.data.model.bookmark.LegacyBookmarkIds
 import com.quran.data.model.bookmark.Tag
 import com.quran.labs.androidquran.database.BookmarksDBAdapter
 import com.quran.labs.androidquran.helpers.inMemoryBookmarksAdapter
@@ -19,7 +20,7 @@ import io.reactivex.rxjava3.core.Single
  * Usage:
  * ```
  * val fake = FakeBookmarkModel()
- * fake.setTags(listOf(Tag(1, "Important")))
+ * fake.setTags(listOf(Tag("1", "Important")))
  * fake.setBookmarks(listOf(bookmark1, bookmark2))
  *
  * // Configure behavior
@@ -37,7 +38,7 @@ open class FakeBookmarkModel : BookmarkModel(inMemoryBookmarksAdapter()) {
   // State
   private val tags = mutableListOf<Tag>()
   private val bookmarks = mutableListOf<Bookmark>()
-  private val bookmarkTagIds = mutableMapOf<Long, List<Long>>() // bookmarkId -> tagIds
+  private val bookmarkTagIds = mutableMapOf<Long, List<Long>>() // legacy bookmarkId -> legacy tagIds
 
   // Configurable results
   private var updateBookmarkTagsResult = true
@@ -115,7 +116,13 @@ open class FakeBookmarkModel : BookmarkModel(inMemoryBookmarksAdapter()) {
     safeAddBookmarkCalls.add(AddBookmarkCall(sura, ayah, page))
 
     // Add to in-memory state
-    val newBookmark = Bookmark(safeAddBookmarkResult, sura, ayah, page, System.currentTimeMillis())
+    val newBookmark = Bookmark(
+      LegacyBookmarkIds.bookmarkId(safeAddBookmarkResult),
+      sura,
+      ayah,
+      page,
+      System.currentTimeMillis()
+    )
     bookmarks.add(newBookmark)
 
     return Observable.just(safeAddBookmarkResult)

--- a/app/src/test/kotlin/com/quran/labs/androidquran/fakes/FakeBookmarksDBAdapter.kt
+++ b/app/src/test/kotlin/com/quran/labs/androidquran/fakes/FakeBookmarksDBAdapter.kt
@@ -2,7 +2,7 @@ package com.quran.labs.androidquran.fakes
 
 import androidx.core.util.Pair
 import com.quran.data.model.bookmark.Bookmark
-import com.quran.data.model.bookmark.BookmarkData
+import com.quran.data.model.bookmark.LegacyBookmarkIds
 import com.quran.data.model.bookmark.RecentPage
 import com.quran.data.model.bookmark.Tag
 
@@ -18,7 +18,7 @@ import com.quran.data.model.bookmark.Tag
  * Usage:
  * ```
  * val fake = FakeBookmarksDBAdapter()
- * fake.setTags(listOf(Tag(1, "Important")))
+ * fake.setTags(listOf(Tag("1", "Important")))
  * fake.setBookmarks(listOf(bookmark1, bookmark2))
  * fake.setRecentPages(listOf(RecentPage(42, timestamp)))
  *
@@ -36,12 +36,11 @@ class FakeBookmarksDBAdapter {
   private val tags = mutableListOf<Tag>()
   private val bookmarks = mutableListOf<Bookmark>()
   private val recentPages = mutableListOf<RecentPage>()
-  private val bookmarkTags = mutableMapOf<Long, MutableList<Long>>() // bookmarkId -> list of tagIds
+  private val bookmarkTags = mutableMapOf<Long, MutableList<Long>>() // old bookmarkId -> old tagIds
 
   // Configurable behavior
   private var updateTagResult = true
   private var tagBookmarksResult = true
-  private var importBookmarksResult = true
 
   // Call tracking for assertions
   private val updateTagCalls = mutableListOf<UpdateTagCall>()
@@ -80,10 +79,6 @@ class FakeBookmarksDBAdapter {
     tagBookmarksResult = result
   }
 
-  fun setImportBookmarksResult(result: Boolean) {
-    importBookmarksResult = result
-  }
-
   // Public API methods matching BookmarksDBAdapter
   fun getRecentPages(): List<RecentPage> {
     return recentPages.toList()
@@ -114,14 +109,15 @@ class FakeBookmarksDBAdapter {
     }
 
     // Check if name already exists (would fail)
-    if (tags.any { it.name == newName && it.id != id }) {
+    val runtimeTagId = LegacyBookmarkIds.tagId(id)
+    if (tags.any { it.name == newName && it.id != runtimeTagId }) {
       return false
     }
 
     // Update the tag
-    val index = tags.indexOfFirst { it.id == id }
+    val index = tags.indexOfFirst { it.id == runtimeTagId }
     if (index >= 0) {
-      tags[index] = Tag(id, newName)
+      tags[index] = Tag(runtimeTagId, newName)
       return true
     }
     return false
@@ -154,10 +150,10 @@ class FakeBookmarksDBAdapter {
     bulkDeleteCalls.add(BulkDeleteCall(tagIds, bookmarkIds, untag))
 
     // Remove tags
-    tags.removeIf { it.id in tagIds }
+    tags.removeIf { it.id.oldDatabaseIdToLongOrNull() in tagIds }
 
     // Remove bookmarks
-    bookmarks.removeIf { it.id in bookmarkIds }
+    bookmarks.removeIf { it.id.oldDatabaseIdToLongOrNull() in bookmarkIds }
 
     // Remove bookmark-tag associations for deleted bookmarks
     bookmarkIds.forEach { bookmarkTags.remove(it) }
@@ -192,12 +188,12 @@ class FakeBookmarksDBAdapter {
     val bookmark = bookmarks.find {
       it.sura == sura && it.ayah == ayah && it.page == page
     }
-    return bookmark?.id ?: -1L
+    return bookmark?.id?.oldDatabaseIdToLongOrNull() ?: -1L
   }
 
   fun addBookmark(sura: Int?, ayah: Int?, page: Int): Long {
-    val newId = (bookmarks.maxOfOrNull { it.id } ?: 0) + 1
-    val bookmark = Bookmark(newId, sura, ayah, page, System.currentTimeMillis())
+    val newId = (bookmarks.mapNotNull { it.id.oldDatabaseIdToLongOrNull() }.maxOrNull() ?: 0) + 1
+    val bookmark = Bookmark(LegacyBookmarkIds.bookmarkId(newId), sura, ayah, page, System.currentTimeMillis())
     bookmarks.add(bookmark)
     return newId
   }
@@ -212,41 +208,19 @@ class FakeBookmarksDBAdapter {
   }
 
   fun removeBookmark(bookmarkId: Long) {
-    bookmarks.removeIf { it.id == bookmarkId }
+    bookmarks.removeIf { it.id == LegacyBookmarkIds.bookmarkId(bookmarkId) }
     bookmarkTags.remove(bookmarkId)
   }
 
   fun addTag(name: String): Long {
     val existingTag = tags.find { it.name == name }
     if (existingTag != null) {
-      return existingTag.id
+      return existingTag.id.oldDatabaseIdToLongOrNull() ?: -1L
     }
 
-    val newId = (tags.maxOfOrNull { it.id } ?: 0) + 1
-    tags.add(Tag(newId, name))
+    val newId = (tags.mapNotNull { it.id.oldDatabaseIdToLongOrNull() }.maxOrNull() ?: 0) + 1
+    tags.add(Tag(LegacyBookmarkIds.tagId(newId), name))
     return newId
-  }
-
-  fun importBookmarks(data: BookmarkData): Boolean {
-    if (!importBookmarksResult) {
-      return false
-    }
-
-    // Clear all existing data
-    tags.clear()
-    bookmarks.clear()
-    bookmarkTags.clear()
-
-    // Import new data
-    tags.addAll(data.tags)
-    bookmarks.addAll(data.bookmarks)
-
-    // Rebuild bookmark-tag associations
-    data.bookmarks.forEach { bookmark ->
-      bookmarkTags[bookmark.id] = bookmark.tags.toMutableList()
-    }
-
-    return true
   }
 
   // Assertion methods
@@ -317,11 +291,12 @@ class FakeBookmarksDBAdapter {
     clearCallHistory()
     updateTagResult = true
     tagBookmarksResult = true
-    importBookmarksResult = true
   }
 
   companion object {
     const val SORT_DATE_ADDED = 0
     const val SORT_LOCATION = 1
   }
+
+  private fun String.oldDatabaseIdToLongOrNull(): Long? = toLongOrNull()
 }

--- a/app/src/test/kotlin/com/quran/labs/androidquran/fakes/FakeBookmarksDBAdapterTest.kt
+++ b/app/src/test/kotlin/com/quran/labs/androidquran/fakes/FakeBookmarksDBAdapterTest.kt
@@ -2,6 +2,7 @@ package com.quran.labs.androidquran.fakes
 
 import com.google.common.truth.Truth.assertThat
 import com.quran.data.model.bookmark.Bookmark
+import com.quran.data.model.bookmark.LegacyBookmarkIds
 import com.quran.data.model.bookmark.RecentPage
 import com.quran.data.model.bookmark.Tag
 import org.junit.Before
@@ -21,7 +22,7 @@ class FakeBookmarksDBAdapterTest {
 
   @Test
   fun `should store and retrieve tags`() {
-    val tags = listOf(Tag(1, "Important"), Tag(2, "Review"))
+    val tags = listOf(Tag(LegacyBookmarkIds.tagId(1L), "Important"), Tag(LegacyBookmarkIds.tagId(2L), "Review"))
     fake.setTags(tags)
 
     val result = fake.getTags()
@@ -33,7 +34,7 @@ class FakeBookmarksDBAdapterTest {
 
   @Test
   fun `should update tag successfully`() {
-    fake.setTags(listOf(Tag(1, "Old Name")))
+    fake.setTags(listOf(Tag(LegacyBookmarkIds.tagId(1L), "Old Name")))
 
     val result = fake.updateTag(1, "New Name")
 
@@ -44,7 +45,7 @@ class FakeBookmarksDBAdapterTest {
 
   @Test
   fun `should fail to update tag when name already exists`() {
-    fake.setTags(listOf(Tag(1, "First"), Tag(2, "Second")))
+    fake.setTags(listOf(Tag(LegacyBookmarkIds.tagId(1L), "First"), Tag(LegacyBookmarkIds.tagId(2L), "Second")))
 
     val result = fake.updateTag(1, "Second")
 
@@ -54,7 +55,7 @@ class FakeBookmarksDBAdapterTest {
 
   @Test
   fun `should track update tag calls`() {
-    fake.setTags(listOf(Tag(1, "Name")))
+    fake.setTags(listOf(Tag(LegacyBookmarkIds.tagId(1L), "Name")))
 
     fake.updateTag(1, "Updated")
     fake.updateTag(1, "Updated Again")
@@ -107,22 +108,26 @@ class FakeBookmarksDBAdapterTest {
   fun `should sort bookmarks by date`() {
     val now = System.currentTimeMillis()
     fake.setBookmarks(listOf(
-      Bookmark(1, 2, 4, 10, now - 1000),
-      Bookmark(2, 3, 5, 20, now),
-      Bookmark(3, 4, 6, 30, now - 2000)
+      Bookmark(LegacyBookmarkIds.bookmarkId(1L), 2, 4, 10, now - 1000),
+      Bookmark(LegacyBookmarkIds.bookmarkId(2L), 3, 5, 20, now),
+      Bookmark(LegacyBookmarkIds.bookmarkId(3L), 4, 6, 30, now - 2000)
     ))
 
     val sorted = fake.getBookmarks(FakeBookmarksDBAdapter.SORT_DATE_ADDED)
 
-    assertThat(sorted.map { it.id }).containsExactly(2L, 1L, 3L).inOrder()
+    assertThat(sorted.map { it.id }).containsExactly(
+      LegacyBookmarkIds.bookmarkId(2L),
+      LegacyBookmarkIds.bookmarkId(1L),
+      LegacyBookmarkIds.bookmarkId(3L)
+    ).inOrder()
   }
 
   @Test
   fun `should sort bookmarks by location`() {
     fake.setBookmarks(listOf(
-      Bookmark(1, 2, 4, 30, System.currentTimeMillis()),
-      Bookmark(2, 3, 5, 10, System.currentTimeMillis()),
-      Bookmark(3, 4, 6, 20, System.currentTimeMillis())
+      Bookmark(LegacyBookmarkIds.bookmarkId(1L), 2, 4, 30, System.currentTimeMillis()),
+      Bookmark(LegacyBookmarkIds.bookmarkId(2L), 3, 5, 10, System.currentTimeMillis()),
+      Bookmark(LegacyBookmarkIds.bookmarkId(3L), 4, 6, 20, System.currentTimeMillis())
     ))
 
     val sorted = fake.getBookmarks(FakeBookmarksDBAdapter.SORT_LOCATION)
@@ -132,8 +137,8 @@ class FakeBookmarksDBAdapterTest {
 
   @Test
   fun `should reset state`() {
-    fake.setTags(listOf(Tag(1, "Test")))
-    fake.setBookmarks(listOf(Bookmark(1, 2, 4, 10, System.currentTimeMillis())))
+    fake.setTags(listOf(Tag(LegacyBookmarkIds.tagId(1L), "Test")))
+    fake.setBookmarks(listOf(Bookmark(LegacyBookmarkIds.bookmarkId(1L), 2, 4, 10, System.currentTimeMillis())))
     fake.updateTag(1, "Updated")
 
     fake.reset()
@@ -145,7 +150,7 @@ class FakeBookmarksDBAdapterTest {
 
   @Test
   fun `should configure updateTag to fail`() {
-    fake.setTags(listOf(Tag(1, "Test")))
+    fake.setTags(listOf(Tag(LegacyBookmarkIds.tagId(1L), "Test")))
     fake.setUpdateTagResult(false)
 
     val result = fake.updateTag(1, "Updated")

--- a/app/src/test/kotlin/com/quran/labs/androidquran/fakes/FakeBookmarksDao.kt
+++ b/app/src/test/kotlin/com/quran/labs/androidquran/fakes/FakeBookmarksDao.kt
@@ -4,6 +4,7 @@ import com.quran.data.dao.BookmarkSortOrder
 import com.quran.data.dao.BookmarksDao
 import com.quran.data.model.SuraAyah
 import com.quran.data.model.bookmark.Bookmark
+import com.quran.data.model.bookmark.LegacyBookmarkIds
 import com.quran.data.model.bookmark.Tag
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -62,8 +63,8 @@ class FakeBookmarksDao : BookmarksDao {
     return tags
   }
 
-  override suspend fun addTag(name: String): Long {
-    val id = (tags.value.maxOfOrNull { it.id } ?: 0L) + 1
+  override suspend fun addTag(name: String): String {
+    val id = LegacyBookmarkIds.tagId((tags.value.size + 1).toLong())
     addedTagNames += name
     tags.update { current -> current + Tag(id, name) }
     changesFlow.tryEmit(Unit)
@@ -85,11 +86,11 @@ class FakeBookmarksDao : BookmarksDao {
     changesFlow.tryEmit(Unit)
   }
 
-  override suspend fun getBookmarkTagIds(bookmarkId: Long): List<Long> {
+  override suspend fun getBookmarkTagIds(bookmarkId: String): List<String> {
     return bookmarks.value.firstOrNull { it.id == bookmarkId }?.tags.orEmpty()
   }
 
-  override suspend fun getAyahBookmarkTagIds(suraAyah: SuraAyah): List<Long> {
+  override suspend fun getAyahBookmarkTagIds(suraAyah: SuraAyah): List<String> {
     return bookmarks.value
       .firstOrNull { it.sura == suraAyah.sura && it.ayah == suraAyah.ayah }
       ?.tags
@@ -97,8 +98,8 @@ class FakeBookmarksDao : BookmarksDao {
   }
 
   override suspend fun updateBookmarkTags(
-    bookmarkIds: LongArray,
-    tagIds: Set<Long>,
+    bookmarkIds: Array<String>,
+    tagIds: Set<String>,
     deleteNonTagged: Boolean
   ): Boolean {
     val bookmarkIdSet = bookmarkIds.toSet()
@@ -123,24 +124,24 @@ class FakeBookmarksDao : BookmarksDao {
   override suspend fun updateAyahBookmarkTags(
     suraAyah: SuraAyah,
     page: Int,
-    tagIds: Set<Long>,
+    tagIds: Set<String>,
     deleteNonTagged: Boolean
   ): Boolean {
     val existing = bookmarks.value.firstOrNull { it.sura == suraAyah.sura && it.ayah == suraAyah.ayah }
     if (existing == null && tagIds.isNotEmpty()) {
-      val id = (bookmarks.value.maxOfOrNull { it.id } ?: 0L) + 1
+      val id = LegacyBookmarkIds.bookmarkId((bookmarks.value.size + 1).toLong())
       bookmarks.update { current ->
         current + Bookmark(id, suraAyah.sura, suraAyah.ayah, page, System.currentTimeMillis() / 1000, tagIds.toList())
       }
     } else if (existing != null) {
-      updateBookmarkTags(longArrayOf(existing.id), tagIds, deleteNonTagged)
+      updateBookmarkTags(arrayOf(existing.id), tagIds, deleteNonTagged)
       return true
     }
     changesFlow.tryEmit(Unit)
     return true
   }
 
-  override suspend fun removeBookmarkFromTag(bookmark: Bookmark, tagId: Long): Boolean {
+  override suspend fun removeBookmarkFromTag(bookmark: Bookmark, tagId: String): Boolean {
     bookmarks.update { current ->
       current.map {
         if (it.id == bookmark.id) {
@@ -182,7 +183,7 @@ class FakeBookmarksDao : BookmarksDao {
       changesFlow.tryEmit(Unit)
       false
     } else {
-      val id = (bookmarks.value.maxOfOrNull { it.id } ?: 0L) + 1
+      val id = LegacyBookmarkIds.bookmarkId((bookmarks.value.size + 1).toLong())
       bookmarks.update { current ->
         current + Bookmark(id, suraAyah.sura, suraAyah.ayah, page, System.currentTimeMillis() / 1000)
       }

--- a/app/src/test/kotlin/com/quran/labs/androidquran/model/bookmark/BookmarkModelTest.kt
+++ b/app/src/test/kotlin/com/quran/labs/androidquran/model/bookmark/BookmarkModelTest.kt
@@ -3,6 +3,7 @@ package com.quran.labs.androidquran.model.bookmark
 import app.cash.sqldelight.adapter.primitive.IntColumnAdapter
 import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
 import com.google.common.truth.Truth.assertThat
+import com.quran.data.model.bookmark.LegacyBookmarkIds
 import com.quran.data.model.bookmark.Tag
 import com.quran.labs.awaitTerminalEvent
 import com.quran.labs.androidquran.BookmarksDatabase
@@ -53,7 +54,7 @@ class BookmarkModelTest {
   fun testUpdateTag() {
     // Setup: Create a tag first
     val tagId = bookmarksAdapter.addTag("Original Tag")
-    val tag = Tag(tagId, "Updated Tag")
+    val tag = Tag(LegacyBookmarkIds.tagId(tagId), "Updated Tag")
 
     // Execute: Update the tag
     val testObserver = model.updateTag(tag).test()
@@ -65,7 +66,7 @@ class BookmarkModelTest {
 
     // Verify: Tag was actually updated in database
     val allTags = bookmarksAdapter.getTags()
-    val updatedTag = requireNotNull(allTags.find { it.id == tagId })
+    val updatedTag = requireNotNull(allTags.find { it.id == LegacyBookmarkIds.tagId(tagId) })
     assertThat(updatedTag.name).isEqualTo("Updated Tag")
   }
 

--- a/common/bookmark/src/main/java/com/quran/mobile/bookmark/importdata/BookmarkBackupImportNormalizer.kt
+++ b/common/bookmark/src/main/java/com/quran/mobile/bookmark/importdata/BookmarkBackupImportNormalizer.kt
@@ -69,7 +69,7 @@ class BookmarkBackupImportNormalizer @Inject constructor(
   private fun CollectionState.oldPageBookmarkCollectionId(timestamp: Long): String {
     val oldPageBookmarksName = appContext.getString(R.string.old_page_bookmarks)
     return importIdForName[oldPageBookmarksName]
-      ?: OLD_PAGE_BOOKMARKS_COLLECTION_ID.also { importId ->
+      ?: nextCollectionImportId().also { importId ->
         add(
           MobileSyncImportCollection(
             importId = importId,
@@ -194,40 +194,62 @@ class BookmarkBackupImportNormalizer @Inject constructor(
   }
 
   private data class CollectionState(
-    val importIdForBackupTagId: MutableMap<Long, String> = mutableMapOf(),
+    val importIdForBackupTagId: MutableMap<String, String> = mutableMapOf(),
     val importIdForName: MutableMap<String, String> = mutableMapOf(),
-    val collections: MutableList<MobileSyncImportCollection> = mutableListOf()
+    val collections: MutableList<MobileSyncImportCollection> = mutableListOf(),
+    val reservedCollectionImportIds: MutableSet<String> = mutableSetOf()
   ) {
+    private var nextCollectionImportIndex = 0
+
     fun add(collection: MobileSyncImportCollection) {
       importIdForName[collection.name] = collection.importId
+      reservedCollectionImportIds.add(collection.importId)
       collections.add(collection)
     }
 
     companion object {
       fun from(tags: List<Tag>, importTimestampMillis: Long): CollectionState {
         val state = CollectionState()
-        tags.sortedBy { tag -> tag.id }.forEach { tag ->
-          val name = tag.name
-          if (name.isBlank()) return@forEach
-          val existingImportId = state.importIdForName[name]
-          if (existingImportId != null) {
-            state.importIdForBackupTagId[tag.id] = existingImportId
-          } else {
-            val collection = MobileSyncImportCollection(
-              importId = "tag-${tag.id}",
-              name = name,
-              timestampMillis = importTimestampMillis
-            )
-            state.importIdForBackupTagId[tag.id] = collection.importId
-            state.add(collection)
+        state.reservedCollectionImportIds.addAll(tags.map { tag -> tag.id })
+        tags.sortedWith(
+          compareBy<Tag> { tag -> legacyTagNumber(tag.id) ?: Long.MAX_VALUE }
+            .thenBy { tag -> tag.id }
+        )
+          .forEach { tag ->
+            val name = tag.name
+            if (name.isBlank()) return@forEach
+            val existingImportId = state.importIdForName[name]
+            if (existingImportId != null) {
+              state.importIdForBackupTagId[tag.id] = existingImportId
+            } else {
+              val collection = MobileSyncImportCollection(
+                importId = state.nextCollectionImportId(),
+                name = name,
+                timestampMillis = importTimestampMillis
+              )
+              state.importIdForBackupTagId[tag.id] = collection.importId
+              state.add(collection)
+            }
           }
-        }
         return state
       }
-    }
-  }
 
-  companion object {
-    private const val OLD_PAGE_BOOKMARKS_COLLECTION_ID = "old-page-bookmarks"
+      private fun legacyTagNumber(tagId: String): Long? {
+        return tagId.toLongOrNull()
+      }
+    }
+
+    /**
+     * Import IDs only correlate this import payload's collections to its bookmark links. They are
+     * not mobile-sync local IDs, so do not reuse backup-provided tag IDs here.
+     */
+    fun nextCollectionImportId(): String {
+      while (true) {
+        val importId = "backup-collection-${nextCollectionImportIndex++}"
+        if (reservedCollectionImportIds.add(importId)) {
+          return importId
+        }
+      }
+    }
   }
 }

--- a/common/bookmark/src/main/java/com/quran/mobile/bookmark/mapper/BookmarkExtensions.kt
+++ b/common/bookmark/src/main/java/com/quran/mobile/bookmark/mapper/BookmarkExtensions.kt
@@ -15,7 +15,7 @@ fun List<Bookmark>.convergeCommonlyTagged(): List<Bookmark> {
         firstBookmark
       } else {
         val tagIds =
-          it.value.fold(mutableListOf<Long>()) { acc, bookmark ->
+          it.value.fold(mutableListOf<String>()) { acc, bookmark ->
             acc.apply { addAll(bookmark.tags) }
           }
         firstBookmark.withTags(tagIds)

--- a/common/bookmark/src/main/java/com/quran/mobile/bookmark/mapper/Mappers.kt
+++ b/common/bookmark/src/main/java/com/quran/mobile/bookmark/mapper/Mappers.kt
@@ -1,12 +1,13 @@
 package com.quran.mobile.bookmark.mapper
 
 import com.quran.data.model.bookmark.Bookmark
+import com.quran.data.model.bookmark.LegacyBookmarkIds
 import com.quran.data.model.bookmark.RecentPage
 import com.quran.data.model.bookmark.Tag
 
 object Mappers {
   val pageBookmarkMapper: ((id: Long, page: Int, addedDate: Long) -> Bookmark) = { id, page, addedDate ->
-    Bookmark(id, null, null, page, addedDate)
+    Bookmark(LegacyBookmarkIds.bookmarkId(id), null, null, page, addedDate)
   }
 
   val bookmarkWithTagMapper: ((
@@ -17,13 +18,13 @@ object Mappers {
     addedDate: Long,
     tagId: Long?
   ) -> Bookmark) = { id, sura, ayah, page, addedDate, tagId ->
-    val tags = if (tagId == null) emptyList() else listOf(tagId)
-    Bookmark(id, sura, ayah, page, addedDate, tags)
+    val tags = if (tagId == null) emptyList() else listOf(LegacyBookmarkIds.tagId(tagId))
+    Bookmark(LegacyBookmarkIds.bookmarkId(id), sura, ayah, page, addedDate, tags)
   }
 
   val recentPageMapper: ((id: Long, page: Int, addedDate: Long) -> RecentPage) =
     { _, page, addedDate -> RecentPage(page, addedDate) }
 
   val tagMapper: ((id: Long, name: String, addedDate: Long) -> Tag) =
-    { id, name, _ -> Tag(id, name) }
+    { id, name, _ -> Tag(LegacyBookmarkIds.tagId(id), name) }
 }

--- a/common/bookmark/src/main/java/com/quran/mobile/bookmark/migration/LegacyBookmarkMigrationNormalizer.kt
+++ b/common/bookmark/src/main/java/com/quran/mobile/bookmark/migration/LegacyBookmarkMigrationNormalizer.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import com.quran.data.core.QuranInfo
 import com.quran.data.model.SuraAyah
 import com.quran.data.model.bookmark.Bookmark
+import com.quran.data.model.bookmark.LegacyBookmarkIds
 import com.quran.data.model.bookmark.RecentPage
 import com.quran.mobile.bookmark.R
 import com.quran.mobile.bookmark.importdata.MobileSyncImportBookmark
@@ -70,7 +71,7 @@ class LegacyBookmarkMigrationNormalizer @Inject constructor(
   private fun CollectionState.oldPageBookmarkCollectionId(timestamp: Long): String {
     val oldPageBookmarksName = appContext.getString(R.string.old_page_bookmarks)
     return importIdForName[oldPageBookmarksName]
-      ?: OLD_PAGE_BOOKMARKS_COLLECTION_ID.also { importId ->
+      ?: nextCollectionImportId().also { importId ->
         add(
           MobileSyncImportCollection(
             importId = importId,
@@ -174,10 +175,12 @@ class LegacyBookmarkMigrationNormalizer @Inject constructor(
   }
 
   private data class CollectionState(
-    val importIdForLegacyTagId: MutableMap<Long, String> = mutableMapOf(),
+    val importIdForLegacyTagId: MutableMap<String, String> = mutableMapOf(),
     val importIdForName: MutableMap<String, String> = mutableMapOf(),
     val collections: MutableList<MobileSyncImportCollection> = mutableListOf()
   ) {
+    private var nextCollectionImportIndex = 0
+
     fun add(collection: MobileSyncImportCollection) {
       importIdForName[collection.name] = collection.importId
       collections.add(collection)
@@ -187,27 +190,32 @@ class LegacyBookmarkMigrationNormalizer @Inject constructor(
       fun from(tags: List<LegacyBookmarkTag>): CollectionState {
         val state = CollectionState()
         tags.sortedBy { tag -> tag.id }.forEach { tag ->
+          val runtimeTagId = LegacyBookmarkIds.tagId(tag.id)
           val name = tag.name
           if (name.isBlank()) return@forEach
           val existingImportId = state.importIdForName[name]
           if (existingImportId != null) {
-            state.importIdForLegacyTagId[tag.id] = existingImportId
+            state.importIdForLegacyTagId[runtimeTagId] = existingImportId
           } else {
             val collection = MobileSyncImportCollection(
-              importId = "tag-${tag.id}",
+              importId = state.nextCollectionImportId(),
               name = name,
               timestampMillis = tag.timestamp.legacyTimestampMillis()
             )
-            state.importIdForLegacyTagId[tag.id] = collection.importId
+            state.importIdForLegacyTagId[runtimeTagId] = collection.importId
             state.add(collection)
           }
         }
         return state
       }
     }
-  }
 
-  companion object {
-    private const val OLD_PAGE_BOOKMARKS_COLLECTION_ID = "old-page-bookmarks"
+    /**
+     * Import IDs only correlate this migration payload's collections to its bookmark links. They
+     * are not mobile-sync local IDs, so do not reuse old SQLite tag IDs here.
+     */
+    fun nextCollectionImportId(): String {
+      return "legacy-collection-${nextCollectionImportIndex++}"
+    }
   }
 }

--- a/common/bookmark/src/main/java/com/quran/mobile/bookmark/model/BookmarkCollectionIds.kt
+++ b/common/bookmark/src/main/java/com/quran/mobile/bookmark/model/BookmarkCollectionIds.kt
@@ -1,0 +1,14 @@
+package com.quran.mobile.bookmark.model
+
+import com.quran.shared.persistence.model.DEFAULT_COLLECTION_ID as SYNC_DEFAULT_COLLECTION_ID
+
+/**
+ * Canonical mobile-sync default collection ID exposed for app code that should not compile
+ * directly against mobile-sync.
+ */
+val DEFAULT_BOOKMARK_COLLECTION_ID: String
+  get() = SYNC_DEFAULT_COLLECTION_ID
+
+fun String.isDefaultBookmarkCollectionId(): Boolean {
+  return this == DEFAULT_BOOKMARK_COLLECTION_ID
+}

--- a/common/bookmark/src/main/java/com/quran/mobile/bookmark/model/BookmarksDaoImpl.kt
+++ b/common/bookmark/src/main/java/com/quran/mobile/bookmark/model/BookmarksDaoImpl.kt
@@ -15,7 +15,6 @@ import com.quran.mobile.bookmark.sync.notifyLocalDataChanged
 import com.quran.mobile.bookmark.time.MobileSyncTimestampProvider
 import com.quran.shared.persistence.model.AyahBookmark
 import com.quran.shared.persistence.model.CollectionAyahBookmark
-import com.quran.shared.persistence.model.DEFAULT_COLLECTION_ID
 import com.quran.shared.persistence.repository.bookmark.repository.BookmarksRepository
 import com.quran.shared.persistence.repository.collection.repository.CollectionsRepository
 import com.quran.shared.persistence.repository.collectionbookmark.repository.CollectionBookmarksRepository
@@ -61,7 +60,7 @@ class BookmarksDaoImpl @Inject constructor(
       .distinctUntilChanged()
       .stateIn(appCoroutineScope, SharingStarted.Eagerly, null)
 
-  private val bookmarkTagsState: StateFlow<Map<Long, List<Long>>?> =
+  private val bookmarkTagsState: StateFlow<Map<String, List<String>>?> =
     bookmarkTagsByBookmarkIdFlow()
       .distinctUntilChanged()
       .stateIn(appCoroutineScope, SharingStarted.Eagerly, null)
@@ -98,7 +97,7 @@ class BookmarksDaoImpl @Inject constructor(
         bookmarks.map { bookmark ->
           toBookmark(
             bookmark,
-            tagsByBookmarkId[bookmark.localId.toLongOrNull()].orEmpty()
+            tagsByBookmarkId[bookmark.localId].orEmpty()
           )
         },
         sortOrder
@@ -125,10 +124,10 @@ class BookmarksDaoImpl @Inject constructor(
       .distinctUntilChanged()
   }
 
-  override suspend fun addTag(name: String): Long {
+  override suspend fun addTag(name: String): String {
     val timestamp = timestampProvider.now()
     val tagId = withContext(Dispatchers.IO) {
-      collectionsRepository.addCollection(name, timestamp).localId.toLong()
+      collectionsRepository.addCollection(name, timestamp).localId
     }
     localDataChangeNotifier.notifyLocalDataChanged()
     return tagId
@@ -137,12 +136,12 @@ class BookmarksDaoImpl @Inject constructor(
   override suspend fun updateTag(tag: Tag): Boolean {
     val timestamp = timestampProvider.now()
     val updated = withContext(Dispatchers.IO) {
-      val localId = tag.id.toString()
-      val collections = collectionsRepository.getAllCollections()
-      val existingCollection = collections.firstOrNull { collection -> collection.localId == localId }
+      val localId = tag.id
+      val collectionsById = collectionsById()
+      val existingCollection = collectionsById[localId]
         ?: return@withContext false
       if (existingCollection.name == tag.name ||
-        collections.any { collection -> collection.localId != localId && collection.name == tag.name }
+        collectionsById.any { (collectionId, collection) -> collectionId != localId && collection.name == tag.name }
       ) {
         return@withContext false
       }
@@ -163,8 +162,9 @@ class BookmarksDaoImpl @Inject constructor(
 
   override suspend fun removeTags(tags: List<Tag>) {
     val removed = withContext(Dispatchers.IO) {
-      val tagsToRemove = tags.filter { tag -> tag.id > 0 }
-      tagsToRemove.forEach { tag -> collectionsRepository.deleteCollection(tag.id.toString()) }
+      val collectionsById = collectionsById()
+      val tagsToRemove = tags.filter { tag -> collectionsById.containsKey(tag.id) }
+      tagsToRemove.forEach { tag -> collectionsRepository.deleteCollection(tag.id) }
       tagsToRemove.isNotEmpty()
     }
     if (removed) {
@@ -172,13 +172,13 @@ class BookmarksDaoImpl @Inject constructor(
     }
   }
 
-  override suspend fun getBookmarkTagIds(bookmarkId: Long): List<Long> {
+  override suspend fun getBookmarkTagIds(bookmarkId: String): List<String> {
     return withContext(Dispatchers.IO) {
       bookmarkTagsByBookmarkId()[bookmarkId].orEmpty()
     }
   }
 
-  override suspend fun getAyahBookmarkTagIds(suraAyah: SuraAyah): List<Long> {
+  override suspend fun getAyahBookmarkTagIds(suraAyah: SuraAyah): List<String> {
     return withContext(Dispatchers.IO) {
       val bookmark = bookmarkForSuraAyah(suraAyah) ?: return@withContext emptyList()
       tagIdsForBookmark(bookmark.localId)
@@ -186,8 +186,8 @@ class BookmarksDaoImpl @Inject constructor(
   }
 
   override suspend fun updateBookmarkTags(
-    bookmarkIds: LongArray,
-    tagIds: Set<Long>,
+    bookmarkIds: Array<String>,
+    tagIds: Set<String>,
     deleteNonTagged: Boolean
   ): Boolean {
     val timestamp = timestampProvider.now()
@@ -197,10 +197,10 @@ class BookmarksDaoImpl @Inject constructor(
       val currentTagsByBookmarkId = bookmarkTagsByBookmarkId()
       val defaultBookmarkIds = defaultBookmarkIds()
       val bookmarksById = bookmarksRepository.getAllBookmarks()
-        .associateBy { bookmark -> bookmark.localId.toLongOrNull() }
+        .associateBy { bookmark -> bookmark.localId }
       var didWrite = false
       bookmarkIds
-        .filter { bookmarkId -> bookmarkId > 0 }
+        .filter { bookmarkId -> bookmarkId.isNotBlank() }
         .distinct()
         .forEach { bookmarkId ->
           val bookmark = bookmarksById[bookmarkId] ?: return@forEach
@@ -229,7 +229,7 @@ class BookmarksDaoImpl @Inject constructor(
   override suspend fun updateAyahBookmarkTags(
     suraAyah: SuraAyah,
     page: Int,
-    tagIds: Set<Long>,
+    tagIds: Set<String>,
     deleteNonTagged: Boolean
   ): Boolean {
     val timestamp = timestampProvider.now()
@@ -238,7 +238,7 @@ class BookmarksDaoImpl @Inject constructor(
       val targetTagIds = validTagIds(tagIds, collectionsById)
       val existingBookmark = bookmarkForSuraAyah(suraAyah)
       if (existingBookmark != null) {
-        val bookmarkId = existingBookmark.localId.toLongOrNull() ?: return@withContext false
+        val bookmarkId = existingBookmark.localId
         val nextTagIds = if (deleteNonTagged) {
           targetTagIds
         } else {
@@ -268,7 +268,7 @@ class BookmarksDaoImpl @Inject constructor(
     return true
   }
 
-  override suspend fun removeBookmarkFromTag(bookmark: Bookmark, tagId: Long): Boolean {
+  override suspend fun removeBookmarkFromTag(bookmark: Bookmark, tagId: String): Boolean {
     val removed = withContext(Dispatchers.IO) {
       val ayahBookmark = findAyahBookmark(bookmark) ?: return@withContext false
       val collection = collectionsById()[tagId] ?: return@withContext false
@@ -364,14 +364,14 @@ class BookmarksDaoImpl @Inject constructor(
 
   private suspend fun replaceBookmarkMemberships(
     bookmark: AyahBookmark,
-    tagIds: Set<Long>,
+    tagIds: Set<String>,
     isInDefaultCollection: Boolean,
-    collectionsById: Map<Long, SyncCollection>,
+    collectionsById: Map<String, SyncCollection>,
     timestamp: PlatformDateTime
   ): Boolean {
     val collectionLocalIds = buildList {
       if (isInDefaultCollection) {
-        add(DEFAULT_COLLECTION_ID)
+        add(DEFAULT_BOOKMARK_COLLECTION_ID)
       }
       addAll(collectionLocalIds(tagIds, collectionsById))
     }
@@ -382,20 +382,18 @@ class BookmarksDaoImpl @Inject constructor(
     }
   }
 
-  private suspend fun tagIdsForBookmark(bookmarkLocalId: String): List<Long> {
+  private suspend fun tagIdsForBookmark(bookmarkLocalId: String): List<String> {
     return tagIdsForBookmark(bookmarkLocalId, bookmarkTagsByBookmarkId())
   }
 
   private fun tagIdsForBookmark(
     bookmarkLocalId: String,
-    tagsByBookmarkId: Map<Long, List<Long>>
-  ): List<Long> {
-    return bookmarkLocalId.toLongOrNull()
-      ?.let { bookmarkId -> tagsByBookmarkId[bookmarkId] }
-      .orEmpty()
+    tagsByBookmarkId: Map<String, List<String>>
+  ): List<String> {
+    return tagsByBookmarkId[bookmarkLocalId].orEmpty()
   }
 
-  private fun bookmarkTagsByBookmarkIdFlow(): Flow<Map<Long, List<Long>>> {
+  private fun bookmarkTagsByBookmarkIdFlow(): Flow<Map<String, List<String>>> {
     return collectionsState.filterNotNull()
       .flatMapLatest { collections ->
         if (collections.isEmpty()) {
@@ -421,26 +419,24 @@ class BookmarksDaoImpl @Inject constructor(
   private fun collectionBookmarksToPairs(
     collection: SyncCollection,
     bookmarks: List<CollectionAyahBookmark>
-  ): List<Pair<Long, Long>> {
-    val tagId = collection.localId.toLongOrNull() ?: return emptyList()
-    return bookmarks.mapNotNull { bookmark ->
-      bookmark.bookmarkLocalId.toLongOrNull()?.let { bookmarkId -> bookmarkId to tagId }
-    }
+  ): List<Pair<String, String>> {
+    if (collection.localId.isDefaultBookmarkCollectionId()) return emptyList()
+    return bookmarks.map { bookmark -> bookmark.bookmarkLocalId to collection.localId }
   }
 
-  private suspend fun bookmarkTagsByBookmarkId(): Map<Long, List<Long>> {
+  private suspend fun bookmarkTagsByBookmarkId(): Map<String, List<String>> {
     return loadBookmarkTagsByBookmarkId(collectionsRepository.getAllCollections())
   }
 
-  private suspend fun defaultBookmarkIds(): Set<Long> {
-    return collectionBookmarksRepository.getBookmarksForCollection(DEFAULT_COLLECTION_ID)
-      .mapNotNull { bookmark -> bookmark.bookmarkLocalId.toLongOrNull() }
+  private suspend fun defaultBookmarkIds(): Set<String> {
+    return collectionBookmarksRepository.getBookmarksForCollection(DEFAULT_BOOKMARK_COLLECTION_ID)
+      .map { bookmark -> bookmark.bookmarkLocalId }
       .toSet()
   }
 
   private suspend fun loadBookmarkTagsByBookmarkId(
     collections: List<SyncCollection>
-  ): Map<Long, List<Long>> {
+  ): Map<String, List<String>> {
     return collections
       .flatMap { collection ->
         collectionBookmarksToPairs(
@@ -452,25 +448,23 @@ class BookmarksDaoImpl @Inject constructor(
   }
 
   private fun validTagIds(
-    tagIds: Set<Long>,
-    collectionsById: Map<Long, SyncCollection>
-  ): Set<Long> {
-    return tagIds.filter { tagId -> tagId > 0 && collectionsById.containsKey(tagId) }.toSet()
+    tagIds: Set<String>,
+    collectionsById: Map<String, SyncCollection>
+  ): Set<String> {
+    return tagIds.filter { tagId -> collectionsById.containsKey(tagId) }.toSet()
   }
 
   private fun collectionLocalIds(
-    tagIds: Set<Long>,
-    collectionsById: Map<Long, SyncCollection>
+    tagIds: Set<String>,
+    collectionsById: Map<String, SyncCollection>
   ): List<String> {
     return tagIds.mapNotNull { tagId -> collectionsById[tagId]?.localId }
   }
 
-  private suspend fun collectionsById(): Map<Long, SyncCollection> {
+  private suspend fun collectionsById(): Map<String, SyncCollection> {
     return collectionsRepository.getAllCollections()
-      .mapNotNull { collection ->
-        collection.localId.toLongOrNull()?.let { id -> id to collection }
-      }
-      .toMap()
+      .filterNot { collection -> collection.localId.isDefaultBookmarkCollectionId() }
+      .associateBy { collection -> collection.localId }
   }
 
   private suspend fun bookmarkForSuraAyah(suraAyah: SuraAyah): AyahBookmark? {
@@ -483,7 +477,7 @@ class BookmarksDaoImpl @Inject constructor(
     val sura = bookmark.sura
     val ayah = bookmark.ayah
     return bookmarksRepository.getAllBookmarks()
-      .firstOrNull { ayahBookmark -> ayahBookmark.localId.toLongOrNull() == bookmarkId }
+      .firstOrNull { ayahBookmark -> ayahBookmark.localId == bookmarkId }
       ?: if (sura != null && ayah != null) {
         bookmarkForSuraAyah(SuraAyah(sura, ayah))
       } else {
@@ -509,11 +503,11 @@ class BookmarksDaoImpl @Inject constructor(
       }
   }
 
-  private fun toBookmark(bookmark: AyahBookmark, tagIds: List<Long>): Bookmark {
+  private fun toBookmark(bookmark: AyahBookmark, tagIds: List<String>): Bookmark {
     val timestampSeconds = bookmark.lastUpdated.fromPlatform().toEpochMilliseconds() / 1000
     val page = quranInfoProvider().getPageFromSuraAyah(bookmark.sura, bookmark.ayah)
     return Bookmark(
-      id = bookmark.localId.toLong(),
+      id = bookmark.localId,
       sura = bookmark.sura,
       ayah = bookmark.ayah,
       page = page,
@@ -523,7 +517,9 @@ class BookmarksDaoImpl @Inject constructor(
   }
 
   private fun toTag(collection: SyncCollection): Tag? {
-    return collection.localId.toLongOrNull()?.let { id -> Tag(id, collection.name) }
+    return collection
+      .takeUnless { it.localId.isDefaultBookmarkCollectionId() }
+      ?.let { Tag(it.localId, it.name) }
   }
 
   private fun sortBookmarks(bookmarks: List<Bookmark>, sortOrder: Int): List<Bookmark> {

--- a/common/bookmark/src/test/kotlin/com/quran/mobile/bookmark/model/BookmarksDaoImplTest.kt
+++ b/common/bookmark/src/test/kotlin/com/quran/mobile/bookmark/model/BookmarksDaoImplTest.kt
@@ -13,14 +13,19 @@ import com.quran.mobile.bookmark.sync.FakeLocalDataChangeNotifier
 import com.quran.mobile.bookmark.time.FakeMobileSyncTimestampProvider
 import com.quran.shared.persistence.QuranDatabase
 import com.quran.shared.persistence.repository.bookmark.repository.BookmarksRepositoryImpl
+import com.quran.shared.persistence.repository.collection.repository.CollectionsRepository
 import com.quran.shared.persistence.repository.collection.repository.CollectionsRepositoryImpl
 import com.quran.shared.persistence.repository.collectionbookmark.repository.CollectionBookmarksRepositoryImpl
+import com.quran.shared.persistence.util.PlatformDateTime
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
+import com.quran.shared.persistence.model.Collection as SyncCollection
 
 class BookmarksDaoImplTest {
 
@@ -120,7 +125,7 @@ class BookmarksDaoImplTest {
     val suraAyah = SuraAyah(36, 1)
     dao.toggleAyahBookmark(suraAyah, quranInfo.getPageFromSuraAyah(36, 1))
     val ayahBookmark = dao.bookmarks().single()
-    val pageBookmark = Bookmark(999, null, null, 50, 1)
+    val pageBookmark = Bookmark("bookmark-999", null, null, 50, 1)
 
     dao.removeBookmarks(listOf(ayahBookmark, pageBookmark))
 
@@ -224,9 +229,31 @@ class BookmarksDaoImplTest {
   fun `update tag returns false when tag no longer exists`() = runTest {
     localDataChangeNotifier.reset()
 
-    val updated = dao.updateTag(com.quran.data.model.bookmark.Tag(999, "Missing"))
+    val updated = dao.updateTag(com.quran.data.model.bookmark.Tag("missing", "Missing"))
 
     assertThat(updated).isFalse()
+    assertThat(localDataChangeNotifier.updateCount).isEqualTo(0)
+  }
+
+  @Test
+  fun `update tag returns false for default collection`() = runTest {
+    val collectionsRepository = DefaultCollectionTestRepository(timestampProvider.now())
+    val dao = BookmarksDaoImpl(
+      quranInfoProvider = { quranInfo },
+      bookmarksRepository = BookmarksRepositoryImpl(database),
+      collectionsRepository = collectionsRepository,
+      collectionBookmarksRepository = CollectionBookmarksRepositoryImpl(database),
+      localDataChangeNotifier = localDataChangeNotifier,
+      timestampProvider = timestampProvider,
+      appCoroutineScope = appCoroutineScope
+    )
+
+    val updated = dao.updateTag(
+      com.quran.data.model.bookmark.Tag(DEFAULT_BOOKMARK_COLLECTION_ID, "Default Renamed")
+    )
+
+    assertThat(updated).isFalse()
+    assertThat(collectionsRepository.updateCount).isEqualTo(0)
     assertThat(localDataChangeNotifier.updateCount).isEqualTo(0)
   }
 
@@ -237,7 +264,7 @@ class BookmarksDaoImplTest {
     dao.toggleAyahBookmark(suraAyah, quranInfo.getPageFromSuraAyah(suraAyah.sura, suraAyah.ayah))
     val bookmark = dao.bookmarks().single()
 
-    dao.updateBookmarkTags(longArrayOf(bookmark.id), setOf(tagId), deleteNonTagged = true)
+    dao.updateBookmarkTags(arrayOf(bookmark.id), setOf(tagId), deleteNonTagged = true)
 
     val taggedBookmark = dao.bookmarks().single()
     assertThat(taggedBookmark.tags).containsExactly(tagId)
@@ -253,7 +280,7 @@ class BookmarksDaoImplTest {
     val bookmark = dao.bookmarks().single()
     localDataChangeNotifier.reset()
 
-    dao.updateBookmarkTags(longArrayOf(bookmark.id), setOf(tagId), deleteNonTagged = true)
+    dao.updateBookmarkTags(arrayOf(bookmark.id), setOf(tagId), deleteNonTagged = true)
 
     assertThat(localDataChangeNotifier.updateCount).isEqualTo(1)
   }
@@ -265,9 +292,9 @@ class BookmarksDaoImplTest {
     val suraAyah = SuraAyah(2, 255)
     dao.toggleAyahBookmark(suraAyah, quranInfo.getPageFromSuraAyah(suraAyah.sura, suraAyah.ayah))
     val bookmark = dao.bookmarks().single()
-    dao.updateBookmarkTags(longArrayOf(bookmark.id), setOf(firstTagId), deleteNonTagged = true)
+    dao.updateBookmarkTags(arrayOf(bookmark.id), setOf(firstTagId), deleteNonTagged = true)
 
-    dao.updateBookmarkTags(longArrayOf(bookmark.id), setOf(secondTagId), deleteNonTagged = true)
+    dao.updateBookmarkTags(arrayOf(bookmark.id), setOf(secondTagId), deleteNonTagged = true)
 
     assertThat(dao.bookmarks().single().tags).containsExactly(secondTagId)
   }
@@ -279,9 +306,9 @@ class BookmarksDaoImplTest {
     val suraAyah = SuraAyah(2, 255)
     dao.toggleAyahBookmark(suraAyah, quranInfo.getPageFromSuraAyah(suraAyah.sura, suraAyah.ayah))
     val bookmark = dao.bookmarks().single()
-    dao.updateBookmarkTags(longArrayOf(bookmark.id), setOf(firstTagId), deleteNonTagged = true)
+    dao.updateBookmarkTags(arrayOf(bookmark.id), setOf(firstTagId), deleteNonTagged = true)
 
-    dao.updateBookmarkTags(longArrayOf(bookmark.id), setOf(secondTagId), deleteNonTagged = false)
+    dao.updateBookmarkTags(arrayOf(bookmark.id), setOf(secondTagId), deleteNonTagged = false)
 
     assertThat(dao.bookmarks().single().tags).containsExactly(firstTagId, secondTagId)
   }
@@ -310,9 +337,9 @@ class BookmarksDaoImplTest {
     val suraAyah = SuraAyah(2, 255)
     dao.toggleAyahBookmark(suraAyah, quranInfo.getPageFromSuraAyah(suraAyah.sura, suraAyah.ayah))
     val bookmark = dao.bookmarks().single()
-    dao.updateBookmarkTags(longArrayOf(bookmark.id), setOf(tagId), deleteNonTagged = true)
+    dao.updateBookmarkTags(arrayOf(bookmark.id), setOf(tagId), deleteNonTagged = true)
 
-    dao.updateBookmarkTags(longArrayOf(bookmark.id), emptySet(), deleteNonTagged = true)
+    dao.updateBookmarkTags(arrayOf(bookmark.id), emptySet(), deleteNonTagged = true)
 
     val remainingBookmark = dao.bookmarks().single()
     assertThat(remainingBookmark.sura).isEqualTo(suraAyah.sura)
@@ -348,7 +375,7 @@ class BookmarksDaoImplTest {
     val suraAyah = SuraAyah(2, 255)
     dao.toggleAyahBookmark(suraAyah, quranInfo.getPageFromSuraAyah(suraAyah.sura, suraAyah.ayah))
     val bookmark = dao.bookmarks().single()
-    dao.updateBookmarkTags(longArrayOf(bookmark.id), setOf(firstTagId, secondTagId), deleteNonTagged = true)
+    dao.updateBookmarkTags(arrayOf(bookmark.id), setOf(firstTagId, secondTagId), deleteNonTagged = true)
 
     dao.removeBookmarkFromTag(bookmark, firstTagId)
 
@@ -361,7 +388,7 @@ class BookmarksDaoImplTest {
     val suraAyah = SuraAyah(2, 255)
     dao.toggleAyahBookmark(suraAyah, quranInfo.getPageFromSuraAyah(suraAyah.sura, suraAyah.ayah))
     val bookmark = dao.bookmarks().single()
-    dao.updateBookmarkTags(longArrayOf(bookmark.id), setOf(tagId), deleteNonTagged = true)
+    dao.updateBookmarkTags(arrayOf(bookmark.id), setOf(tagId), deleteNonTagged = true)
 
     dao.removeBookmarks(listOf(bookmark))
 
@@ -375,7 +402,7 @@ class BookmarksDaoImplTest {
     val suraAyah = SuraAyah(2, 255)
     dao.toggleAyahBookmark(suraAyah, quranInfo.getPageFromSuraAyah(suraAyah.sura, suraAyah.ayah))
     val bookmark = dao.bookmarks().single()
-    dao.updateBookmarkTags(longArrayOf(bookmark.id), setOf(tagId), deleteNonTagged = true)
+    dao.updateBookmarkTags(arrayOf(bookmark.id), setOf(tagId), deleteNonTagged = true)
 
     val removed = dao.toggleAyahBookmark(suraAyah, quranInfo.getPageFromSuraAyah(suraAyah.sura, suraAyah.ayah))
 
@@ -392,7 +419,7 @@ class BookmarksDaoImplTest {
     dao.toggleAyahBookmark(target, quranInfo.getPageFromSuraAyah(target.sura, target.ayah))
     dao.toggleAyahBookmark(other, quranInfo.getPageFromSuraAyah(other.sura, other.ayah))
     val targetBookmark = dao.bookmarks().first { it.sura == target.sura && it.ayah == target.ayah }
-    dao.updateBookmarkTags(longArrayOf(targetBookmark.id), setOf(tagId), deleteNonTagged = true)
+    dao.updateBookmarkTags(arrayOf(targetBookmark.id), setOf(tagId), deleteNonTagged = true)
 
     dao.removeBookmarksForPage(quranInfo.getPageFromSuraAyah(target.sura, target.ayah))
 
@@ -408,12 +435,12 @@ class BookmarksDaoImplTest {
     val newSuraAyah = SuraAyah(36, 1)
     dao.toggleAyahBookmark(oldSuraAyah, quranInfo.getPageFromSuraAyah(oldSuraAyah.sura, oldSuraAyah.ayah))
     val oldBookmark = dao.bookmarks().single()
-    dao.updateBookmarkTags(longArrayOf(oldBookmark.id), setOf(oldTagId), deleteNonTagged = true)
+    dao.updateBookmarkTags(arrayOf(oldBookmark.id), setOf(oldTagId), deleteNonTagged = true)
 
     dao.replaceAyahBookmarks(
       listOf(
         Bookmark(
-          id = 999,
+          id = "bookmark-999",
           sura = newSuraAyah.sura,
           ayah = newSuraAyah.ayah,
           page = quranInfo.getPageFromSuraAyah(newSuraAyah.sura, newSuraAyah.ayah),
@@ -435,11 +462,58 @@ class BookmarksDaoImplTest {
     val suraAyah = SuraAyah(2, 255)
     dao.toggleAyahBookmark(suraAyah, quranInfo.getPageFromSuraAyah(suraAyah.sura, suraAyah.ayah))
     val bookmark = dao.bookmarks().single()
-    dao.updateBookmarkTags(longArrayOf(bookmark.id), setOf(tagId), deleteNonTagged = true)
+    dao.updateBookmarkTags(arrayOf(bookmark.id), setOf(tagId), deleteNonTagged = true)
     localDataChangeNotifier.reset()
 
     dao.removeBookmarks(listOf(bookmark))
 
     assertThat(localDataChangeNotifier.updateCount).isEqualTo(1)
+  }
+
+  private class DefaultCollectionTestRepository(
+    timestamp: PlatformDateTime
+  ) : CollectionsRepository {
+    private val defaultCollection = SyncCollection(
+      name = "Default",
+      lastUpdated = timestamp,
+      localId = DEFAULT_BOOKMARK_COLLECTION_ID
+    )
+
+    var updateCount = 0
+      private set
+
+    override suspend fun getAllCollections(): List<SyncCollection> {
+      return listOf(defaultCollection)
+    }
+
+    override suspend fun addCollection(name: String): SyncCollection {
+      throw UnsupportedOperationException()
+    }
+
+    override suspend fun addCollection(name: String, timestamp: PlatformDateTime): SyncCollection {
+      throw UnsupportedOperationException()
+    }
+
+    override suspend fun updateCollection(localId: String, name: String): SyncCollection {
+      updateCount++
+      return defaultCollection.copy(name = name)
+    }
+
+    override suspend fun updateCollection(
+      localId: String,
+      name: String,
+      timestamp: PlatformDateTime
+    ): SyncCollection {
+      updateCount++
+      return defaultCollection.copy(name = name, lastUpdated = timestamp)
+    }
+
+    override suspend fun deleteCollection(localId: String): Boolean {
+      throw UnsupportedOperationException()
+    }
+
+    override fun getCollectionsFlow(): Flow<List<SyncCollection>> {
+      return flowOf(listOf(defaultCollection))
+    }
   }
 }

--- a/common/data/src/main/java/com/quran/data/dao/BookmarksDao.kt
+++ b/common/data/src/main/java/com/quran/data/dao/BookmarksDao.kt
@@ -19,24 +19,24 @@ interface BookmarksDao {
 
   suspend fun tags(): List<Tag>
   fun tagsFlow(): Flow<List<Tag>>
-  suspend fun addTag(name: String): Long
+  suspend fun addTag(name: String): String
   suspend fun updateTag(tag: Tag): Boolean
   suspend fun removeTags(tags: List<Tag>)
 
-  suspend fun getBookmarkTagIds(bookmarkId: Long): List<Long>
-  suspend fun getAyahBookmarkTagIds(suraAyah: SuraAyah): List<Long>
+  suspend fun getBookmarkTagIds(bookmarkId: String): List<String>
+  suspend fun getAyahBookmarkTagIds(suraAyah: SuraAyah): List<String>
   suspend fun updateBookmarkTags(
-    bookmarkIds: LongArray,
-    tagIds: Set<Long>,
+    bookmarkIds: Array<String>,
+    tagIds: Set<String>,
     deleteNonTagged: Boolean
   ): Boolean
   suspend fun updateAyahBookmarkTags(
     suraAyah: SuraAyah,
     page: Int,
-    tagIds: Set<Long>,
+    tagIds: Set<String>,
     deleteNonTagged: Boolean
   ): Boolean
-  suspend fun removeBookmarkFromTag(bookmark: Bookmark, tagId: Long): Boolean
+  suspend fun removeBookmarkFromTag(bookmark: Bookmark, tagId: String): Boolean
 
   suspend fun removeBookmarks(bookmarks: List<Bookmark>)
   suspend fun removeBookmarksForPage(page: Int)

--- a/common/data/src/main/java/com/quran/data/model/bookmark/Bookmark.kt
+++ b/common/data/src/main/java/com/quran/data/model/bookmark/Bookmark.kt
@@ -2,22 +2,33 @@ package com.quran.data.model.bookmark
 
 import com.squareup.moshi.JsonClass
 
+/**
+ * Converts numeric IDs from the deprecated bookmarks database and old backups into runtime string
+ * IDs. Bookmark IDs and tag IDs live in separate namespaces, so the stable string form can stay the
+ * original decimal value.
+ */
+object LegacyBookmarkIds {
+  fun bookmarkId(id: Long): String = id.toString()
+
+  fun tagId(id: Long): String = id.toString()
+}
+
 @JsonClass(generateAdapter = true)
 data class Bookmark @JvmOverloads constructor(
-  val id: Long,
+  val id: String,
   // sura and ayah are nullable for page bookmarks
   val sura: Int?,
   val ayah: Int?,
   val page: Int,
   val timestamp: Long = System.currentTimeMillis(),
-  val tags: List<Long> = emptyList(),
+  val tags: List<String> = emptyList(),
   val ayahText: String? = null
 ) {
 
   fun isPageBookmark() = sura == null && ayah == null
 
-  fun withTags(tagIds: List<Long>): Bookmark {
-    return this.copy(tags = mutableListOf<Long>().apply { addAll(tagIds) })
+  fun withTags(tagIds: List<String>): Bookmark {
+    return this.copy(tags = mutableListOf<String>().apply { addAll(tagIds) })
   }
 
   fun withAyahText(ayahText: String): Bookmark {

--- a/common/data/src/main/java/com/quran/data/model/bookmark/Tag.kt
+++ b/common/data/src/main/java/com/quran/data/model/bookmark/Tag.kt
@@ -3,4 +3,4 @@ package com.quran.data.model.bookmark
 import com.squareup.moshi.JsonClass
 
 @JsonClass(generateAdapter = true)
-data class Tag(val id: Long, val name: String)
+data class Tag(val id: String, val name: String)

--- a/common/test-utils/src/main/kotlin/com/quran/labs/test/TestDataFactory.kt
+++ b/common/test-utils/src/main/kotlin/com/quran/labs/test/TestDataFactory.kt
@@ -2,6 +2,7 @@ package com.quran.labs.test
 
 import com.quran.data.model.SuraAyah
 import com.quran.data.model.bookmark.Bookmark
+import com.quran.data.model.bookmark.LegacyBookmarkIds
 import com.quran.data.model.bookmark.RecentPage
 import com.quran.data.model.bookmark.Tag
 
@@ -79,7 +80,7 @@ object TestDataFactory {
   // ==================== Bookmark Factory ====================
 
   /**
-   * Creates a [Bookmark] for a specific ayah with default values.
+   * Creates a [Bookmark] for a specific ayah from legacy numeric IDs.
    */
   fun createBookmark(
     id: Long = 1L,
@@ -89,12 +90,12 @@ object TestDataFactory {
     timestamp: Long = System.currentTimeMillis(),
     tags: List<Long> = emptyList()
   ): Bookmark = Bookmark(
-    id = id,
+    id = LegacyBookmarkIds.bookmarkId(id),
     sura = sura,
     ayah = ayah,
     page = page,
     timestamp = timestamp,
-    tags = tags
+    tags = tags.map(LegacyBookmarkIds::tagId)
   )
 
   /**
@@ -105,7 +106,7 @@ object TestDataFactory {
     page: Int = 1,
     timestamp: Long = System.currentTimeMillis()
   ): Bookmark = Bookmark(
-    id = id,
+    id = LegacyBookmarkIds.bookmarkId(id),
     sura = null,
     ayah = null,
     page = page,
@@ -120,14 +121,14 @@ object TestDataFactory {
   fun createTag(
     id: Long = 1L,
     name: String = "Test Tag"
-  ): Tag = Tag(id, name)
+  ): Tag = Tag(LegacyBookmarkIds.tagId(id), name)
 
   /**
    * Creates multiple tags for testing.
    */
   fun createTags(count: Int): List<Tag> =
     (1..count).map { index ->
-      Tag(index.toLong(), "Tag $index")
+      Tag(LegacyBookmarkIds.tagId(index.toLong()), "Tag $index")
     }
 
   // ==================== RecentPage Factory ====================


### PR DESCRIPTION
Do not require numeric identifiers anymore and rely instead on using
whatever mobile-sync uses as identifiers.
