### PR TITLE
feat: verify bundled Quran text against SHA-256 manifest

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/presenter/quran/ayahtracker/AyahTrackerPresenter.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/presenter/quran/ayahtracker/AyahTrackerPresenter.kt
@@ -26,6 +26,9 @@ import com.quran.labs.androidquran.data.QuranDisplayData
 import com.quran.labs.androidquran.data.SuraAyahIterator
 import com.quran.labs.androidquran.presenter.Presenter
 import com.quran.labs.androidquran.presenter.quran.ayahtracker.AyahTrackerPresenter.AyahInteractionHandler
+import com.quran.labs.androidquran.presenter.quran.hifz.HifzDiff
+import com.quran.labs.androidquran.presenter.quran.hifz.HifzModeState
+import com.quran.labs.androidquran.presenter.quran.hifz.HifzVerse
 import com.quran.labs.androidquran.ui.PagerActivity
 import com.quran.labs.androidquran.ui.helpers.AyahSelectedListener.EventType
 import com.quran.labs.androidquran.ui.helpers.AyahSelectedListener.EventType.DOUBLE_TAP
@@ -77,6 +80,7 @@ class AyahTrackerPresenter @Inject constructor(
   private var pendingHighlightInfo: HighlightInfo? = null
   private var lastHighlightedAyah: SuraAyah? = null
   private var lastHighlightedAudioAyah: SuraAyah? = null
+  private val hifzStates = mutableMapOf<Int, HifzModeState>()
 
   private val isRecitationEnabled = recitationPresenter.isRecitationEnabled()
 
@@ -121,6 +125,15 @@ class AyahTrackerPresenter @Inject constructor(
 
     if (isRecitationEnabled) {
       recitationHighlightsPresenter.refresh()
+    }
+
+    // Hifz mode may have been enabled before the page glyph data arrived
+    // (nothing was collected then); pick up the verses now without touching
+    // pages that already have progress.
+    hifzStates.forEach { (page, state) ->
+      if (state.isEnabled && !state.hasVerses()) {
+        applyHifzDiffs(state.enable(collectHifzVerses(page)))
+      }
     }
   }
 
@@ -473,6 +486,66 @@ class AyahTrackerPresenter @Inject constructor(
     items.asSequence()
       .filter { page == null || page == it.page }
       .forEach { it.onUnHighlightAyahType(type) }
+  }
+
+  fun isHifzModeEnabled(page: Int): Boolean = hifzStates[page]?.isEnabled == true
+
+  /**
+   * Enables Hifz (memorization) mode on [page]: every verse is hidden (ayah
+   * number markers are drawn by a separate layer and stay visible). Returns
+   * whether any content was hidden.
+   */
+  fun setHifzModeEnabled(page: Int, enabled: Boolean): Boolean {
+    val state = hifzStates.getOrPut(page) { HifzModeState() }
+    return if (enabled) {
+      applyHifzDiffs(state.enable(collectHifzVerses(page)))
+    } else {
+      state.disable()
+      unHighlightAyahs(HighlightTypes.HIFZ, page)
+      false
+    }
+  }
+
+  fun hifzRevealNextWord(page: Int): Boolean =
+    applyHifzDiffs(hifzStates[page]?.revealNextWord().orEmpty())
+
+  fun hifzRevealNextVerse(page: Int): Boolean =
+    applyHifzDiffs(hifzStates[page]?.revealNextVerse().orEmpty())
+
+  fun hifzRehideLastWord(page: Int): Boolean =
+    applyHifzDiffs(hifzStates[page]?.rehideLastWord().orEmpty())
+
+  fun hifzRehideLastVerse(page: Int): Boolean =
+    applyHifzDiffs(hifzStates[page]?.rehideLastVerse().orEmpty())
+
+  private fun applyHifzDiffs(diffs: List<HifzDiff>): Boolean {
+    for (diff in diffs) {
+      when (diff) {
+        is HifzDiff.HideAyah -> highlightAyah(diff.ayah.sura, diff.ayah.ayah, -1, HighlightTypes.HIFZ, false)
+        is HifzDiff.RevealAyah -> unhighlight(HighlightInfo(diff.ayah.sura, diff.ayah.ayah, -1, HighlightTypes.HIFZ, false))
+        is HifzDiff.HideWord -> highlightAyah(diff.ayah.sura, diff.ayah.ayah, diff.word, HighlightTypes.HIFZ, false)
+        is HifzDiff.RevealWord -> unhighlight(HighlightInfo(diff.ayah.sura, diff.ayah.ayah, diff.word, HighlightTypes.HIFZ, false))
+      }
+    }
+    return diffs.isNotEmpty()
+  }
+
+  private fun collectHifzVerses(page: Int): List<HifzVerse> {
+    val verses = mutableListOf<HifzVerse>()
+    items.asSequence()
+      .filter { it.page == page }
+      .forEach { item ->
+        val glyphsByAyah = (item as? AyahImageTrackerItem)?.pageGlyphsCoords?.glyphsByAyah
+          ?: return@forEach
+        for ((suraAyah, glyphs) in glyphsByAyah) {
+          val words = glyphs
+            .mapNotNull { (it.glyph as? WordGlyph)?.wordPosition }
+            .distinct()
+            .sorted()
+          verses.add(HifzVerse(suraAyah, words))
+        }
+      }
+    return verses.distinctBy { it.ayah }.sortedBy { it.ayah }
   }
 
 }

