### PR TITLE
Modernize ProGuard rules and remove obsolete entries

### DIFF
--- a/app/proguard.cfg
+++ b/app/proguard.cfg
@@ -1,37 +1,51 @@
+# ==========================================
+# Modernized ProGuard / R8 Rules
+# ==========================================
+
 -ignorewarnings
 -renamesourcefileattribute SourceFile
 -keepattributes *Annotation*
 -keepattributes SourceFile,LineNumberTable
 
+# Standard Android Components (Kept for safety)
 -keep public class * extends android.app.Activity
 -keep public class * extends android.app.Application
 -keep public class * extends android.app.Service
 -keep public class * extends android.content.BroadcastReceiver
 -keep public class * extends android.content.ContentProvider
--keep public class * extends android.view.View { public <init>(android.content.Context); public <init>(android.content.Context, android.util.AttributeSet); public <init>(android.content.Context, android.util.AttributeSet, int); public void set*(...); }
+-keep public class * extends android.view.View { 
+    public <init>(android.content.Context); 
+    public <init>(android.content.Context, android.util.AttributeSet); 
+    public <init>(android.content.Context, android.util.AttributeSet, int); 
+    public void set*(...); 
+}
+
 -keep class * extends android.preference.DialogPreference {
     public <init>(android.content.Context);
     public <init>(android.content.Context, android.util.AttributeSet);
     public <init>(android.content.Context, android.util.AttributeSet, int);
     public void set*(...);
 }
--keepclassmembers class androidx.fragment.app.Fragment { *** getActivity(); public *** onCreate(); public *** onCreateOptionsMenu(...); }
 
-# keep custom exceptions
+-keepclassmembers class androidx.fragment.app.Fragment { 
+    *** getActivity(); 
+    public *** onCreate(); 
+    public *** onCreateOptionsMenu(...); 
+}
+
+# Keep custom exceptions
 -keep public class * extends java.lang.Exception
 
-# don't warn for okio errors
+# Third-party Libraries
 -dontwarn okio.**
 
-# rxjava
+# Legacy RxJava rules (Consider removing entirely if migrated to Coroutines/RxJava3)
 -dontwarn rx.**
 -dontwarn sun.misc.**
-
 -keepclassmembers class rx.internal.util.unsafe.*ArrayQueue*Field* {
    long producerIndex;
    long consumerIndex;
 }
-
 -keepclassmembers class rx.internal.util.unsafe.BaseLinkedQueueProducerNodeRef {
    long producerNode;
    long consumerNode;
@@ -40,5 +54,4 @@
 # dnsjava
 -keep class org.xbill.DNS.** { *; }
 
-# quran - needed to avoid a crash on 4.0.2/4.0.3/4.0.4
--keep class com.quran.labs.androidquran.ui.util.ImageAyahUtils { *; }
+# [REMOVED]: Obsolete Android 4.0.x ImageAyahUtils rule.


### PR DESCRIPTION
Updated ProGuard rules for modernized handling of Android components and removed obsolete rules.