### PR TITLE
Remove the page from ayah page bookmarks

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/model/bookmark/BookmarkImportExportModel.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/model/bookmark/BookmarkImportExportModel.kt
@@ -13,6 +13,7 @@ import com.quran.data.model.bookmark.BookmarkData
 import com.quran.labs.androidquran.R
 import com.quran.mobile.bookmark.importdata.BookmarkBackupImportNormalizer
 import com.quran.mobile.bookmark.importdata.MobileSyncImporter
+import com.quran.mobile.bookmark.model.ReadingBookmarkPageMapper
 import com.quran.mobile.di.qualifier.ApplicationContext
 import dev.zacsweers.metro.Inject
 import io.reactivex.rxjava3.core.Observable
@@ -32,6 +33,7 @@ class BookmarkImportExportModel @Inject internal constructor(
   private val recentPagesDao: RecentPagesDao,
   private val readingBookmarksDao: ReadingBookmarksDao,
   private val settings: Settings,
+  private val pageMapper: ReadingBookmarkPageMapper,
   private val backupImportNormalizer: BookmarkBackupImportNormalizer,
   private val mobileSyncImporter: MobileSyncImporter
 ) {
@@ -97,14 +99,19 @@ class BookmarkImportExportModel @Inject internal constructor(
   private fun bookmarkDataWithRecentsObservable(): Single<BookmarkData> {
     return Single.fromCallable {
       runBlocking {
+        val pageType = pageMapper.currentPageType()
         BookmarkData(
           tags = bookmarksDao.tags(),
           bookmarks = bookmarksDao.bookmarks(BookmarkSortOrder.SORT_DATE_ADDED)
             .filterNot { bookmark -> bookmark.isPageBookmark() },
           recentPages = recentPagesDao.recentPages(),
           readingBookmark = readingBookmarksDao.readingBookmark()
-            ?.let(BackupReadingBookmark::fromReadingBookmark),
-          pageType = settings.pageType()
+            ?.let { bookmark ->
+              BackupReadingBookmark.fromReadingBookmark(bookmark) { sura, ayah ->
+                pageMapper.suraAyahToPage(sura, ayah, pageType)
+              }
+            },
+          pageType = pageType
         )
       }
     }.subscribeOn(Schedulers.io())

--- a/app/src/test/java/com/quran/labs/androidquran/model/bookmark/BookmarkImportExportModelTest.kt
+++ b/app/src/test/java/com/quran/labs/androidquran/model/bookmark/BookmarkImportExportModelTest.kt
@@ -7,6 +7,7 @@ import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.quran.data.core.QuranInfo
 import com.quran.data.dao.Settings
+import com.quran.data.model.bookmark.AyahReadingBookmark
 import com.quran.data.model.bookmark.BackupReadingBookmark
 import com.quran.data.model.bookmark.Bookmark
 import com.quran.data.model.bookmark.BookmarkData
@@ -76,6 +77,7 @@ class BookmarkImportExportModelTest {
       recentPagesDao,
       readingBookmarksDao,
       settings,
+      pageMapper,
       BookmarkBackupImportNormalizer(
         context,
         pageMapper,
@@ -175,6 +177,33 @@ class BookmarkImportExportModelTest {
   }
 
   @Test
+  fun testExportBookmarksWithAyahReadingBookmarkIncludesResolvedPage() {
+    val sura = 2
+    val ayah = 255
+    val page = quranInfo.getPageFromSuraAyah(sura, ayah)
+    readingBookmarksDao.setReadingBookmark(AyahReadingBookmark(sura, ayah, timestamp = 1234))
+
+    val testObserver = TestObserver<Uri>()
+    bookmarkImportExportModel.exportBookmarksObservable()
+      .subscribe(testObserver)
+    BaseTestExtension.awaitTerminalEvent(testObserver)
+
+    testObserver.assertNoErrors()
+    testObserver.assertValueCount(1)
+
+    val exportedData = BookmarkJsonModel().fromJson(backupFile().source().buffer())
+    assertThat(exportedData.readingBookmark).isEqualTo(
+      BackupReadingBookmark(
+        type = BackupReadingBookmark.TYPE_AYAH,
+        sura = sura,
+        ayah = ayah,
+        page = page,
+        timestamp = 1234
+      )
+    )
+  }
+
+  @Test
   fun testExportBookmarksCsvWithDataProducesUri() {
     bookmarksDao.setTags(listOf(Tag("1", "CSV Tag")))
     bookmarksDao.setBookmarks(
@@ -193,6 +222,23 @@ class BookmarkImportExportModelTest {
     assertThat(testObserver.values()[0]).isNotNull()
     assertThat(csvBackupFile().readText()).contains("recent,,, 12, 1000")
     assertThat(csvBackupFile().readText()).contains("reading_bookmark, null, null, 12, 999")
+  }
+
+  @Test
+  fun testExportBookmarksCsvWithAyahReadingBookmarkIncludesResolvedPage() {
+    val sura = 2
+    val ayah = 255
+    val page = quranInfo.getPageFromSuraAyah(sura, ayah)
+    readingBookmarksDao.setReadingBookmark(AyahReadingBookmark(sura, ayah, timestamp = 999))
+
+    val testObserver = TestObserver<Uri>()
+    bookmarkImportExportModel.exportBookmarksCSVObservable()
+      .subscribe(testObserver)
+    BaseTestExtension.awaitTerminalEvent(testObserver)
+
+    testObserver.assertNoErrors()
+    testObserver.assertValueCount(1)
+    assertThat(csvBackupFile().readText()).contains("reading_bookmark, 2, 255, $page, 999")
   }
 
   @Test

--- a/app/src/test/java/com/quran/labs/androidquran/presenter/QuranImportPresenterTest.kt
+++ b/app/src/test/java/com/quran/labs/androidquran/presenter/QuranImportPresenterTest.kt
@@ -56,6 +56,7 @@ class QuranImportPresenterTest {
       FakeRecentPagesDao(),
       FakeReadingBookmarksDao(),
       settings,
+      pageMapper,
       BookmarkBackupImportNormalizer(
         context,
         pageMapper,

--- a/app/src/test/kotlin/com/quran/labs/androidquran/fakes/FakeReadingBookmarksDao.kt
+++ b/app/src/test/kotlin/com/quran/labs/androidquran/fakes/FakeReadingBookmarksDao.kt
@@ -35,7 +35,6 @@ class FakeReadingBookmarksDao(
     readingBookmark.value = AyahReadingBookmark(
       sura = suraAyah.sura,
       ayah = suraAyah.ayah,
-      page = 1,
       timestamp = 1
     )
     return true

--- a/app/src/test/kotlin/com/quran/labs/androidquran/feature/reading/presenter/ReadingBookmarkPresenterTest.kt
+++ b/app/src/test/kotlin/com/quran/labs/androidquran/feature/reading/presenter/ReadingBookmarkPresenterTest.kt
@@ -54,7 +54,7 @@ class ReadingBookmarkPresenterTest {
 
   @Test
   fun `page icon is not selected for ayah reading bookmark on current page`() = runTest {
-    val readingBookmarksDao = FakeReadingBookmarksDao(AyahReadingBookmark(2, 255, 42, 1))
+    val readingBookmarksDao = FakeReadingBookmarksDao(AyahReadingBookmark(2, 255, timestamp = 1))
     val screen = RecordingScreen()
     val presenter = ReadingBookmarkPresenter(readingBookmarksDao)
 

--- a/common/bookmark/src/main/java/com/quran/mobile/bookmark/model/ReadingBookmarksDaoImpl.kt
+++ b/common/bookmark/src/main/java/com/quran/mobile/bookmark/model/ReadingBookmarksDaoImpl.kt
@@ -128,11 +128,9 @@ class ReadingBookmarksDaoImpl @Inject constructor(
   private fun toReadingBookmark(bookmark: SyncReadingBookmark?, pageType: String): ReadingBookmark? {
     return when (bookmark) {
       is SyncAyahReadingBookmark -> {
-        val page = pageMapper.suraAyahToPage(bookmark.sura, bookmark.ayah, pageType)
         AyahReadingBookmark(
           sura = bookmark.sura,
           ayah = bookmark.ayah,
-          page = page,
           timestamp = bookmark.lastUpdated.fromPlatform().toEpochMilliseconds() / 1000
         )
       }

--- a/common/bookmark/src/test/kotlin/com/quran/mobile/bookmark/model/ReadingBookmarksDaoImplTest.kt
+++ b/common/bookmark/src/test/kotlin/com/quran/mobile/bookmark/model/ReadingBookmarksDaoImplTest.kt
@@ -84,7 +84,7 @@ class ReadingBookmarksDaoImplTest {
   }
 
   @Test
-  fun `set ayah reading bookmark maps page from quran info`() = runTest {
+  fun `set ayah reading bookmark stores ayah reading bookmark`() = runTest {
     val suraAyah = SuraAyah(2, 255)
 
     dao.setAyahReadingBookmark(suraAyah)
@@ -92,7 +92,7 @@ class ReadingBookmarksDaoImplTest {
     val bookmark = dao.readingBookmark() as AyahReadingBookmark
     assertThat(bookmark.sura).isEqualTo(suraAyah.sura)
     assertThat(bookmark.ayah).isEqualTo(suraAyah.ayah)
-    assertThat(bookmark.page).isEqualTo(quranInfo.getPageFromSuraAyah(suraAyah.sura, suraAyah.ayah))
+    assertThat(bookmark.timestamp).isEqualTo(timestampProvider.timestampSeconds)
   }
 
   @Test

--- a/common/data/src/main/java/com/quran/data/model/bookmark/BackupReadingBookmark.kt
+++ b/common/data/src/main/java/com/quran/data/model/bookmark/BackupReadingBookmark.kt
@@ -17,13 +17,16 @@ data class BackupReadingBookmark(
     const val TYPE_AYAH = "ayah"
     const val TYPE_PAGE = "page"
 
-    fun fromReadingBookmark(readingBookmark: ReadingBookmark): BackupReadingBookmark {
+    fun fromReadingBookmark(
+      readingBookmark: ReadingBookmark,
+      ayahPageResolver: (sura: Int, ayah: Int) -> Int
+    ): BackupReadingBookmark {
       return when (readingBookmark) {
         is AyahReadingBookmark -> BackupReadingBookmark(
           type = TYPE_AYAH,
           sura = readingBookmark.sura,
           ayah = readingBookmark.ayah,
-          page = readingBookmark.page,
+          page = ayahPageResolver(readingBookmark.sura, readingBookmark.ayah),
           timestamp = readingBookmark.timestamp
         )
         is PageReadingBookmark -> BackupReadingBookmark(

--- a/common/data/src/main/java/com/quran/data/model/bookmark/ReadingBookmark.kt
+++ b/common/data/src/main/java/com/quran/data/model/bookmark/ReadingBookmark.kt
@@ -16,6 +16,5 @@ data class PageReadingBookmark(
 data class AyahReadingBookmark(
   val sura: Int,
   val ayah: Int,
-  val page: Int,
   override val timestamp: Long
 ) : ReadingBookmark


### PR DESCRIPTION
Today, ayah page bookmarks have the page bundled in. This is not
necessary, and, instead, this can be computed on demand instead.
