### PR TITLE
Fix reading bookmarks in ayah bookmark dialog

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/data/QuranDisplayData.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/data/QuranDisplayData.kt
@@ -98,6 +98,12 @@ class QuranDisplayData @Inject constructor(private val quranInfo: QuranInfo): Qu
     return getSuraAyahString(context, sura, ayah, R.string.sura_ayah_notification_str)
   }
 
+  override fun getSuraPageString(context: Context, page: Int): String {
+    val suraName = getSuraNameFromPage(context, page, wantTitle = true)
+    val pageText = context.getString(R.string.quran_page) + ' ' + QuranUtils.getLocalizedNumber(page)
+    return if (suraName.isEmpty()) pageText else "$suraName ($pageText)"
+  }
+
   fun getSuraAyahString(context: Context, sura: Int, ayah: Int, @StringRes resource: Int): String {
     val suraName = getSuraName(context, sura, wantPrefix = false, wantTranslation = false)
     return context.getString(resource, suraName, ayah)
@@ -179,7 +185,7 @@ class QuranDisplayData @Inject constructor(private val quranInfo: QuranInfo): Qu
   }
 
   // do not remove the nullable return type
-  fun getSuraNameString(context: Context, page: Int): String? {
+  fun getSuraNameString(context: Context, page: Int): String {
     return context.getString(R.string.quran_sura_title, getSuraNameFromPage(context, page))
   }
 

--- a/common/pages/src/main/java/com/quran/page/common/data/QuranNaming.kt
+++ b/common/pages/src/main/java/com/quran/page/common/data/QuranNaming.kt
@@ -6,4 +6,5 @@ interface QuranNaming {
   fun getSuraName(context: Context, sura: Int, wantPrefix: Boolean = true): String
   fun getSuraNameWithNumber(context: Context, sura: Int, wantPrefix: Boolean): String
   fun getSuraAyahString(context: Context, sura: Int, ayah: Int): String
+  fun getSuraPageString(context: Context, page: Int): String
 }

--- a/feature/ayahbookmark/src/main/kotlin/com/quran/mobile/feature/ayahbookmark/presenter/AyahBookmarkPresenter.kt
+++ b/feature/ayahbookmark/src/main/kotlin/com/quran/mobile/feature/ayahbookmark/presenter/AyahBookmarkPresenter.kt
@@ -1,5 +1,6 @@
 package com.quran.mobile.feature.ayahbookmark.presenter
 
+import android.content.Context
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -11,6 +12,7 @@ import com.quran.data.dao.ReadingBookmarksDao
 import com.quran.data.di.AppCoroutineScope
 import com.quran.data.model.SuraAyah
 import com.quran.data.model.bookmark.AyahReadingBookmark
+import com.quran.data.model.bookmark.PageReadingBookmark
 import com.quran.data.model.bookmark.ReadingBookmark
 import com.quran.mobile.feature.ayahbookmark.state.AyahBookmarkCollectionCreationState
 import com.quran.mobile.feature.ayahbookmark.state.AyahBookmarkCollectionItem
@@ -189,7 +191,7 @@ class AyahBookmarkPresenter(
     return AyahBookmarkState(
       ayah = currentAyah,
       isReadingBookmarkEnabled = isReadingBookmarkEnabledState.value,
-      currentReadingBookmark = readingBookmark.value.asSuraAyah(),
+      currentReadingBookmark = readingBookmark.value,
       collections = collections,
       collectionCreation = collectionCreationState.value,
       showLastPlaceWarning = showLastPlaceWarningState.value,
@@ -197,6 +199,7 @@ class AyahBookmarkPresenter(
       isDismissed = isDismissed.value,
       showRemoveBookmarkButton = hasPersistedBookmark,
       suraAyahNameResolver = { context, ayah -> quranNaming.getSuraAyahString(context, ayah.sura, ayah.ayah) },
+      readingBookmarkNameResolver = { context, bookmark -> quranNaming.getReadingBookmarkString(context, bookmark) },
       eventSink = eventSink
     )
   }
@@ -206,6 +209,13 @@ class AyahBookmarkPresenter(
       SuraAyah(this.sura, this.ayah)
     } else {
       null
+    }
+  }
+
+  private fun QuranNaming.getReadingBookmarkString(context: Context, bookmark: ReadingBookmark): String {
+    return when (bookmark) {
+      is AyahReadingBookmark -> getSuraAyahString(context, bookmark.sura, bookmark.ayah)
+      is PageReadingBookmark -> getSuraPageString(context, bookmark.page)
     }
   }
 

--- a/feature/ayahbookmark/src/main/kotlin/com/quran/mobile/feature/ayahbookmark/state/AyahBookmarkState.kt
+++ b/feature/ayahbookmark/src/main/kotlin/com/quran/mobile/feature/ayahbookmark/state/AyahBookmarkState.kt
@@ -3,6 +3,7 @@ package com.quran.mobile.feature.ayahbookmark.state
 import android.content.Context
 import androidx.compose.runtime.Immutable
 import com.quran.data.model.SuraAyah
+import com.quran.data.model.bookmark.ReadingBookmark
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 
@@ -10,7 +11,7 @@ import kotlinx.collections.immutable.persistentListOf
 data class AyahBookmarkState(
   val ayah: SuraAyah,
   val isReadingBookmarkEnabled: Boolean,
-  val currentReadingBookmark: SuraAyah? = null,
+  val currentReadingBookmark: ReadingBookmark? = null,
   val collections: ImmutableList<AyahBookmarkCollectionItem> = persistentListOf(),
   val collectionCreation: AyahBookmarkCollectionCreationState = AyahBookmarkCollectionCreationState.Inactive,
   val showLastPlaceWarning: Boolean = false,
@@ -18,6 +19,7 @@ data class AyahBookmarkState(
   val isBookmarkRemoved: Boolean = false,
   val isDismissed: Boolean = false,
   val suraAyahNameResolver: (Context, SuraAyah) -> String,
+  val readingBookmarkNameResolver: (Context, ReadingBookmark) -> String,
   val eventSink: (AyahBookmarkEvent) -> Unit = {}
 )
 

--- a/feature/ayahbookmark/src/main/kotlin/com/quran/mobile/feature/ayahbookmark/ui/AyahBookmark.kt
+++ b/feature/ayahbookmark/src/main/kotlin/com/quran/mobile/feature/ayahbookmark/ui/AyahBookmark.kt
@@ -13,6 +13,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.quran.data.model.SuraAyah
+import com.quran.data.model.bookmark.AyahReadingBookmark
+import com.quran.data.model.bookmark.PageReadingBookmark
+import com.quran.data.model.bookmark.ReadingBookmark
 import com.quran.labs.androidquran.common.ui.core.QuranTheme
 import com.quran.mobile.feature.ayahbookmark.state.AyahBookmarkCollectionCreationState
 import com.quran.mobile.feature.ayahbookmark.state.AyahBookmarkCollectionItem
@@ -50,6 +53,13 @@ private val previewSuraAyahNameResolver: (Context, SuraAyah) -> String = { _, su
   "An-Nisāʾ ${suraAyah.ayah}"
 }
 
+private val previewReadingBookmarkNameResolver: (Context, ReadingBookmark) -> String = { _, bookmark ->
+  when (bookmark) {
+    is AyahReadingBookmark -> "An-Nisāʾ ${bookmark.ayah}"
+    is PageReadingBookmark -> "An-Nisāʾ (Page ${bookmark.page})"
+  }
+}
+
 private val previewCollections = persistentListOf(
   AyahBookmarkCollectionItem(id = "family", name = "Family", countLabel = 12, isChecked = true),
   AyahBookmarkCollectionItem(id = "favorites", name = "Favorites", countLabel = 34, isChecked = false),
@@ -79,9 +89,10 @@ private fun AyahBookmarkDefaultPreview() {
     state = AyahBookmarkState(
       ayah = SuraAyah(4, 1),
       isReadingBookmarkEnabled = true,
-      currentReadingBookmark = SuraAyah(4, 34),
+      currentReadingBookmark = AyahReadingBookmark(sura = 4, ayah = 34, timestamp = 0),
       collections = previewCollections,
-      suraAyahNameResolver = previewSuraAyahNameResolver
+      suraAyahNameResolver = previewSuraAyahNameResolver,
+      readingBookmarkNameResolver = previewReadingBookmarkNameResolver
     )
   )
 }
@@ -93,10 +104,11 @@ private fun AyahBookmarkWarningPreview() {
     state = AyahBookmarkState(
       ayah = SuraAyah(4, 1),
       isReadingBookmarkEnabled = false,
-      currentReadingBookmark = SuraAyah(4, 34),
+      currentReadingBookmark = PageReadingBookmark(page = 83, timestamp = 0),
       collections = previewCollections.replacingAt(0, previewCollections[0].copy(isChecked = false)),
       showLastPlaceWarning = true,
-      suraAyahNameResolver = previewSuraAyahNameResolver
+      suraAyahNameResolver = previewSuraAyahNameResolver,
+      readingBookmarkNameResolver = previewReadingBookmarkNameResolver
     )
   )
 }
@@ -110,7 +122,8 @@ private fun AyahBookmarkCreatingCollectionPreview() {
       isReadingBookmarkEnabled = true,
       collections = previewCollections,
       collectionCreation = AyahBookmarkCollectionCreationState.Active(name = "Qiyam"),
-      suraAyahNameResolver = previewSuraAyahNameResolver
+      suraAyahNameResolver = previewSuraAyahNameResolver,
+      readingBookmarkNameResolver = previewReadingBookmarkNameResolver
     )
   )
 }
