### PR TITLE
fix: correct French sura name

### DIFF
--- a/common/ui/core/src/main/res/values-fr/sura_names.xml
+++ b/common/ui/core/src/main/res/values-fr/sura_names.xml
@@ -142,7 +142,7 @@
     <item>Le pélerinage</item>
     <item>Les croyants</item>
     <item>La lumière</item>
-    <item>TLe discernement</item>
+    <item>Le discernement</item>
     <item>Les poètes</item>
     <item>Les fourmis</item>
     <item>Le récit</item>


### PR DESCRIPTION
## Summary
- correct the French name for Al-Furqan from TLe discernement to Le discernement

## Validation
- xmllint --noout common/ui/core/src/main/res/values-fr/sura_names.xml
- git diff --check