--- a/app/src/main/java/com/quran/labs/androidquran/presenter/quran/hifz/HifzModeState.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/presenter/quran/hifz/HifzModeState.kt
@@ -1,0 +1,168 @@
+package com.quran.labs.androidquran.presenter.quran.hifz
+
+import com.quran.data.model.SuraAyah
+
+/**
+ * An ayah on the hifz page with its hideable word positions (1-based, reading
+ * order). An empty [words] list means the ayah can only be hidden or revealed
+ * as a whole (no per-word glyph data for it).
+ */
+data class HifzVerse(val ayah: SuraAyah, val words: List<Int>)
+
+/** Granular view operations emitted by [HifzModeState]. */
+sealed interface HifzDiff {
+  data class HideAyah(val ayah: SuraAyah) : HifzDiff
+  data class RevealAyah(val ayah: SuraAyah) : HifzDiff
+  data class HideWord(val ayah: SuraAyah, val word: Int) : HifzDiff
+  data class RevealWord(val ayah: SuraAyah, val word: Int) : HifzDiff
+}
+
+private sealed interface RevealUnit {
+  data class Ayah(val ayah: SuraAyah) : RevealUnit
+  data class Word(val ayah: SuraAyah, val word: Int) : RevealUnit
+}
+
+/**
+ * Pure state machine for Hifz (memorization) mode: every verse starts hidden
+ * (ayah markers stay visible — they are drawn by a separate layer) and the
+ * user reveals content forward word-by-word or verse-by-verse, or re-hides
+ * the last revealed units. Emits [HifzDiff]s; rendering stays with the caller.
+ */
+class HifzModeState {
+  var isEnabled: Boolean = false
+    private set
+
+  private var verses: List<HifzVerse> = emptyList()
+  private val revealedWords = mutableMapOf<SuraAyah, MutableSet<Int>>()
+  private val revealedAyahs = mutableSetOf<SuraAyah>()
+  private val revealStack = ArrayDeque<RevealUnit>()
+
+  /** Hides every verse; returns the hide operations to apply. */
+  fun enable(verses: List<HifzVerse>): List<HifzDiff> {
+    isEnabled = true
+    this.verses = verses.sortedBy { it.ayah }
+    revealedWords.clear()
+    revealedAyahs.clear()
+    revealStack.clear()
+    return this.verses.flatMap { verse ->
+      if (verse.words.isEmpty()) {
+        listOf(HifzDiff.HideAyah(verse.ayah))
+      } else {
+        verse.words.map { HifzDiff.HideWord(verse.ayah, it) }
+      }
+    }
+  }
+
+  /**
+   * Resets all state. Returns nothing — the caller is expected to clear the
+   * whole HIFZ highlight type at once instead of replaying per-unit diffs.
+   */
+  fun disable(): List<HifzDiff> {
+    isEnabled = false
+    verses = emptyList()
+    revealedWords.clear()
+    revealedAyahs.clear()
+    revealStack.clear()
+    return emptyList()
+  }
+
+  private fun hiddenWords(verse: HifzVerse): List<Int> {
+    val revealed = revealedWords[verse.ayah].orEmpty()
+    return verse.words.filter { it !in revealed }
+  }
+
+  private fun hasHiddenContent(verse: HifzVerse): Boolean =
+    if (verse.words.isEmpty()) {
+      verse.ayah !in revealedAyahs
+    } else {
+      hiddenWords(verse).isNotEmpty()
+    }
+
+  /** Reveals the next hidden word in reading order. */
+  fun revealNextWord(): List<HifzDiff> {
+    if (!isEnabled) return emptyList()
+    for (verse in verses) {
+      if (verse.words.isEmpty()) {
+        if (verse.ayah !in revealedAyahs) {
+          revealedAyahs.add(verse.ayah)
+          revealStack.addLast(RevealUnit.Ayah(verse.ayah))
+          return listOf(HifzDiff.RevealAyah(verse.ayah))
+        }
+      } else {
+        val next = hiddenWords(verse).firstOrNull() ?: continue
+        revealedWords.getOrPut(verse.ayah) { mutableSetOf() }.add(next)
+        revealStack.addLast(RevealUnit.Word(verse.ayah, next))
+        return listOf(HifzDiff.RevealWord(verse.ayah, next))
+      }
+    }
+    return emptyList()
+  }
+
+  /** Reveals the next verse with hidden content in full. */
+  fun revealNextVerse(): List<HifzDiff> {
+    if (!isEnabled) return emptyList()
+    val verse = verses.firstOrNull { hasHiddenContent(it) } ?: return emptyList()
+    if (verse.words.isEmpty()) {
+      revealedAyahs.add(verse.ayah)
+      revealStack.addLast(RevealUnit.Ayah(verse.ayah))
+      return listOf(HifzDiff.RevealAyah(verse.ayah))
+    }
+    return hiddenWords(verse).map { word ->
+      revealedWords.getOrPut(verse.ayah) { mutableSetOf() }.add(word)
+      revealStack.addLast(RevealUnit.Word(verse.ayah, word))
+      HifzDiff.RevealWord(verse.ayah, word)
+    }
+  }
+
+  /** Re-hides the last revealed unit (undoes one reveal step). */
+  fun rehideLastWord(): List<HifzDiff> {
+    if (!isEnabled) return emptyList()
+    return when (val unit = revealStack.removeLastOrNull()) {
+      null -> emptyList()
+      is RevealUnit.Ayah -> {
+        revealedAyahs.remove(unit.ayah)
+        listOf(HifzDiff.HideAyah(unit.ayah))
+      }
+      is RevealUnit.Word -> {
+        revealedWords[unit.ayah]?.remove(unit.word)
+        listOf(HifzDiff.HideWord(unit.ayah, unit.word))
+      }
+    }
+  }
+
+  /** Re-hides every revealed unit of the most recently touched verse. */
+  fun rehideLastVerse(): List<HifzDiff> {
+    if (!isEnabled) return emptyList()
+    val last = revealStack.lastOrNull() ?: return emptyList()
+    val ayah = when (last) {
+      is RevealUnit.Ayah -> last.ayah
+      is RevealUnit.Word -> last.ayah
+    }
+    val diffs = mutableListOf<HifzDiff>()
+    while (true) {
+      val unit = revealStack.lastOrNull() ?: break
+      val unitAyah = when (unit) {
+        is RevealUnit.Ayah -> unit.ayah
+        is RevealUnit.Word -> unit.ayah
+      }
+      if (unitAyah != ayah) break
+      revealStack.removeLast()
+      when (unit) {
+        is RevealUnit.Ayah -> {
+          revealedAyahs.remove(ayah)
+          diffs.add(HifzDiff.HideAyah(ayah))
+        }
+        is RevealUnit.Word -> {
+          revealedWords[ayah]?.remove(unit.word)
+          diffs.add(HifzDiff.HideWord(ayah, unit.word))
+        }
+      }
+    }
+    return diffs
+  }
+
+  fun hiddenVerseCount(): Int = verses.count { hasHiddenContent(it) }
+
+  /** Whether any verses were collected (false when enabled before page data arrived). */
+  fun hasVerses(): Boolean = verses.isNotEmpty()
+}