@@ -124,7 +137,8 @@ private fun AyahBookmarkCreatingCollectionSubmittingPreview() {
       isReadingBookmarkEnabled = true,
       collections = previewCollections,
       collectionCreation = AyahBookmarkCollectionCreationState.Active(name = "Qiyam", isSubmitting = true),
-      suraAyahNameResolver = previewSuraAyahNameResolver
+      suraAyahNameResolver = previewSuraAyahNameResolver,
+      readingBookmarkNameResolver = previewReadingBookmarkNameResolver
     )
   )
 }
@@ -138,7 +152,8 @@ private fun AyahBookmarkRemovedPreview() {
       isReadingBookmarkEnabled = false,
       collections = previewCollections,
       isBookmarkRemoved = true,
-      suraAyahNameResolver = previewSuraAyahNameResolver
+      suraAyahNameResolver = previewSuraAyahNameResolver,
+      readingBookmarkNameResolver = previewReadingBookmarkNameResolver
     )
   )
 }

--- a/feature/ayahbookmark/src/main/kotlin/com/quran/mobile/feature/ayahbookmark/ui/AyahBookmarkSheet.kt
+++ b/feature/ayahbookmark/src/main/kotlin/com/quran/mobile/feature/ayahbookmark/ui/AyahBookmarkSheet.kt
@@ -36,11 +36,11 @@ internal fun AyahBookmarkSheet(
   val eventSink = state.eventSink
 
   val context = LocalContext.current
-  val suraAyahName = remember(state.ayah) {
+  val suraAyahName = remember(context, state.ayah) {
     state.suraAyahNameResolver(context, state.ayah)
   }
-  val currentReadingBookmarkName = remember(state.currentReadingBookmark) {
-    state.currentReadingBookmark?.let { state.suraAyahNameResolver(context, it) }
+  val currentReadingBookmarkName = remember(context, state.currentReadingBookmark) {
+    state.currentReadingBookmark?.let { state.readingBookmarkNameResolver(context, it) }
   }
 
   Column(


### PR DESCRIPTION
Reading bookmarks may be page bookmarks or ayah bookmarks. Previously,
the dialog assumed ayah bookmarks only. This patch fixes this.
