### PR TITLE
#1407 improvements to audio settings

### DIFF
--- a/app/src/main/java/com/quran/labs/androidquran/data/Constants.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/data/Constants.kt
@@ -94,6 +94,7 @@ object Constants {
   const val PREF_APP_THEME = "appTheme"
   const val PREF_MOBILE_SYNC_LEGACY_BOOKMARKS_MIGRATED = "mobileSyncLegacyBookmarksMigrated"
   const val PREF_HAS_SEEN_MOVABLE_BOOKMARK_EDUCATION = "hasSeenMovableBookmarkEducation"
+  const val PREF_RESTRICT_TO_RANGE = "restrictToRange"
 
   // Themes
   const val THEME_LIGHT = "light"

--- a/app/src/main/java/com/quran/labs/androidquran/service/AudioService.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/service/AudioService.kt
@@ -375,19 +375,46 @@ class AudioService : Service(), Player.Listener {
     } else if (ACTION_PLAYBACK == action) {
       val updatedAudioRequest = intent.getParcelableExtra<AudioRequest>(EXTRA_PLAY_INFO)
       if (updatedAudioRequest != null) {
-        audioRequest = updatedAudioRequest
-        val start = updatedAudioRequest.start
-        val basmallah = !updatedAudioRequest.isGapless() && start.requiresBasmallah()
-        audioQueue = AudioQueue(
-          quranInfo, updatedAudioRequest,
-          AudioPlaybackInfo(start, 1, 1, basmallah)
-        )
-        Timber.d("audio request has changed...")
-        player?.stop()
-        state = State.Stopped
-        Timber.d("stop if playing...")
+        val currentRequest = audioRequest
+        val currentQueue = audioQueue
+        val currentAyah = currentQueue?.getCurrentPlaybackAyah()
+        val canContinuePlayback = state != State.Stopped &&
+            currentRequest != null &&
+            currentQueue != null &&
+            currentAyah != null &&
+            currentRequest.qari == updatedAudioRequest.qari &&
+            currentRequest.audioPathInfo == updatedAudioRequest.audioPathInfo &&
+            currentRequest.start == updatedAudioRequest.start &&
+            currentAyah in updatedAudioRequest.start..updatedAudioRequest.end
+
+        if (canContinuePlayback) {
+          audioQueue = currentQueue.withUpdatedAudioRequest(updatedAudioRequest)
+          if (updatedAudioRequest.playbackSpeed != currentRequest.playbackSpeed) {
+            processUpdatePlaybackSpeed(updatedAudioRequest.playbackSpeed)
+            serviceHandler.sendEmptyMessageDelayed(MSG_UPDATE_AUDIO_POS, 200)
+          }
+          audioRequest = updatedAudioRequest
+          updateAudioPlaybackStatus()
+          if (state == State.Paused) {
+            processPlayRequest()
+          }
+        } else {
+          audioRequest = updatedAudioRequest
+          val start = updatedAudioRequest.start
+          val basmallah = !updatedAudioRequest.isGapless() && start.requiresBasmallah()
+          audioQueue = AudioQueue(
+            quranInfo, updatedAudioRequest,
+            AudioPlaybackInfo(start, 1, 1, basmallah)
+          )
+          Timber.d("audio request has changed...")
+          player?.stop()
+          state = State.Stopped
+          Timber.d("stop if playing...")
+          processPlayRequest()
+        }
+      } else {
+        processTogglePlaybackRequest()
       }
-      processTogglePlaybackRequest()
     } else if (ACTION_PLAY == action) {
       processPlayRequest()
     } else if (ACTION_PAUSE == action) {

--- a/app/src/main/java/com/quran/labs/androidquran/ui/fragment/AyahPlaybackFragment.kt
+++ b/app/src/main/java/com/quran/labs/androidquran/ui/fragment/AyahPlaybackFragment.kt
@@ -18,6 +18,7 @@ import com.quran.labs.androidquran.common.audio.model.playback.AudioRequest
 import com.quran.labs.androidquran.ui.PagerActivity
 import com.quran.labs.androidquran.ui.helpers.SlidingPagerAdapter
 import com.quran.labs.androidquran.ui.util.TypefaceManager
+import com.quran.labs.androidquran.util.QuranSettings
 import com.quran.labs.androidquran.util.QuranUtils
 import com.quran.labs.androidquran.view.QuranSpinner
 import com.quran.mobile.di.AyahActionFragmentProvider
@@ -56,6 +57,9 @@ class AyahPlaybackFragment : AyahActionFragment() {
 
   @Inject
   lateinit var quranInfo: QuranInfo
+
+  @Inject
+  lateinit var quranSettings: QuranSettings
 
   object Provider : AyahActionFragmentProvider {
     override val order = SlidingPagerAdapter.AUDIO_PAGE
@@ -193,6 +197,7 @@ class AyahPlaybackFragment : AyahActionFragment() {
       val verseRepeat = repeatVerse
       val rangeRepeat = repeatRange
       val enforceRange = restrictToRange.isChecked
+      quranSettings.setShouldEnforceAudioBounds(enforceRange)
       var updatedRange = false
 
       val speed = SPEEDS[playbackSpeedPicker.value - 1]
@@ -310,7 +315,7 @@ class AyahPlaybackFragment : AyahActionFragment() {
           verseRepeatCount = lastRequest.repeatInfo
           rangeRepeatCount = lastRequest.rangeRepeatInfo
           currentSpeed = lastRequest.playbackSpeed
-          shouldEnforce = lastRequest.enforceBounds
+          shouldEnforce = lastRequest.enforceBounds || quranSettings.shouldEnforceAudioBounds()
         } else {
           shouldReset = false
         }
@@ -324,7 +329,7 @@ class AyahPlaybackFragment : AyahActionFragment() {
           val startPage = quranInfo.getPageFromSuraAyah(start.sura, start.ayah)
           val pageBounds = quranInfo.getPageBounds(startPage)
           ending = SuraAyah(pageBounds[2], pageBounds[3])
-          shouldEnforce = false
+          shouldEnforce = quranSettings.shouldEnforceAudioBounds()
         } else {
           ending = selectionEnd
           shouldEnforce = true

--- a/app/src/main/java/com/quran/labs/androidquran/util/QuranSettings.java
+++ b/app/src/main/java/com/quran/labs/androidquran/util/QuranSettings.java
@@ -453,4 +453,12 @@ public class QuranSettings {
     perInstallationPrefs.edit()
         .putStringSet(Constants.PREF_CHECKED_PARTIAL_IMAGES, setToSave).apply();
   }
+
+  public boolean shouldEnforceAudioBounds() {
+    return prefs.getBoolean(Constants.PREF_RESTRICT_TO_RANGE, false);
+  }
+
+  public void setShouldEnforceAudioBounds(boolean shouldEnforce) {
+    prefs.edit().putBoolean(Constants.PREF_RESTRICT_TO_RANGE, shouldEnforce).apply();
+  }
 }

--- a/app/src/test/java/com/quran/labs/androidquran/presenter/audio/service/AudioQueueTest.kt
+++ b/app/src/test/java/com/quran/labs/androidquran/presenter/audio/service/AudioQueueTest.kt
@@ -59,6 +59,59 @@ class AudioQueueTest {
     assertThat(queue.getUrl()).isEqualTo("https://example.com/audio/1/1.opus")
   }
 
+  @Test
+  fun testWithUpdatedAudioRequestPreservesCurrentPlaybackAyah() {
+    val format = "https://example.com/audio/%d/%d.opus"
+    val initialRequest = audioRequest(format, listOf("opus", "mp3")).copy(
+      start = SuraAyah(1, 1),
+      end = SuraAyah(1, 7),
+      enforceBounds = false
+    )
+    val queue = AudioQueue(quranInfo, initialRequest)
+
+    // Advance to ayah 2
+    assertThat(queue.playNextAyah()).isTrue()
+    assertThat(queue.getCurrentPlaybackAyah()).isEqualTo(SuraAyah(1, 2))
+
+    // Update with a new range and enforceBounds = true
+    val updatedRequest = initialRequest.copy(
+      end = SuraAyah(1, 5),
+      enforceBounds = true
+    )
+    val updatedQueue = queue.withUpdatedAudioRequest(updatedRequest)
+
+    // Verify current playback ayah is preserved at 1:2
+    assertThat(updatedQueue.getCurrentPlaybackAyah()).isEqualTo(SuraAyah(1, 2))
+  }
+
+  @Test
+  fun testWithUpdatedAudioRequestEnforcesNewBounds() {
+    val format = "https://example.com/audio/%d/%d.opus"
+    val initialRequest = audioRequest(format, listOf("opus", "mp3")).copy(
+      start = SuraAyah(1, 1),
+      end = SuraAyah(1, 7),
+      enforceBounds = false
+    )
+    val queue = AudioQueue(quranInfo, initialRequest)
+
+    // Advance to ayah 3
+    assertThat(queue.playNextAyah()).isTrue()
+    assertThat(queue.playNextAyah()).isTrue()
+    assertThat(queue.getCurrentPlaybackAyah()).isEqualTo(SuraAyah(1, 3))
+
+    // Update with bounds restricted to 1:3
+    val updatedRequest = initialRequest.copy(
+      end = SuraAyah(1, 3),
+      enforceBounds = true,
+      rangeRepeatInfo = 0
+    )
+    val updatedQueue = queue.withUpdatedAudioRequest(updatedRequest)
+
+    // Attempting to advance beyond end bound with rangeRepeat=0 should return false
+    assertThat(updatedQueue.playNextAyah()).isFalse()
+    assertThat(updatedQueue.getCurrentPlaybackAyah()).isEqualTo(SuraAyah(1, 3))
+  }
+
   private fun audioRequest(urlFormat: String, allowedExtensions: List<String>): AudioRequest {
     val qariItem = QariItem(
       id = 1,

--- a/app/src/test/java/com/quran/labs/androidquran/util/QuranSettingsAudioTest.kt
+++ b/app/src/test/java/com/quran/labs/androidquran/util/QuranSettingsAudioTest.kt
@@ -1,0 +1,32 @@
+package com.quran.labs.androidquran.util
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import com.quran.labs.androidquran.base.TestApplication
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@Config(application = TestApplication::class, sdk = [33])
+@RunWith(RobolectricTestRunner::class)
+class QuranSettingsAudioTest {
+
+  @Test
+  fun testShouldEnforceAudioBoundsDefaultAndToggle() {
+    val context = ApplicationProvider.getApplicationContext<Context>()
+    val settings = QuranSettings.getInstance(context)
+
+    // Verify default value is false
+    assertThat(settings.shouldEnforceAudioBounds()).isFalse()
+
+    // Verify setting to true persists
+    settings.setShouldEnforceAudioBounds(true)
+    assertThat(settings.shouldEnforceAudioBounds()).isTrue()
+
+    // Verify setting back to false persists
+    settings.setShouldEnforceAudioBounds(false)
+    assertThat(settings.shouldEnforceAudioBounds()).isFalse()
+  }
+}


### PR DESCRIPTION
supersedes #1429 (from my old account)

fixing the two things from #1407, with the feedback from #1429 addressed:

1. when changing audio settings while playing, audio restarts from the beginning.
- in AudioService, check if the current playing ayah is still within the new range, and if so keep playing without restarting. if it's out of range or start ayah changed, it stops and starts from the new start.

2. remember "play only above verses" setting instead of having to manually check it every time.
- saved the setting in shared preferences through QuranSettings when apply is clicked, and restore it in refreshView in AyahPlaybackFragment. no gson or extra dependencies.