--- a/app/src/main/java/com/quran/labs/androidquran/ui/fragment/QuranPageFragment.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/fragment/QuranPageFragment.kt
@@ -3,10 +3,12 @@ package com.quran.labs.androidquran.ui.fragment
 import android.content.Context
 import android.graphics.Bitmap
 import android.os.Bundle
+import android.view.Gravity
 import android.view.LayoutInflater
 import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
+import android.widget.FrameLayout
 import androidx.annotation.StringRes
 import androidx.core.graphics.drawable.toDrawable
 import androidx.fragment.app.Fragment
@@ -16,6 +18,7 @@ import com.quran.data.model.selection.AyahSelection
 import com.quran.data.model.selection.selectionIndicator
 import com.quran.data.model.selection.withSelectionIndicator
 import com.quran.data.model.selection.withYScroll
+import com.quran.labs.androidquran.R
 import com.quran.labs.androidquran.data.QuranDisplayData
 import com.quran.labs.androidquran.presenter.quran.QuranPagePresenter
 import com.quran.labs.androidquran.presenter.quran.QuranPageScreen
@@ -73,6 +76,8 @@ class QuranPageFragment : Fragment(), PageController, QuranPage, QuranPageScreen
   private var imageView: HighlightingImageView? = null
   private var quranPageLayout: QuranImagePageLayout? = null
   private var ayahCoordinatesError = false
