### PR TITLE
fix(ci): harden privileged Android workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  # Required to read baseline artifacts from the post-merge workflow.
+  actions: read
+  contents: read
+
 jobs:
   build:
     name: Validate PR
@@ -16,16 +21,18 @@ jobs:
     if: github.event_name != 'merge_group'
     steps:
       - name: Checkout the Code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup JDK
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
         with:
           distribution: zulu
           java-version-file: .github/workflows/.java-version
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v6
+        uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6
 
       - name: Build debug APK
         run: ./gradlew assembleMadaniDebug
@@ -34,7 +41,7 @@ jobs:
         run: ./gradlew lintMadaniDebug
 
       - name: Upload lint results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: failure()
         with:
           name: lint_report
@@ -48,7 +55,7 @@ jobs:
         run: ./gradlew testMadaniDebug testReleaseUnitTest -PdisableFirebase
 
       - name: Upload test report
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: failure()
         with:
           name: unit_test_report
@@ -56,7 +63,7 @@ jobs:
           retention-days: 3
 
       - name: Download Previous Debug APK
-        uses: dawidd6/action-download-artifact@v24
+        uses: dawidd6/action-download-artifact@d63b86af1b34672e53c440b1b83979861906bad7 # v24
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           workflow: post_merge.yml
@@ -71,7 +78,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload Apk Diff Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: success()
         with:
           name: apk_differences
@@ -82,7 +89,7 @@ jobs:
         run: ./gradlew :app:dependencies --configuration madaniReleaseRuntimeClasspath > current_dependencies.txt
 
       - name: Download Previous Dependencies List
-        uses: dawidd6/action-download-artifact@v24
+        uses: dawidd6/action-download-artifact@d63b86af1b34672e53c440b1b83979861906bad7 # v24
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           workflow: post_merge.yml
@@ -97,22 +104,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload Dependency Diff Results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: success()
         with:
           name: dependency_differences
           path: difference.txt
-          retention-days: 1
-
-      - name: Write the PR Number
-        run: |
-          echo ${{ github.event.number }} > pr.txt
-
-      - name: Upload PR Number
-        uses: actions/upload-artifact@v7
-        with:
-          name: pr
-          path: pr.txt
           retention-days: 1
 
 env:

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -3,6 +3,13 @@ on:
   pull_request:
   merge_group:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Merge
@@ -10,16 +17,18 @@ jobs:
     if: github.event_name != 'pull_request'
     steps:
       - name: Checkout the Code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup JDK
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
         with:
           distribution: zulu
           java-version-file: .github/workflows/.java-version
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v6
+        uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6
 
       - name: Build debug APK
         run: ./gradlew assembleMadaniDebug

--- a/.github/workflows/post_build.yml
+++ b/.github/workflows/post_build.yml
@@ -6,48 +6,50 @@ on:
     types:
       - completed
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.id }}
+  cancel-in-progress: true
+
+permissions: {}
+
 jobs:
   comment:
     name: Comment on Pull Request
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    timeout-minutes: 10
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.pull_requests[0].number != null
+    permissions:
+      # Required to read artifacts produced by the unprivileged PR workflow.
+      actions: read
+      contents: read
+      # This job only posts the generated reports back to the originating PR.
+      pull-requests: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+      PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
     steps:
-      - name: Download PR Number
-        uses: dawidd6/action-download-artifact@v24
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          run_id: ${{ github.event.workflow_run.id }}
-          workflow: build.yml
-          name: pr
-
       - name: Download Apk Diff Results
-        uses: dawidd6/action-download-artifact@v24
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          run_id: ${{ github.event.workflow_run.id }}
-          workflow: build.yml
+          github-token: ${{ github.token }}
+          run-id: ${{ github.event.workflow_run.id }}
           name: apk_differences
 
       - name: Comment with Apk Diff Results
-        run: |
-          export PR=`cat pr.txt | head -1`
-          gh pr -R quran/quran_android comment $PR -F apk_differences_summary.txt
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr --repo "$GITHUB_REPOSITORY" comment "$PR_NUMBER" --body-file apk_differences_summary.txt
 
       - name: Download Dependency Diff Results
-        uses: dawidd6/action-download-artifact@v24
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          run_id: ${{ github.event.workflow_run.id }}
-          workflow: build.yml
+          github-token: ${{ github.token }}
+          run-id: ${{ github.event.workflow_run.id }}
           name: dependency_differences
 
       - name: Comment with Dependency Diff Results
         run: |
           if [ -s difference.txt ]; then
-            export PR=`cat pr.txt | head -1`
-            gh pr -R quran/quran_android comment $PR -F difference.txt
+            gh pr --repo "$GITHUB_REPOSITORY" comment "$PR_NUMBER" --body-file difference.txt
           fi
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/post_merge.yml
+++ b/.github/workflows/post_merge.yml
@@ -9,28 +9,33 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   apkdeps:
     name: Build
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the Code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup JDK
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
         with:
           distribution: zulu
           java-version-file: .github/workflows/.java-version
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v6
+        uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6
 
       - name: Build debug Apk
         run: ./gradlew assembleDebug
 
       - name: Upload Debug Apk
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: success()
         with:
           name: latest-apk
@@ -40,7 +45,7 @@ jobs:
         run: ./gradlew :app:dependencies --configuration madaniReleaseRuntimeClasspath > dependencies.txt
 
       - name: Upload dependencies list
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: success()
         with:
           name: dependencies


### PR DESCRIPTION
## Summary

- replace the artifact-controlled PR number with `workflow_run.pull_requests` metadata
- restrict the privileged comment job to `actions: read`, `contents: read`, and `pull-requests: write`
- replace third-party cross-run artifact downloads with the pinned official action
- SHA-pin every external action and disable persisted checkout credentials
- add concurrency limits to the follow-up workflows

## Security model

The `workflow_run` job still has permission to comment, but it never checks out or executes pull-request code. Downloaded artifacts are only passed to `gh pr comment` as body files; they cannot select the target PR or enter a shell command.

## Validation

- `nix run nixpkgs#actionlint -- -color=false .github/workflows/*.yml`
- `nix run nixpkgs#zizmor -- --pedantic --min-severity high --min-confidence high .` — no findings
