### PR TITLE
Add pause-between-verses playback option

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/feature/reading/presenter/AudioPresenter.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/feature/reading/presenter/AudioPresenter.kt
@@ -40,7 +40,8 @@ constructor(
     rangeRepeat: Int,
     enforceRange: Boolean,
     playbackSpeed: Float,
-    shouldStream: Boolean
+    shouldStream: Boolean,
+    pauseBetweenAyahs: Int = 0
   ) {
     val audioPathInfo = getLocalAudioPathInfo(qari)
     if (audioPathInfo != null) {
@@ -84,7 +85,8 @@ constructor(
         enforceRange,
         playbackSpeed,
         stream,
-        audioPath
+        audioPath,
+        pauseBetweenAyahs = pauseBetweenAyahs
       )
       play(audioRequest)
     }

--- a/app/src/main/java/com/quran/labs/androidquran/service/AudioService.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/service/AudioService.kt
@@ -128,6 +128,10 @@ class AudioService : Service(), Player.Listener {
   // should we stop (after preparing is done) or not
   private var shouldStop = false
 
+  // true while waiting out a deliberate pause-between-ayahs gap, so that the
+  // ExoPlayer pause/end callbacks don't flip our state to Paused during it
+  private var isPausingBetweenAyahs = false
+
   // The ID we use for the notification (the onscreen alert that appears
   // at the notification area at the top of the screen as an icon -- and
   // as text as well if the user expands the notification area).
@@ -175,11 +179,24 @@ class AudioService : Service(), Player.Listener {
 
   private inner class ServiceHandler(looper: Looper) : Handler(looper) {
     override fun handleMessage(msg: Message) {
-      if (msg.what == MSG_INCOMING && msg.obj != null) {
-        val intent = msg.obj as Intent
-        handleIntent(intent)
-      } else if (msg.what == MSG_UPDATE_AUDIO_POS) {
-        updateAudioPlayPosition()
+      when (msg.what) {
+        MSG_INCOMING -> {
+          if (msg.obj != null) {
+            handleIntent(msg.obj as Intent)
+          }
+        }
+        MSG_UPDATE_AUDIO_POS -> updateAudioPlayPosition()
+        MSG_PLAY_NEXT_AYAH -> {
+          isPausingBetweenAyahs = false
+          val playRepeatSep = msg.arg1 == 1
+          playAudio(playRepeatSep)
+        }
+        MSG_RESUME_AFTER_PAUSE -> {
+          isPausingBetweenAyahs = false
+          if (player != null) {
+            configAndStartExoPlayer()
+          }
+        }
       }
     }
   }
@@ -516,6 +533,17 @@ class AudioService : Service(), Player.Listener {
 
         // moved on to next ayah
         updateNotification()
+
+        // pause between ayahs for gapless playback
+        val pauseBetweenAyahs = audioRequest?.pauseBetweenAyahs ?: 0
+        if (pauseBetweenAyahs > 0) {
+          serviceHandler.removeMessages(MSG_UPDATE_AUDIO_POS)
+          notifyAyahChanged()
+          isPausingBetweenAyahs = true
+          localPlayer.pause()
+          serviceHandler.sendEmptyMessageDelayed(MSG_RESUME_AFTER_PAUSE, pauseBetweenAyahs * 1000L)
+          return
+        }
       } else {
         // if we have end of sura info and we bypassed end of sura
         // line, switch the sura.
@@ -607,7 +635,20 @@ class AudioService : Service(), Player.Listener {
     }
   }
 
+  // cancel any pending pause-between-ayahs gap (used when the user manually
+  // plays/pauses/skips/rewinds so the gap doesn't fire afterwards)
+  private fun cancelPauseBetweenAyahs() {
+    isPausingBetweenAyahs = false
+    serviceHandler.removeMessages(MSG_PLAY_NEXT_AYAH)
+    serviceHandler.removeMessages(MSG_RESUME_AFTER_PAUSE)
+  }
+
   private fun processPlayRequest() {
+    // remove any pending pause-between-ayahs messages when user manually plays.
+    // during a gap, state is still Playing, so treat it like a paused resume.
+    val wasPausingBetweenAyahs = isPausingBetweenAyahs
+    cancelPauseBetweenAyahs()
+
     val localAudioRequest = audioRequest
     val localAudioQueue = audioQueue
     if (localAudioRequest == null || localAudioQueue == null) {
@@ -619,19 +660,26 @@ class AudioService : Service(), Player.Listener {
     if (State.Stopped == state) {
       // If we're stopped, just go ahead to the next file and start playing
       playAudio(localAudioQueue.getCurrentSura() == 9 && localAudioQueue.getCurrentAyah() == 1)
-    } else if (State.Paused == state) {
+    } else if (State.Paused == state || wasPausingBetweenAyahs) {
       // If we're paused, just continue playback and restore the
       // 'foreground service' state.
       state = State.Playing
       if (!isSetupAsForeground) {
         setUpAsForeground()
       }
-      configAndStartExoPlayer()
+      // handle pause-between-ayahs: player may be in STATE_ENDED (gapped)
+      // in which case we need to load the next file instead of resuming current
+      if (player?.playbackState == Player.STATE_ENDED) {
+        playAudio(localAudioQueue.getCurrentSura() == 9 && localAudioQueue.getCurrentAyah() == 1)
+      } else {
+        configAndStartExoPlayer()
+      }
       updateAudioPlaybackStatus()
     }
   }
 
   private fun processPauseRequest() {
+    cancelPauseBetweenAyahs()
     if (State.Playing == state) {
       // Pause exo player and cancel the 'foreground service' state.
       state = State.Paused
@@ -653,6 +701,7 @@ class AudioService : Service(), Player.Listener {
   }
 
   private fun processRewindRequest() {
+    cancelPauseBetweenAyahs()
     if (State.Playing == state || State.Paused == state) {
       setState(PlaybackStateCompat.STATE_REWINDING)
       val localPlayer = player ?: return
@@ -666,7 +715,7 @@ class AudioService : Service(), Player.Listener {
         pos -= seekTo
       }
 
-      if (pos > 1500 && !playerOverride) {
+      if (pos > 1500 && !playerOverride && localPlayer.playbackState != Player.STATE_ENDED) {
         localPlayer.seekTo(seekTo)
         state = State.Playing // in case we were paused
       } else {
@@ -697,6 +746,7 @@ class AudioService : Service(), Player.Listener {
     if (audioRequest == null) {
       return
     }
+    cancelPauseBetweenAyahs()
     if (State.Playing == state || State.Paused == state) {
       setState(PlaybackStateCompat.STATE_SKIPPING_TO_NEXT)
       if (playerOverride) {
@@ -724,6 +774,7 @@ class AudioService : Service(), Player.Listener {
 
   private fun processStopRequest(force: Boolean = false) {
     setState(PlaybackStateCompat.STATE_STOPPED)
+    isPausingBetweenAyahs = false
     serviceHandler.removeMessages(MSG_UPDATE_AUDIO_POS)
     currentWord = null
     if (State.Preparing == state) {
@@ -1062,6 +1113,10 @@ class AudioService : Service(), Player.Listener {
 
   // Called when the player starts or stops playing
   override fun onIsPlayingChanged(isPlaying: Boolean) {
+    // Ignore the pause/resume that bracket a deliberate pause-between-ayahs gap
+    if (isPausingBetweenAyahs) {
+      return
+    }
     // Ensure UI stays in sync with actual ExoPlayer state changes
     // Only update state if it's a legitimate transition
     if (isPlaying && state == State.Paused) {
@@ -1124,7 +1179,16 @@ class AudioService : Service(), Player.Listener {
           // sura changed, then play the basmala if the ayah is
           // not the first one (or if we're in sura tawba).
           val flag = beforeSura != localAudioQueue.getCurrentSura()
-          playAudio(flag)
+          val pauseDuration = localAudioRequest.pauseBetweenAyahs
+          if (pauseDuration > 0) {
+            // delay playback for pause between ayahs
+            isPausingBetweenAyahs = true
+            val msg = serviceHandler.obtainMessage(MSG_PLAY_NEXT_AYAH)
+            msg.arg1 = if (flag) 1 else 0
+            serviceHandler.sendMessageDelayed(msg, pauseDuration * 1000L)
+          } else {
+            playAudio(flag)
+          }
         }
       } else {
         processStopRequest(true)
@@ -1374,6 +1438,8 @@ class AudioService : Service(), Player.Listener {
     private const val NOTIFICATION_CHANNEL_ID = Constants.AUDIO_CHANNEL
     private const val MSG_INCOMING = 1
     private const val MSG_UPDATE_AUDIO_POS = 2
+    private const val MSG_PLAY_NEXT_AYAH = 3
+    private const val MSG_RESUME_AFTER_PAUSE = 4
     private const val DEBUG_TIMINGS = false
 
     // 5 minutes

--- a/app/src/main/java/com/quran/labs/androidquran/ui/PagerActivity.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/PagerActivity.kt
@@ -1488,7 +1488,7 @@ class PagerActivity : AppCompatActivity(), AudioBarListener, OnBookmarkTagsUpdat
     val end = selectionEnd
     // handle the case of multiple ayat being selected and play them as a range if so
     val ending = if ((end == null || start == end || start.after(end))) null else end
-    playFromAyah(start, ending, page, 0, 0, ending != null, 1.0f)
+    playFromAyah(start, ending, page, 0, 0, ending != null, 1.0f, 0)
   }
 
   fun playFromAyah(
@@ -1498,7 +1498,8 @@ class PagerActivity : AppCompatActivity(), AudioBarListener, OnBookmarkTagsUpdat
     verseRepeat: Int,
     rangeRepeat: Int,
     enforceRange: Boolean,
-    playbackSpeed: Float
+    playbackSpeed: Float,
+    pauseBetweenAyahs: Int = 0
   ) {
     val ending = end
       ?: audioUtils.getLastAyahToPlay(
@@ -1522,7 +1523,8 @@ class PagerActivity : AppCompatActivity(), AudioBarListener, OnBookmarkTagsUpdat
         rangeRepeat,
         enforceRange,
         playbackSpeed,
-        shouldStream
+        shouldStream,
+        pauseBetweenAyahs
       )
     }
   }
@@ -1667,7 +1669,8 @@ class PagerActivity : AppCompatActivity(), AudioBarListener, OnBookmarkTagsUpdat
     rangeRepeat: Int,
     verseRepeat: Int,
     enforceRange: Boolean,
-    playbackSpeed: Float
+    playbackSpeed: Float,
+    pauseBetweenAyahs: Int = 0
   ): Boolean {
     val lastAudioRequest = audioStatusRepositoryBridge.audioRequest()
     if (lastAudioRequest != null) {
@@ -1675,7 +1678,8 @@ class PagerActivity : AppCompatActivity(), AudioBarListener, OnBookmarkTagsUpdat
         repeatInfo = verseRepeat,
         rangeRepeatInfo = rangeRepeat,
         enforceBounds = enforceRange,
-        playbackSpeed = playbackSpeed
+        playbackSpeed = playbackSpeed,
+        pauseBetweenAyahs = pauseBetweenAyahs
       )
       val i = Intent(this, AudioService::class.java)
       i.setAction(AudioService.ACTION_UPDATE_SETTINGS)

--- a/app/src/main/java/com/quran/labs/androidquran/ui/fragment/AyahPlaybackFragment.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/fragment/AyahPlaybackFragment.kt
@@ -37,6 +37,7 @@ class AyahPlaybackFragment : AyahActionFragment() {
   private var rangeRepeatCount = 0
   private var verseRepeatCount = 0
   private var currentSpeed = 1.0f
+  private var currentPause = 0
 
   private lateinit var applyButton: Button
   private lateinit var startSuraSpinner: QuranSpinner
@@ -46,6 +47,7 @@ class AyahPlaybackFragment : AyahActionFragment() {
   private lateinit var repeatVersePicker: NumberPicker
   private lateinit var repeatRangePicker: NumberPicker
   private lateinit var playbackSpeedPicker: NumberPicker
+  private lateinit var pauseBetweenAyahsPicker: NumberPicker
   private lateinit var restrictToRange: CheckBox
 
   private lateinit var startAyahAdapter: ArrayAdapter<CharSequence>
@@ -80,6 +82,7 @@ class AyahPlaybackFragment : AyahActionFragment() {
     repeatVersePicker = view.findViewById(R.id.repeat_verse_picker)
     repeatRangePicker = view.findViewById(R.id.repeat_range_picker)
     playbackSpeedPicker = view.findViewById(R.id.playback_speed_picker)
+    pauseBetweenAyahsPicker = view.findViewById(R.id.pause_between_verses_picker)
 
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
       val speedArea = view.findViewById<View>(R.id.playback_speed_area)
@@ -96,7 +99,7 @@ class AyahPlaybackFragment : AyahActionFragment() {
     values[MAX_REPEATS] = getString(UiCoreR.string.infinity)
     val isArabicNames = locale.language == "ar"
     if (isArabicNames) {
-      listOf(repeatVersePicker, repeatRangePicker, playbackSpeedPicker).forEach {
+      listOf(repeatVersePicker, repeatRangePicker, playbackSpeedPicker, pauseBetweenAyahsPicker).forEach {
         it.formatter = NumberPicker.Formatter { value: Int -> arFormat(value) }
         val typeface = TypefaceManager.getHeaderFooterTypeface(context)
         it.typeface = typeface
@@ -118,6 +121,11 @@ class AyahPlaybackFragment : AyahActionFragment() {
     playbackSpeedPicker.maxValue = SPEEDS.size
     playbackSpeedPicker.displayedValues = SPEEDS.map { numberFormat.format(it) }.toTypedArray()
     playbackSpeedPicker.value = DEFAULT_SPEED_INDEX + 1
+    val pauseValues = Array(MAX_PAUSE + 1) { i -> numberFormat.format(i.toLong()) }
+    pauseBetweenAyahsPicker.minValue = 1
+    pauseBetweenAyahsPicker.maxValue = MAX_PAUSE + 1
+    pauseBetweenAyahsPicker.displayedValues = pauseValues
+    pauseBetweenAyahsPicker.value = 1
     repeatRangePicker.setOnValueChangedListener { _: NumberPicker?, _: Int, newVal: Int ->
       if (newVal > 1) {
         // whenever we want to repeat the range, we have to enable restrictToRange
@@ -196,20 +204,21 @@ class AyahPlaybackFragment : AyahActionFragment() {
       var updatedRange = false
 
       val speed = SPEEDS[playbackSpeedPicker.value - 1]
+      val pauseBetweenAyahs = pauseBetweenAyahsPicker.value - 1
       if (currentStart != decidedStart || currentEnding != decidedEnd) {
         // different range or not playing, so make a new request
         updatedRange = true
         context.playFromAyah(
           currentStart, currentEnding, page, verseRepeat,
-          rangeRepeat, enforceRange, speed
+          rangeRepeat, enforceRange, speed, pauseBetweenAyahs
         )
-      } else if (shouldEnforce != enforceRange || rangeRepeatCount != rangeRepeat || verseRepeatCount != verseRepeat || currentSpeed != speed) {
+      } else if (shouldEnforce != enforceRange || rangeRepeatCount != rangeRepeat || verseRepeatCount != verseRepeat || currentSpeed != speed || pauseBetweenAyahs != currentPause) {
         // can just update repeat settings
-        if (!context.updatePlayOptions(rangeRepeat, verseRepeat, enforceRange, speed)
+        if (!context.updatePlayOptions(rangeRepeat, verseRepeat, enforceRange, speed, pauseBetweenAyahs)
         ) {
           // audio stopped in the process, let's start it
           context.playFromAyah(
-            currentStart, currentEnding, page, verseRepeat, rangeRepeat, enforceRange, speed
+            currentStart, currentEnding, page, verseRepeat, rangeRepeat, enforceRange, speed, pauseBetweenAyahs
           )
         }
       }
@@ -310,6 +319,7 @@ class AyahPlaybackFragment : AyahActionFragment() {
           verseRepeatCount = lastRequest.repeatInfo
           rangeRepeatCount = lastRequest.rangeRepeatInfo
           currentSpeed = lastRequest.playbackSpeed
+          currentPause = lastRequest.pauseBetweenAyahs
           shouldEnforce = lastRequest.enforceBounds
         } else {
           shouldReset = false
@@ -332,6 +342,7 @@ class AyahPlaybackFragment : AyahActionFragment() {
         rangeRepeatCount = 0
         verseRepeatCount = 0
         currentSpeed = 1.0f
+        currentPause = 0
         decidedStart = null
         decidedEnd = null
         applyButton.setText(R.string.play_apply_and_play)
@@ -356,6 +367,7 @@ class AyahPlaybackFragment : AyahActionFragment() {
         repeatRangePicker.value = rangeRepeatCount + 1
         repeatVersePicker.value = verseRepeatCount + 1
         playbackSpeedPicker.value = SPEEDS.indexOf(currentSpeed) + 1
+        pauseBetweenAyahsPicker.value = currentPause + 1
       }
     }
   }
@@ -364,6 +376,7 @@ class AyahPlaybackFragment : AyahActionFragment() {
     private val ITEM_LAYOUT = R.layout.sherlock_spinner_item
     private val ITEM_DROPDOWN_LAYOUT = R.layout.sherlock_spinner_dropdown_item
     private const val MAX_REPEATS = 25
+    private const val MAX_PAUSE = 25
     private val SPEEDS = listOf(0.5f, 0.75f, 1.0f, 1.25f, 1.5f)
     private const val DEFAULT_SPEED_INDEX = 2
   }

--- a/app/src/main/res/layout-ar-land/audio_panel.xml
+++ b/app/src/main/res/layout-ar-land/audio_panel.xml
@@ -86,6 +86,7 @@
       <include layout="@layout/play_set_of_verses" />
       <include layout="@layout/play_each_verse" />
       <include layout="@layout/playback_speed" />
+      <include layout="@layout/pause_between_verses" />
 
       <CheckBox
           android:id="@+id/restrict_to_range"

--- a/app/src/main/res/layout-ar/audio_panel.xml
+++ b/app/src/main/res/layout-ar/audio_panel.xml
@@ -64,6 +64,7 @@
     <include layout="@layout/play_set_of_verses" />
     <include layout="@layout/play_each_verse" />
     <include layout="@layout/playback_speed" />
+    <include layout="@layout/pause_between_verses" />
 
     <CheckBox
         android:id="@+id/restrict_to_range"

--- a/app/src/main/res/layout-land/audio_panel.xml
+++ b/app/src/main/res/layout-land/audio_panel.xml
@@ -86,6 +86,7 @@
       <include layout="@layout/play_set_of_verses" />
       <include layout="@layout/play_each_verse" />
       <include layout="@layout/playback_speed" />
+      <include layout="@layout/pause_between_verses" />
 
       <CheckBox
           android:id="@+id/restrict_to_range"

--- a/app/src/main/res/layout/audio_panel.xml
+++ b/app/src/main/res/layout/audio_panel.xml
@@ -64,6 +64,7 @@
     <include layout="@layout/play_set_of_verses" />
     <include layout="@layout/play_each_verse" />
     <include layout="@layout/playback_speed" />
+    <include layout="@layout/pause_between_verses" />
 
     <CheckBox
         android:id="@+id/restrict_to_range"

--- a/app/src/main/res/layout/pause_between_verses.xml
+++ b/app/src/main/res/layout/pause_between_verses.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal"
+    >
+  <TextView
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:layout_gravity="center_vertical"
+      android:text="@string/pause_between_verses"
+      android:textAppearance="@style/PanelLabel"
+      />
+  <com.shawnlin.numberpicker.NumberPicker
+      android:id="@+id/pause_between_verses_picker"
+      android:layout_width="120dp"
+      android:layout_height="wrap_content"
+      android:layout_gravity="center_vertical"
+      app:np_orientation="horizontal"
+      app:np_width="135dp"
+      app:np_height="40dp"
+      app:np_max="25"
+      app:np_value="3"
+      app:np_min="1"
+      app:np_textSize="21sp"
+      app:np_textColor="@color/inactive"
+      app:np_selectedTextSize="24sp"
+      app:np_selectedTextColor="@color/panel_label"
+      app:np_dividerColor="@color/panel_label"
+      app:np_dividerType="underline"
+      app:np_fadingEdgeEnabled="true"
+      app:np_wrapSelectorWheel="true"
+      />
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -343,6 +343,7 @@
   <string name="stop">Stop</string>
   <string name="next">Next</string>
   <string name="playback_speed">Playback Speed:</string>
+  <string name="pause_between_verses">Pause between verses:</string>
 
   <string-array name="repeatValues">
     <item>1 time</item>

--- a/common/audio/src/main/java/com/quran/labs/androidquran/common/audio/model/playback/AudioRequest.kt
+++ b/common/audio/src/main/java/com/quran/labs/androidquran/common/audio/model/playback/AudioRequest.kt
@@ -15,7 +15,8 @@ data class AudioRequest(val start: SuraAyah,
                         val playbackSpeed: Float = 1f,
                         val shouldStream: Boolean,
                         val audioPathInfo: AudioPathInfo,
-                        val wordHighlighting: Boolean = false
+                        val wordHighlighting: Boolean = false,
+                        val pauseBetweenAyahs: Int = 0
 ) : Parcelable {
   fun isGapless() = qari.isGapless
   fun needsIsti3athaAudio() =


### PR DESCRIPTION
## Summary

Adds a configurable pause duration between ayahs during audio playback. The motivation is to give reciters time to repeat each verse aloud after it plays — useful for memorization and recitation practice.

- New pause duration option in the audio panel's playback settings (`AyahPlaybackFragment`), plumbed through `AudioRequest` into `AudioService`.
- `AudioService` honors the configured gap between verses during gapped playback.
- Fixes a media-session flicker where the inter-verse gap briefly reported a Paused state to the media session.

## Test plan

- Play a sura with pause-between-verses set to various durations; verify the gap between ayahs matches.
- Verify default (no pause) behavior is unchanged.
- Verify media session / notification no longer flickers Paused during the inter-verse gap.


https://github.com/user-attachments/assets/ace01fa8-a5f7-420c-9f40-d50003ab150e