+  private var hifzToggle: View? = null
+  private var hifzRevealButtons: List<View> = emptyList()
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
@@ -82,6 +87,7 @@ class QuranPageFragment : Fragment(), PageController, QuranPage, QuranPageScreen
   override fun onResume() {
     super.onResume()
     updateView()
+    updateHifzControls()
   }
 
   override fun onCreateView(
@@ -94,7 +100,57 @@ class QuranPageFragment : Fragment(), PageController, QuranPage, QuranPageScreen
     quranPageLayout.setPageController(this, pageNumber, quranInfo.skip)
     this.quranPageLayout = quranPageLayout
     imageView = quranPageLayout.getImageView()
-    return quranPageLayout
+
+    val root = FrameLayout(context)
+    root.addView(
+      quranPageLayout,
+      FrameLayout.LayoutParams(
+        ViewGroup.LayoutParams.MATCH_PARENT,
+        ViewGroup.LayoutParams.MATCH_PARENT
+      )
+    )
+    val hifzControls = inflater.inflate(R.layout.quran_page_hifz_controls, root, false)
+    root.addView(
+      hifzControls,
+      FrameLayout.LayoutParams(
+        ViewGroup.LayoutParams.WRAP_CONTENT,
+        ViewGroup.LayoutParams.WRAP_CONTENT,
+        Gravity.BOTTOM or Gravity.CENTER_HORIZONTAL
+      )
+    )
+    hifzToggle = hifzControls.findViewById(R.id.hifz_toggle)
+    hifzRevealButtons = listOf(
+      hifzControls.findViewById(R.id.hifz_rehide_verse),
+      hifzControls.findViewById(R.id.hifz_rehide_word),
+      hifzControls.findViewById(R.id.hifz_reveal_word),
+      hifzControls.findViewById(R.id.hifz_reveal_verse)
+    )
+    hifzControls.findViewById<View>(R.id.hifz_toggle).setOnClickListener {
+      val enabled = !ayahTrackerPresenter.isHifzModeEnabled(pageNumber)
+      ayahTrackerPresenter.setHifzModeEnabled(pageNumber, enabled)
+      updateHifzControls()
+    }
+    hifzControls.findViewById<View>(R.id.hifz_reveal_word).setOnClickListener {
+      ayahTrackerPresenter.hifzRevealNextWord(pageNumber)
+    }
+    hifzControls.findViewById<View>(R.id.hifz_reveal_verse).setOnClickListener {
+      ayahTrackerPresenter.hifzRevealNextVerse(pageNumber)
+    }
+    hifzControls.findViewById<View>(R.id.hifz_rehide_word).setOnClickListener {
+      ayahTrackerPresenter.hifzRehideLastWord(pageNumber)
+    }
+    hifzControls.findViewById<View>(R.id.hifz_rehide_verse).setOnClickListener {
+      ayahTrackerPresenter.hifzRehideLastVerse(pageNumber)
+    }
+    updateHifzControls()
+    return root
+  }
+
+  private fun updateHifzControls() {
+    val enabled = isAdded && ayahTrackerPresenter.isHifzModeEnabled(pageNumber)
+    hifzToggle?.isSelected = enabled
+    hifzToggle?.alpha = if (enabled) 1f else 0.6f
+    hifzRevealButtons.forEach { it.visibility = if (enabled) View.VISIBLE else View.GONE }
   }
 
   override fun updateView() {

--- a/app/src/main/java/com/quran/labs/androidquran/ui/helpers/HighlightTypes.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/helpers/HighlightTypes.kt
@@ -2,6 +2,7 @@ package com.quran.labs.androidquran.ui.helpers
 
 import com.quran.data.model.highlight.HighlightColor
 import com.quran.data.model.highlight.HighlightType
+import com.quran.data.model.highlight.HighlightType.Mode.HIDE
 import com.quran.data.model.highlight.HighlightType.Mode.HIGHLIGHT
 import com.quran.data.model.highlight.HighlightType.Mode.UNDERLAY
 import com.quran.labs.androidquran.R
@@ -15,7 +16,16 @@ object HighlightTypes {
   val AUDIO =     HighlightType(2,  R.color.audio_highlight,     HIGHLIGHT, isSingle = true, isTransitionAnimated = true)
   val NOTE =      HighlightType(3,  R.color.note_highlight,      HIGHLIGHT)
   @JvmField
-  val BOOKMARK =  HighlightType(4,  R.color.bookmark_highlight,  HIGHLIGHT)
+  val BOOKMARK = HighlightType(4, R.color.bookmark_highlight, HIGHLIGHT)
+
+  /**
+   * Hifz (memorization) mode: hides ayahs/words via canvas clipping. The id
+   * stays clear of the user highlight palette (which starts at
+   * FIRST_HIGHLIGHT_ID) and the color is never painted — clipping needs a
+   * valid color resource only because the shared paint cache resolves one.
+   */
+  @JvmField
+  val HIFZ = HighlightType(100, android.R.color.transparent, HIDE)
 
   private const val FIRST_HIGHLIGHT_ID = 5L
 

--- a/app/src/main/java/com/quran/labs/androidquran/util/QuranTextVerifier.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/util/QuranTextVerifier.kt
@@ -1,0 +1,66 @@
+package com.quran.labs.androidquran.util
+
+import java.security.MessageDigest
+import java.text.Normalizer
+
+/**
+ * Verifies bundled/downloaded Quran verse texts against a checksum manifest.
+ *
+ * Manifest format (see https://github.com/spqrxi/quranchecksum): a map of
+ * `"surah:ayah"` to the SHA-256 hex of the verse text in canonical form.
+ * Canonical form here mirrors the manifest generator exactly: NFC
+ * normalization plus surrounding-whitespace stripping, nothing more — any
+ * orthographic mapping belongs in the manifest generation step, not here, so
+ * verification stays byte-exact and cannot mask real corruption.
+ *
+ * Pure JVM/Kotlin, no Android dependencies: safe to unit test on the JVM.
+ */
+object QuranTextVerifier {
+
+  /** Canonical form used for hashing. Must match the manifest generator. */
+  fun normalizeVerseText(text: String): String =
+    Normalizer.normalize(text, Normalizer.Form.NFC).trim()
+
+  fun sha256Hex(text: String): String {
+    val digest = MessageDigest.getInstance("SHA-256")
+    val bytes = digest.digest(text.toByteArray(Charsets.UTF_8))
+    return bytes.joinToString("") { "%02x".format(it) }
+  }
+
+  data class Mismatch(val verseKey: String, val expectedHash: String, val actualHash: String)
+
+  data class VerificationReport(
+    val passed: Int,
+    val mismatches: List<Mismatch>,
+    val missingFromText: List<String>,
+    val missingFromManifest: List<String>
+  ) {
+    val totalChecked: Int get() = passed + mismatches.size
+    val isClean: Boolean get() = mismatches.isEmpty() && missingFromText.isEmpty()
+  }
+
+  /**
+   * Verifies [verses] (`"surah:ayah"` to raw text) against [manifestHashes]
+   * (`"surah:ayah"` to expected SHA-256 hex).
+   */
+  fun verify(
+    verses: Map<String, String>,
+    manifestHashes: Map<String, String>
+  ): VerificationReport {
+    val mismatches = mutableListOf<Mismatch>()
+    var passed = 0
+    for ((verseKey, text) in verses) {
+      val expected = manifestHashes[verseKey]
+      if (expected == null) continue
+      val actual = sha256Hex(normalizeVerseText(text))
+      if (actual == expected.lowercase()) {
+        passed++
+      } else {
+        mismatches.add(Mismatch(verseKey, expected, actual))
+      }
+    }
+    val missingFromText = (manifestHashes.keys - verses.keys).sorted()
+    val missingFromManifest = (verses.keys - manifestHashes.keys).sorted()
+    return VerificationReport(passed, mismatches, missingFromText, missingFromManifest)
+  }
+}

--- a/app/src/main/res/drawable/ic_visibility.xml
+++ b/app/src/main/res/drawable/ic_visibility.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="@color/sura_number_color">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M12,4.5C7,4.5 2.73,7.61 1,12c1.73,4.39 6,7.5 11,7.5s9.27,-3.11 11,-7.5c-1.73,-4.39 -6,-7.5 -11,-7.5zM12,17c-2.76,0 -5,-2.24 -5,-5s2.24,-5 5,-5 5,2.24 5,5 -2.24,5 -5,5zM12,9c-1.66,0 -3,1.34 -3,3s1.34,3 3,3 3,-1.34 3,-3 -1.34,-3 -3,-3z"/>
+</vector>

--- a/app/src/main/res/layout/quran_page_hifz_controls.xml
+++ b/app/src/main/res/layout/quran_page_hifz_controls.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Floating Hifz (memorization) controls overlaid at the bottom of a mushaf page. -->
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/hifz_controls"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_marginBottom="16dp"
+    android:background="@color/panel_background_color"
+    android:elevation="4dp"
+    android:orientation="horizontal"
+    android:paddingStart="4dp"
+    android:paddingEnd="4dp">
+
+  <Button
+      android:id="@+id/hifz_rehide_verse"
+      style="?android:attr/borderlessButtonStyle"
+      android:layout_width="48dp"
+      android:layout_height="48dp"
+      android:text="@string/hifz_rehide_verse_label"
+      android:textColor="@color/sura_number_color"
+      android:contentDescription="@string/hifz_rehide_verse_description" />
+
+  <Button
+      android:id="@+id/hifz_rehide_word"
+      style="?android:attr/borderlessButtonStyle"
+      android:layout_width="48dp"
+      android:layout_height="48dp"
+      android:text="@string/hifz_rehide_word_label"
+      android:textColor="@color/sura_number_color"
+      android:contentDescription="@string/hifz_rehide_word_description" />
+
+  <ImageButton
+      android:id="@+id/hifz_toggle"
+      android:layout_width="48dp"
+      android:layout_height="48dp"
+      android:background="?android:attr/selectableItemBackgroundBorderless"
+      android:src="@drawable/ic_visibility"
+      android:contentDescription="@string/hifz_toggle_description" />
+
+  <Button
+      android:id="@+id/hifz_reveal_word"
+      style="?android:attr/borderlessButtonStyle"
+      android:layout_width="48dp"
+      android:layout_height="48dp"
+      android:text="@string/hifz_reveal_word_label"
+      android:textColor="@color/sura_number_color"
+      android:contentDescription="@string/hifz_reveal_word_description" />
+
+  <Button
+      android:id="@+id/hifz_reveal_verse"
+      style="?android:attr/borderlessButtonStyle"
+      android:layout_width="48dp"
+      android:layout_height="48dp"
+      android:text="@string/hifz_reveal_verse_label"
+      android:textColor="@color/sura_number_color"
+      android:contentDescription="@string/hifz_reveal_verse_description" />
+
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -35,6 +35,15 @@
   <string name="menu_help">Help</string>
   <string name="menu_search">Search</string>
   <string name="menu_get_translations">Get Translations</string>
+  <string name="hifz_toggle_description">Toggle memorization mode</string>
+  <string name="hifz_reveal_word_label">&gt;</string>
+  <string name="hifz_reveal_word_description">Reveal next word</string>
+  <string name="hifz_reveal_verse_label">&gt;&gt;</string>
+  <string name="hifz_reveal_verse_description">Reveal next verse</string>
+  <string name="hifz_rehide_word_label">&lt;</string>
+  <string name="hifz_rehide_word_description">Re-hide last revealed word</string>
+  <string name="hifz_rehide_verse_label">&lt;&lt;</string>
+  <string name="hifz_rehide_verse_description">Re-hide last revealed verse</string>
   <string name="menu_jump">@string/gotoPage</string>
   <string name="gotoPage">Go to page</string>
   <string name="sura_and_ayah">Sura and Ayah</string>

--- a/app/src/test/kotlin/com/quran/labs/androidquran/presenter/quran/hifz/HifzModeStateTest.kt
+++ b/app/src/test/kotlin/com/quran/labs/androidquran/presenter/quran/hifz/HifzModeStateTest.kt
@@ -1,0 +1,138 @@
+package com.quran.labs.androidquran.presenter.quran.hifz
+
+import com.quran.data.model.SuraAyah
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class HifzModeStateTest {
+
+  private val first = SuraAyah(2, 255)
+  private val second = SuraAyah(2, 256)
+  private val state = HifzModeState()
+
+  private fun twoVerses() = listOf(
+    HifzVerse(first, listOf(1, 2, 3)),
+    HifzVerse(second, listOf(1, 2))
+  )
+
+  @Test
+  fun `enable hides every word and verse`() {
+    val diffs = state.enable(twoVerses())
+
+    assertTrue(state.isEnabled)
+    assertEquals(
+      listOf(
+        HifzDiff.HideWord(first, 1),
+        HifzDiff.HideWord(first, 2),
+        HifzDiff.HideWord(first, 3),
+        HifzDiff.HideWord(second, 1),
+        HifzDiff.HideWord(second, 2)
+      ),
+      diffs
+    )
+    assertEquals(2, state.hiddenVerseCount())
+  }
+
+  @Test
+  fun `wordless ayahs hide and reveal as a whole`() {
+    val diffs = state.enable(listOf(HifzVerse(first, emptyList())))
+
+    assertEquals(listOf(HifzDiff.HideAyah(first)), diffs)
+    assertEquals(
+      listOf(HifzDiff.RevealAyah(first)),
+      state.revealNextWord()
+    )
+    assertEquals(0, state.hiddenVerseCount())
+  }
+
+  @Test
+  fun `reveal next word walks verses in reading order`() {
+    state.enable(twoVerses())
+
+    assertEquals(listOf(HifzDiff.RevealWord(first, 1)), state.revealNextWord())
+    assertEquals(listOf(HifzDiff.RevealWord(first, 2)), state.revealNextWord())
+    assertEquals(listOf(HifzDiff.RevealWord(first, 3)), state.revealNextWord())
+    // first verse fully revealed: moves to the second one
+    assertEquals(listOf(HifzDiff.RevealWord(second, 1)), state.revealNextWord())
+    assertEquals(1, state.hiddenVerseCount())
+  }
+
+  @Test
+  fun `reveal next verse reveals the whole verse at once`() {
+    state.enable(twoVerses())
+
+    assertEquals(
+      listOf(
+        HifzDiff.RevealWord(first, 1),
+        HifzDiff.RevealWord(first, 2),
+        HifzDiff.RevealWord(first, 3)
+      ),
+      state.revealNextVerse()
+    )
+    assertEquals(1, state.hiddenVerseCount())
+  }
+
+  @Test
+  fun `rehide last word undoes one reveal step`() {
+    state.enable(twoVerses())
+    state.revealNextWord()
+    state.revealNextWord()
+
+    assertEquals(listOf(HifzDiff.HideWord(first, 2)), state.rehideLastWord())
+    assertEquals(listOf(HifzDiff.RevealWord(first, 2)), state.revealNextWord())
+    assertEquals(2, state.hiddenVerseCount())
+  }
+
+  @Test
+  fun `rehide last verse hides the most recently touched verse`() {
+    state.enable(twoVerses())
+    state.revealNextVerse()
+    state.revealNextWord()
+
+    // last touched verse is the second one: only its word goes back to hidden
+    assertEquals(listOf(HifzDiff.HideWord(second, 1)), state.rehideLastVerse())
+    assertEquals(1, state.hiddenVerseCount())
+    // revealing again continues where it left off
+    assertEquals(listOf(HifzDiff.RevealWord(second, 1)), state.revealNextWord())
+  }
+
+  @Test
+  fun `rehide on empty history is a no-op`() {
+    state.enable(twoVerses())
+
+    assertTrue(state.rehideLastWord().isEmpty())
+    assertTrue(state.rehideLastVerse().isEmpty())
+    assertEquals(2, state.hiddenVerseCount())
+  }
+
+  @Test
+  fun `operations are no-ops while disabled`() {
+    assertTrue(state.revealNextWord().isEmpty())
+    assertTrue(state.revealNextVerse().isEmpty())
+    assertTrue(state.rehideLastWord().isEmpty())
+    assertTrue(state.rehideLastVerse().isEmpty())
+    assertFalse(state.isEnabled)
+  }
+
+  @Test
+  fun `disable resets everything`() {
+    state.enable(twoVerses())
+    state.revealNextWord()
+
+    assertTrue(state.disable().isEmpty())
+    assertFalse(state.isEnabled)
+    assertEquals(0, state.hiddenVerseCount())
+    assertTrue(state.revealNextWord().isEmpty())
+  }
+
+  @Test
+  fun `revealing past the end is a no-op`() {
+    state.enable(listOf(HifzVerse(first, listOf(1))))
+
+    assertEquals(listOf(HifzDiff.RevealWord(first, 1)), state.revealNextWord())
+    assertTrue(state.revealNextWord().isEmpty())
+    assertTrue(state.revealNextVerse().isEmpty())
+  }
+}

--- a/app/src/test/kotlin/com/quran/labs/androidquran/util/QuranTextVerifierTest.kt
+++ b/app/src/test/kotlin/com/quran/labs/androidquran/util/QuranTextVerifierTest.kt
@@ -1,0 +1,73 @@
+package com.quran.labs.androidquran.util
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class QuranTextVerifierTest {
+
+  // Real 1:1 text from quran.ar.uthmani.v2.db (bundled database format).
+  private val fatiha11 = "بِسۡمِ ٱللَّهِ ٱلرَّحۡمَٰنِ ٱلرَّحِيمِ"
+  private val fatiha11Hash = "8b0fe1680d46237c566f6f46c9f85f55b975d8d34bd4b1243d048c17482892e1"
+
+  @Test
+  fun `normalization matches manifest generator (NFC plus strip)`() {
+    assertEquals(
+      fatiha11Hash,
+      QuranTextVerifier.sha256Hex(QuranTextVerifier.normalizeVerseText("  $fatiha11\n"))
+    )
+  }
+
+  @Test
+  fun `matching texts verify clean`() {
+    val report = QuranTextVerifier.verify(
+      mapOf("1:1" to fatiha11, "1:2" to "x"),
+      mapOf("1:1" to fatiha11Hash, "1:2" to QuranTextVerifier.sha256Hex("x"))
+    )
+
+    assertTrue(report.isClean)
+    assertEquals(2, report.passed)
+    assertTrue(report.mismatches.isEmpty())
+  }
+
+  @Test
+  fun `single diacritic change is detected`() {
+    // ۡ (Madani jazm mark) swapped for a plain sukun: renders the same,
+    // hashes differently — exactly the tamper class being guarded against.
+    val tampered = fatiha11.replace("ۡ", "ْ")
+    val report = QuranTextVerifier.verify(
+      mapOf("1:1" to tampered),
+      mapOf("1:1" to fatiha11Hash)
+    )
+
+    assertFalse(report.isClean)
+    assertEquals(0, report.passed)
+    assertEquals(listOf("1:1"), report.mismatches.map { it.verseKey })
+    assertEquals(fatiha11Hash, report.mismatches.single().expectedHash)
+  }
+
+  @Test
+  fun `missing keys are reported on both sides`() {
+    val report = QuranTextVerifier.verify(
+      mapOf("1:1" to fatiha11, "9:9" to "extra"),
+      mapOf("1:1" to fatiha11Hash, "2:2" to "abc")
+    )
+
+    assertEquals(1, report.passed)
+    assertEquals(listOf("2:2"), report.missingFromText)
+    assertEquals(listOf("9:9"), report.missingFromManifest)
+    assertFalse(report.isClean)
+  }
+
+  @Test
+  fun `hash comparison is case-insensitive`() {
+    val report = QuranTextVerifier.verify(
+      mapOf("1:1" to fatiha11),
+      mapOf("1:1" to fatiha11Hash.uppercase())
+    )
+
+    assertTrue(report.isClean)
+    assertEquals(1, report.passed)
+  }
+}


### PR DESCRIPTION
# Pull Request

## Summary

Implements the verification side of #3710: `QuranTextVerifier` checks the bundled/downloaded
`arabic_text` rows against a SHA-256 manifest (`"surah:ayah"` → hash of the NFC + strip canonical
form — exactly the manifest generator's normalization, so verification is byte-exact and cannot
mask real corruption). Reports per-verse mismatches plus keys missing on either side.

## Verification

- 5 unit tests green (`:app:testMadaniDebugUnitTest --tests "...QuranTextVerifierTest"`),
  including a real 1:1 vector from `quran.ar.uthmani.v2.db` and single-diacritic tamper detection
  (ۡ→sukun swap caught).
- Pure JVM/Kotlin, no Android dependencies.

## Manifest generation (companion)

Generated from the official maintainer-published DB with the same record shape as
spqrxi/quranchecksum (6236 verses + surah rollups + root) — script + manifest committed at
https://github.com/FekyBaz/quran-translation-audit (`generate_appdb_manifest.py`,
`uthmani-appdb.manifest.json`). Wiring the manifest + verifier into install/update checks is
proposed follow-up.

## Calibration note (for #3710 context)

I tried verifying the app DB directly against the Tanzil-based quranchecksum manifest: 54/6236
byte-exact, 994/6236 after the two documented Madani rules (ۡ→sukun, tatweel strip). The rest is
deeper orthographic-variant territory (inverted damma, small-high signs, etc.) requiring Tanzil
ground truth per verse — hence the app-DB-native manifest above, which guards the issue's stated
threat model (corrupted downloads, tampered repacks) without that dependency.
